### PR TITLE
Allow preserving window position during auto-size

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -236,7 +236,14 @@ func (win *windowData) adjustScrollForResize() {
 	}
 }
 
-func (win *windowData) clampToScreen() {
+// clampToScreen ensures the window remains within the visible screen area.
+// When skipReposition is true the window's position is left unchanged. This is
+// useful for auto-size operations where callers want to preserve the current
+// location even if the new size would normally force the window to move.
+func (win *windowData) clampToScreen(skipReposition ...bool) {
+	if len(skipReposition) > 0 && skipReposition[0] {
+		return
+	}
 	size := win.GetSize()
 	m := win.Margin * uiScale
 
@@ -784,7 +791,11 @@ func (win *windowData) contentBounds() point {
 	return point{X: b.X1 - base.X, Y: b.Y1 - base.Y}
 }
 
-func (win *windowData) updateAutoSize() {
+// updateAutoSize adjusts the window size to fit its contents. If
+// skipReposition is true the window size is updated without clamping its
+// position to the screen, allowing callers to preserve the current location
+// during auto-size operations.
+func (win *windowData) updateAutoSize(skipReposition ...bool) {
 	req := win.contentBounds()
 	pad := (win.Padding + win.BorderPad) * uiScale
 
@@ -805,7 +816,7 @@ func (win *windowData) updateAutoSize() {
 	}
 	win.Size = point{X: size.X / uiScale, Y: size.Y / uiScale}
 	win.resizeFlows()
-	win.clampToScreen()
+	win.clampToScreen(skipReposition...)
 }
 
 func (item *itemData) contentBounds() point {

--- a/eui/window.go
+++ b/eui/window.go
@@ -603,9 +603,10 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 	return xc, yc
 }
 
-// Refresh forces the window to recalculate layout, resize to its contents,
-// and adjust scrolling after modifying contents.
-func (win *windowData) Refresh() {
+// Refresh forces the window to recalculate layout, resize to its contents and
+// adjust scrolling after modifying contents. When skipReposition is true the
+// window's location on screen is preserved during auto-size operations.
+func (win *windowData) Refresh(skipReposition ...bool) {
 	if !win.open {
 		for _, it := range win.Contents {
 			markItemTreeDirty(it)
@@ -615,9 +616,9 @@ func (win *windowData) Refresh() {
 	}
 	win.resizeFlows()
 	if win.AutoSize {
-		win.updateAutoSize()
+		win.updateAutoSize(skipReposition...)
 	} else {
-		win.clampToScreen()
+		win.clampToScreen(skipReposition...)
 	}
 	win.adjustScrollForResize()
 	for _, it := range win.Contents {

--- a/ui.go
+++ b/ui.go
@@ -441,14 +441,16 @@ func updateCharacterButtons() {
 						passHash = ""
 					}
 					updateCharacterButtons()
-					loginWin.Refresh()
+					// Preserve window position while contents change size
+					loginWin.Refresh(true)
 				}
 			}
 			row.AddItem(trash)
 			charactersList.AddItem(row)
 		}
 	}
-	loginWin.Refresh()
+	// Preserve window position while contents change size
+	loginWin.Refresh(true)
 }
 
 func makeAddCharacterWindow() {
@@ -511,7 +513,8 @@ func makeAddCharacterWindow() {
 			saveSettings()
 			updateCharacterButtons()
 			if loginWin != nil && loginWin.IsOpen() {
-				loginWin.Refresh()
+				// Preserve window position while contents change size
+				loginWin.Refresh(true)
 			}
 			addCharWin.Open()
 		}


### PR DESCRIPTION
## Summary
- add `skipReposition` flag to window auto-sizing and screen clamping
- support preserving window position during auto-size refreshes
- document how to opt out of repositioning when contents resize

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b11562f00832a86334c4d4257a852