### PR TITLE
Honor Movable and Resizable for unpinned windows

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -123,13 +123,13 @@ func Update() error {
 				origPos := win.Position
 				switch dragPart {
 				case PART_BAR:
-					if win.PinTo == PIN_TOP_LEFT {
+					if win.PinTo == PIN_NONE {
 						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_TOP:
 					posCh.X = 0
 					sizeCh.X = 0
-					if !win.setSize(pointSub(win.Size, sizeCh)) && win.PinTo == PIN_TOP_LEFT {
+					if !win.setSize(pointSub(win.Size, sizeCh)) && win.PinTo == PIN_NONE {
 						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_BOTTOM:
@@ -138,20 +138,20 @@ func Update() error {
 				case PART_LEFT:
 					posCh.Y = 0
 					sizeCh.Y = 0
-					if !win.setSize(pointSub(win.Size, sizeCh)) && win.PinTo == PIN_TOP_LEFT {
+					if !win.setSize(pointSub(win.Size, sizeCh)) && win.PinTo == PIN_NONE {
 						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_RIGHT:
 					sizeCh.Y = 0
 					win.setSize(pointAdd(win.Size, sizeCh))
 				case PART_TOP_LEFT:
-					if !win.setSize(pointSub(win.Size, sizeCh)) && win.PinTo == PIN_TOP_LEFT {
+					if !win.setSize(pointSub(win.Size, sizeCh)) && win.PinTo == PIN_NONE {
 						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_TOP_RIGHT:
 					tx := win.Size.X + sizeCh.X
 					ty := win.Size.Y - sizeCh.Y
-					if !win.setSize(point{X: tx, Y: ty}) && win.PinTo == PIN_TOP_LEFT {
+					if !win.setSize(point{X: tx, Y: ty}) && win.PinTo == PIN_NONE {
 						win.Position.Y += posCh.Y
 					}
 				case PART_BOTTOM_RIGHT:
@@ -161,7 +161,7 @@ func Update() error {
 				case PART_BOTTOM_LEFT:
 					tx := win.Size.X - sizeCh.X
 					ty := win.Size.Y + sizeCh.Y
-					if !win.setSize(point{X: tx, Y: ty}) && win.PinTo == PIN_TOP_LEFT {
+					if !win.setSize(point{X: tx, Y: ty}) && win.PinTo == PIN_NONE {
 						win.Position.X += posCh.X
 					}
 				case PART_SCROLL_V:

--- a/eui/pin_flags_test.go
+++ b/eui/pin_flags_test.go
@@ -1,0 +1,35 @@
+//go:build test
+
+package eui
+
+import "testing"
+
+func TestAddWindowPinnedDisablesFlags(t *testing.T) {
+	win := &windowData{
+		Size:      point{X: 10, Y: 10},
+		PinTo:     PIN_TOP_LEFT,
+		Movable:   true,
+		Resizable: true,
+		open:      true,
+	}
+	win.AddWindow(false)
+	defer func() { windows = nil }()
+	if win.Movable || win.Resizable {
+		t.Fatalf("expected pinned window to be immovable and non-resizable")
+	}
+}
+
+func TestAddWindowUnpinnedHonorsFlags(t *testing.T) {
+	win := &windowData{
+		Size:      point{X: 10, Y: 10},
+		PinTo:     PIN_NONE,
+		Movable:   true,
+		Resizable: true,
+		open:      true,
+	}
+	win.AddWindow(false)
+	defer func() { windows = nil }()
+	if !win.Movable || !win.Resizable {
+		t.Fatalf("expected unpinned window to honor Movable/Resizable")
+	}
+}

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -22,7 +22,7 @@ type windowData struct {
 	Size     point
 	AspectA  float32
 	AspectB  float32
-	PinTo    pinType
+	PinTo    pinType // Pinning fixes a window in place and disables movement/resizing.
 
 	Padding   float32
 	Margin    float32
@@ -33,7 +33,7 @@ type windowData struct {
 
 	open bool
 	Hovered, Flow,
-	Closable, Movable, Resizable,
+	Closable, Movable, Resizable, // Movable/Resizable only when PinTo == PIN_NONE
 	HoverClose, HoverDragbar,
 	AutoSize, AutoSizeOnScale, FixedRatio bool
 
@@ -238,6 +238,8 @@ const (
 	PIN_BOTTOM_CENTER
 	PIN_BOTTOM_RIGHT
 )
+
+// Any value other than PIN_NONE anchors the window, disabling movement and resizing.
 
 type dragType int
 

--- a/eui/window.go
+++ b/eui/window.go
@@ -117,8 +117,10 @@ func (target *windowData) AddWindow(toBack bool) {
 		}
 	}
 
-	if target.PinTo != PIN_TOP_LEFT {
+	if target.PinTo != PIN_NONE {
+		// Pinned windows can't be moved or resized.
 		target.Movable = false
+		target.Resizable = false
 	}
 
 	if target.NoTitle {
@@ -156,7 +158,7 @@ func (target *windowData) AddWindow(toBack bool) {
 
 	if !toBack {
 		windows = append(windows, target)
-		if target.PinTo == PIN_TOP_LEFT {
+		if target.PinTo == PIN_NONE {
 			activeWindow = target
 		}
 	} else {

--- a/eui/window_drag_test.go
+++ b/eui/window_drag_test.go
@@ -20,6 +20,7 @@ func TestWindowDragClickScaled(t *testing.T) {
 	win := &windowData{
 		Position:    point{X: 0, Y: 0},
 		Size:        point{X: 50, Y: 50},
+		PinTo:       PIN_NONE,
 		open:        true,
 		Movable:     true,
 		Margin:      0,


### PR DESCRIPTION
## Summary
- Treat `PIN_NONE` as the unpinned state for windows
- Keep pinned windows immovable and unresizable
- Add tests for window pinning behavior

## Testing
- `go vet ./...`
- `go test ./...` *(fails: X11 DISPLAY variable is missing)*
- `go test -tags test ./eui` *(fails: X11 DISPLAY variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b0c7ad030832a8e8c5e97f5f3478f