### PR TITLE
Normalize mixed audio to avoid clipping

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -74,7 +74,22 @@ func playSound(ids ...uint16) {
 			}
 		}
 
-		scale := 1.0 / math.Sqrt(float64(len(sounds)))
+		// Find the peak amplitude to normalize the mix
+		maxVal := int32(0)
+		for _, v := range mixed {
+			if v < 0 {
+				v = -v
+			}
+			if v > maxVal {
+				maxVal = v
+			}
+		}
+		// Apply peak normalization and reduce volume for overlapping sounds
+		scale := 1 / float64(len(sounds))
+		if maxVal > 0 {
+			scale *= math.Min(1.0, 32767.0/float64(maxVal))
+		}
+
 		out := make([]byte, len(mixed)*2)
 		for i, v := range mixed {
 			v = int32(float64(v) * scale)


### PR DESCRIPTION
## Summary
- Normalize mixed audio by measuring peak sample, scaling mix to prevent clipping, and adjusting for overlapping sounds.

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689af32bd7e0832ab6a2553d00086c49