### PR TITLE
Offset item draw rects by window position

### DIFF
--- a/eui/geometry.go
+++ b/eui/geometry.go
@@ -26,6 +26,10 @@ func pointDiv(a, b point) point { return point{X: a.X / b.X, Y: a.Y / b.Y} }
 func pointScaleMul(a point) point { return point{X: a.X * uiScale, Y: a.Y * uiScale} }
 func pointScaleDiv(a point) point { return point{X: a.X / uiScale, Y: a.Y / uiScale} }
 
+func rectAdd(r rect, p point) rect {
+	return rect{X0: r.X0 + p.X, Y0: r.Y0 + p.Y, X1: r.X1 + p.X, Y1: r.Y1 + p.Y}
+}
+
 // unionRect expands a to encompass b and returns the result.
 func unionRect(a, b rect) rect {
 	if b.X0 < a.X0 {


### PR DESCRIPTION
## Summary
- adjust window rendering to preserve original position and offset item draw rectangles
- pass base offsets through drawItems, drawFlows, and drawItem for accurate screen-space DrawRect values
- add rectAdd helper for translating rectangles

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b8ba7b97c832aad201c67c753d035