### PR TITLE
Add window zoning and position/size management

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -105,12 +105,16 @@ func Update() error {
 			} else if clickDrag && dragPart != PART_NONE && dragWin == win {
 				switch dragPart {
 				case PART_BAR:
-					win.Position = pointAdd(win.Position, posCh)
+					if win.zone == nil {
+						win.Position = pointAdd(win.Position, posCh)
+					}
 				case PART_TOP:
 					posCh.X = 0
 					sizeCh.X = 0
 					if !win.setSize(pointSub(win.Size, sizeCh)) {
-						win.Position = pointAdd(win.Position, posCh)
+						if win.zone == nil {
+							win.Position = pointAdd(win.Position, posCh)
+						}
 					}
 				case PART_BOTTOM:
 					sizeCh.X = 0
@@ -119,20 +123,26 @@ func Update() error {
 					posCh.Y = 0
 					sizeCh.Y = 0
 					if !win.setSize(pointSub(win.Size, sizeCh)) {
-						win.Position = pointAdd(win.Position, posCh)
+						if win.zone == nil {
+							win.Position = pointAdd(win.Position, posCh)
+						}
 					}
 				case PART_RIGHT:
 					sizeCh.Y = 0
 					win.setSize(pointAdd(win.Size, sizeCh))
 				case PART_TOP_LEFT:
 					if !win.setSize(pointSub(win.Size, sizeCh)) {
-						win.Position = pointAdd(win.Position, posCh)
+						if win.zone == nil {
+							win.Position = pointAdd(win.Position, posCh)
+						}
 					}
 				case PART_TOP_RIGHT:
 					tx := win.Size.X + sizeCh.X
 					ty := win.Size.Y - sizeCh.Y
 					if !win.setSize(point{X: tx, Y: ty}) {
-						win.Position.Y += posCh.Y
+						if win.zone == nil {
+							win.Position.Y += posCh.Y
+						}
 					}
 				case PART_BOTTOM_RIGHT:
 					tx := win.Size.X + sizeCh.X
@@ -142,7 +152,9 @@ func Update() error {
 					tx := win.Size.X - sizeCh.X
 					ty := win.Size.Y + sizeCh.Y
 					if !win.setSize(point{X: tx, Y: ty}) {
-						win.Position.X += posCh.X
+						if win.zone == nil {
+							win.Position.X += posCh.X
+						}
 					}
 				case PART_SCROLL_V:
 					dragWindowScroll(win, mpos, true)

--- a/eui/public.go
+++ b/eui/public.go
@@ -28,6 +28,9 @@ func SetScreenSize(w, h int) {
 			win.resizeFlows()
 			win.adjustScrollForResize()
 		}
+		if win.zone != nil {
+			win.updateZonePosition()
+		}
 		win.clampToScreen()
 	}
 }

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -21,6 +21,8 @@ type windowData struct {
 	Position point
 	Size     point
 
+	zone *windowZone
+
 	Padding   float32
 	Margin    float32
 	Border    float32

--- a/eui/util.go
+++ b/eui/util.go
@@ -150,6 +150,9 @@ func (win *windowData) setSize(size point) bool {
 	win.BringForward()
 	win.resizeFlows()
 	win.adjustScrollForResize()
+	if win.zone != nil {
+		win.updateZonePosition()
+	}
 	win.clampToScreen()
 
 	return true
@@ -185,6 +188,9 @@ func (win *windowData) adjustScrollForResize() {
 }
 
 func (win *windowData) clampToScreen() {
+	if win.zone != nil {
+		return
+	}
 	pos := win.getPosition()
 	size := win.GetSize()
 
@@ -434,16 +440,32 @@ func (win *windowData) GetTitleSize() float32 {
 	return win.TitleHeight * uiScale
 }
 
-func (win *windowData) GetSize() point {
-	return point{X: win.Size.X * uiScale, Y: win.Size.Y * uiScale}
+func (win *windowData) GetSize() Point {
+	return Point{X: win.Size.X * uiScale, Y: win.Size.Y * uiScale}
 }
 
-func (win *windowData) GetPos() point {
-	return point{X: win.Position.X * uiScale, Y: win.Position.Y * uiScale}
+func (win *windowData) GetPos() Point {
+	return Point{X: win.Position.X * uiScale, Y: win.Position.Y * uiScale}
 }
 
-func (item *itemData) GetSize() point {
-	sz := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
+func (win *windowData) SetPos(pos Point) bool {
+	if win.zone != nil {
+		return false
+	}
+	win.Position = point{X: pos.X / uiScale, Y: pos.Y / uiScale}
+	win.clampToScreen()
+	return true
+}
+
+func (win *windowData) SetSize(size Point) bool {
+	if !win.Resizable {
+		return false
+	}
+	return win.setSize(point{X: size.X / uiScale, Y: size.Y / uiScale})
+}
+
+func (item *itemData) GetSize() Point {
+	sz := Point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
 	if item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
 		sz.Y += textSize + currentStyle.TextPadding*uiScale
@@ -451,8 +473,8 @@ func (item *itemData) GetSize() point {
 	return sz
 }
 
-func (item *itemData) GetPos() point {
-	return point{X: item.Position.X * uiScale, Y: item.Position.Y * uiScale}
+func (item *itemData) GetPos() Point {
+	return Point{X: item.Position.X * uiScale, Y: item.Position.Y * uiScale}
 }
 
 func (item *itemData) GetTextPtr() *string {

--- a/eui/zones.go
+++ b/eui/zones.go
@@ -1,0 +1,85 @@
+package eui
+
+// HZone defines the horizontal zone positions.
+type HZone int
+
+const (
+	HZoneLeft HZone = iota
+	HZoneLeftCenter
+	HZoneCenter
+	HZoneRightCenter
+	HZoneRight
+)
+
+// VZone defines the vertical zone positions.
+type VZone int
+
+const (
+	VZoneTop VZone = iota
+	VZoneTopMiddle
+	VZoneMiddle
+	VZoneBottomMiddle
+	VZoneBottom
+)
+
+type windowZone struct {
+	h HZone
+	v VZone
+}
+
+// SetZone assigns a horizontal and vertical zone to the window. The window's
+// center will be kept on this zone.
+func (win *windowData) SetZone(h HZone, v VZone) {
+	win.zone = &windowZone{h: h, v: v}
+	win.updateZonePosition()
+}
+
+// ClearZone removes any zone assignment from the window.
+func (win *windowData) ClearZone() {
+	win.zone = nil
+}
+
+func (win *windowData) updateZonePosition() {
+	if win.zone == nil {
+		return
+	}
+	cx := hZoneCoord(win.zone.h, screenWidth)
+	cy := vZoneCoord(win.zone.v, screenHeight)
+	size := win.GetSize()
+	win.Position.X = (cx - size.X/2) / uiScale
+	win.Position.Y = (cy - size.Y/2) / uiScale
+}
+
+func hZoneCoord(z HZone, width int) float32 {
+	switch z {
+	case HZoneLeft:
+		return 0
+	case HZoneLeftCenter:
+		return float32(width) * 0.25
+	case HZoneCenter:
+		return float32(width) * 0.5
+	case HZoneRightCenter:
+		return float32(width) * 0.75
+	case HZoneRight:
+		return float32(width)
+	default:
+		return float32(width) * 0.5
+	}
+}
+
+func vZoneCoord(z VZone, height int) float32 {
+	switch z {
+	case VZoneTop:
+		return 0
+	case VZoneTopMiddle:
+		return float32(height) * 0.25
+	case VZoneMiddle:
+		return float32(height) * 0.5
+	case VZoneBottomMiddle:
+		return float32(height) * 0.75
+	case VZoneBottom:
+		return float32(height)
+	default:
+		return float32(height) * 0.5
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce horizontal/vertical zone system to anchor windows and keep their centers on specified screen points
- Expose SetPos/SetSize APIs that respect zoning and resizable flags
- Reposition zoned windows on screen resize and ignore movement when zoned

## Testing
- `go vet ./...` *(fails: Xrandr.h missing and ALSA pkg-config not found)*
- `go test ./...` *(fails: Xrandr.h missing and ALSA pkg-config not found)*
- `go build ./...` *(fails: Xrandr.h missing and ALSA pkg-config not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b869a5198832ab146afc13e3f7eae