### PR TITLE
Add development environment setup script

### DIFF
--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fully set up the development environment, including headless support.
+# This script is intended for Debian/Ubuntu based systems.
+
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "apt-get not found. Please install dependencies manually." >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y golang-go build-essential libgl1-mesa-dev \
+  libglu1-mesa-dev xorg-dev xvfb
+
+# Start Xvfb for headless environments if not already running
+if ! pgrep -x Xvfb >/dev/null 2>&1; then
+  echo "Starting Xvfb on display :99..."
+  Xvfb :99 -screen 0 1024x768x24 >/tmp/Xvfb.log 2>&1 &
+  disown
+fi
+export DISPLAY=${DISPLAY:-:99}
+
+go mod download
+go fmt ./...
+go vet ./...
+
+echo "Development environment setup complete."


### PR DESCRIPTION
## Summary
- add script to install dependencies and configure Xvfb for headless development

## Testing
- `bash -n scripts/setup_dev_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b717596fc832a8594963054abb586