### PR TITLE
Update portal window on scale changes

### DIFF
--- a/game.go
+++ b/game.go
@@ -505,6 +505,14 @@ func updateGameScale() {
 	}
 }
 
+func updateGameWindowSize() {
+	if gameWin == nil {
+		return
+	}
+	scale := float32(gs.GameScale) / eui.UIScale()
+	gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * scale, Y: float32(gameAreaSizeY) * scale}
+}
+
 func gameContentOrigin() (int, int) {
 	if gameWin == nil {
 		return 0, 0

--- a/ui.go
+++ b/ui.go
@@ -805,6 +805,7 @@ func makeSettingsWindow() {
 		if ev.Type == eui.EventClick {
 			gs.UIScale = pendingUIScale
 			eui.SetUIScale(float32(gs.UIScale))
+			updateGameWindowSize()
 			settingsDirty = true
 		}
 	}
@@ -827,9 +828,7 @@ func makeSettingsWindow() {
 	gameSizeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.GameScale = float64(ev.Value)
-			if gameWin != nil {
-				gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * float32(gs.GameScale), Y: float32(gameAreaSizeY) * float32(gs.GameScale)}
-			}
+			updateGameWindowSize()
 			initFont()
 			settingsDirty = true
 		}


### PR DESCRIPTION
## Summary
- resize main portal window whenever UI or game scale changes
- simplify game size handling via helper function

## Testing
- `gofmt -w game.go ui.go`
- `go vet ./...` *(fails: github.com/Distortions81/EUI: replacement directory ../EUI/ does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689ae5f7c8ec832abb6bc55427e5f399