### PR TITLE
Handle chat window creation failures

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -2,7 +2,10 @@
 
 package main
 
-import "go_client/eui"
+import (
+	"fmt"
+	"go_client/eui"
+)
 
 var chatWin *eui.WindowData
 var chatList *eui.ItemData
@@ -22,6 +25,10 @@ func updateChatWindow() {
 			}
 		} else {
 			t, _ := eui.NewText()
+			if t == nil {
+				logError("create chat text: eui.NewText returned nil")
+				continue
+			}
 			t.Text = msg
 			t.FontSize = 10
 			t.Size = eui.Point{X: 256, Y: 24}
@@ -41,11 +48,14 @@ func updateChatWindow() {
 	}
 }
 
-func makeChatWindow() {
+func makeChatWindow() error {
 	if chatWin != nil {
-		return
+		return nil
 	}
 	chatWin = eui.NewWindow()
+	if chatWin == nil {
+		return fmt.Errorf("eui.NewWindow returned nil")
+	}
 	chatWin.Title = "Chat"
 	if gs.ChatWindow.Size.X > 0 && gs.ChatWindow.Size.Y > 0 {
 		chatWin.Size = eui.Point{X: float32(gs.ChatWindow.Size.X), Y: float32(gs.ChatWindow.Size.Y)}
@@ -61,6 +71,10 @@ func makeChatWindow() {
 	}
 
 	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
+	if chatList == nil {
+		return fmt.Errorf("failed to create chat list")
+	}
 	chatWin.AddItem(chatList)
 	chatWin.AddWindow(false)
+	return nil
 }

--- a/settings.go
+++ b/settings.go
@@ -212,7 +212,12 @@ func syncWindowSettings() bool {
 	if syncWindow(messagesWin, &gs.MessagesWindow) {
 		changed = true
 	}
-	if syncWindow(chatWin, &gs.ChatWindow) {
+	if chatWin != nil {
+		if syncWindow(chatWin, &gs.ChatWindow) {
+			changed = true
+		}
+	} else if gs.ChatWindow.Open {
+		gs.ChatWindow.Open = false
 		changed = true
 	}
 	return changed

--- a/ui.go
+++ b/ui.go
@@ -75,7 +75,10 @@ func initUI() {
 	makeDownloadsWindow()
 	makeLoginWindow()
 	makeAddCharacterWindow()
-	makeChatWindow()
+	if err := makeChatWindow(); err != nil {
+		logError("make chat window: %v", err)
+		chatMessage("Unable to create chat window")
+	}
 	makeConsoleWindow()
 	makeSettingsWindow()
 	makeQualityWindow()
@@ -86,7 +89,9 @@ func initUI() {
 	makeHelpWindow()
 	makeToolbarWindow()
 
-	chatWin.Open()
+	if chatWin != nil {
+		chatWin.Open()
+	}
 	messagesWin.Open()
 	inventoryWin.Open()
 	playersWin.Open()


### PR DESCRIPTION
## Summary
- Check for nil results from eui.NewWindow and eui.NewText when building the chat UI
- Handle chat window creation errors in initUI and guard against nil dereferences
- Skip syncing chat window settings when the chat window is unavailable

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b11514954832a800a7c78b567a4a3