### PR TITLE
Use raw window dimensions for game scaling

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -57,8 +57,7 @@ func Update() error {
 	wx, wy := pointerWheel()
 	wheelDelta := point{X: float32(wx), Y: float32(wy)}
 
-	posCh := pointScaleDiv(pointSub(mpos, mposOld))
-	sizeCh := pointScaleMul(point{X: posCh.X / uiScale, Y: posCh.Y / uiScale})
+	delta := pointSub(mpos, mposOld)
 	c := ebiten.CursorShapeDefault
 
 	//Check all windows
@@ -67,6 +66,10 @@ func Update() error {
 		if !win.Open {
 			continue
 		}
+
+		s := win.scale()
+		posCh := point{X: delta.X / s, Y: delta.Y / s}
+		sizeCh := posCh
 
 		var part dragType
 		if dragPart != PART_NONE && dragWin == win {
@@ -691,7 +694,7 @@ func scrollWindow(win *windowData, delta point) bool {
 	if win.NoScroll {
 		return false
 	}
-	pad := (win.Padding + win.BorderPad) * uiScale
+	pad := (win.Padding + win.BorderPad) * win.scale()
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -736,7 +739,7 @@ func dragWindowScroll(win *windowData, mpos point, vert bool) {
 		return
 	}
 	old := win.Scroll
-	pad := (win.Padding + win.BorderPad) * uiScale
+	pad := (win.Padding + win.BorderPad) * win.scale()
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -745,7 +748,7 @@ func dragWindowScroll(win *windowData, mpos point, vert bool) {
 	if vert && req.Y > avail.Y {
 		barH := avail.Y * avail.Y / req.Y
 		maxScroll := req.Y - avail.Y
-		track := win.getPosition().Y + win.GetTitleSize() + win.BorderPad
+		track := win.getPosition().Y + win.GetTitleSize() + win.BorderPad*win.scale()
 		pos := mpos.Y - (track + barH/2)
 		if pos < 0 {
 			pos = 0
@@ -764,7 +767,7 @@ func dragWindowScroll(win *windowData, mpos point, vert bool) {
 	if !vert && req.X > avail.X {
 		barW := avail.X * avail.X / req.X
 		maxScroll := req.X - avail.X
-		track := win.getPosition().X + win.BorderPad
+		track := win.getPosition().X + win.BorderPad*win.scale()
 		pos := mpos.X - (track + barW/2)
 		if pos < 0 {
 			pos = 0

--- a/eui/public.go
+++ b/eui/public.go
@@ -17,11 +17,19 @@ func SetScreenSize(w, h int) {
 		size := win.GetSize()
 		resized := false
 		if size.X > float32(screenWidth) {
-			win.Size.X = float32(screenWidth) / uiScale
+			if win.NoScale {
+				win.Size.X = float32(screenWidth)
+			} else {
+				win.Size.X = float32(screenWidth) / uiScale
+			}
 			resized = true
 		}
 		if size.Y > float32(screenHeight) {
-			win.Size.Y = float32(screenHeight) / uiScale
+			if win.NoScale {
+				win.Size.Y = float32(screenHeight)
+			} else {
+				win.Size.Y = float32(screenHeight) / uiScale
+			}
 			resized = true
 		}
 		if resized {

--- a/eui/render.go
+++ b/eui/render.go
@@ -107,10 +107,10 @@ func (win *windowData) drawBG(screen *ebiten.Image) {
 		drawDropShadow(screen, &rr, win.ShadowSize, win.ShadowColor)
 	}
 	r := rect{
-		X0: win.getPosition().X + win.BorderPad,
-		Y0: win.getPosition().Y + win.BorderPad,
-		X1: win.getPosition().X + win.GetSize().X - win.BorderPad,
-		Y1: win.getPosition().Y + win.GetSize().Y - win.BorderPad,
+		X0: win.getPosition().X + win.BorderPad*win.scale(),
+		Y0: win.getPosition().Y + win.BorderPad*win.scale(),
+		X1: win.getPosition().X + win.GetSize().X - win.BorderPad*win.scale(),
+		Y1: win.getPosition().Y + win.GetSize().Y - win.BorderPad*win.scale(),
 	}
 	drawRoundRect(screen, &roundRect{
 		Size:     point{X: r.X1 - r.X0, Y: r.Y1 - r.Y0},
@@ -168,7 +168,7 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 				closeArea := screen.SubImage(r.getRectangle()).(*ebiten.Image)
 				closeArea.Fill(win.Theme.Window.CloseBGColor)
 			}
-			xThick := 1 * uiScale
+			xThick := 1 * win.scale()
 			if win.HoverClose {
 				color = win.Theme.Window.HoverTitleColor
 				win.HoverClose = false
@@ -204,7 +204,7 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			if spacing <= 0 {
 				spacing = 5
 			}
-			for x := textWidth + float64((win.GetTitleSize())/1.5); x < float64(win.GetSize().X-buttonsWidth); x = x + float64(uiScale*spacing) {
+			for x := textWidth + float64((win.GetTitleSize())/1.5); x < float64(win.GetSize().X-buttonsWidth); x = x + float64(win.scale()*spacing) {
 				strokeLine(screen,
 					win.getPosition().X+float32(x), win.getPosition().Y+dpad,
 					win.getPosition().X+float32(x), win.getPosition().Y+(win.GetTitleSize())-dpad,
@@ -238,7 +238,7 @@ func (win *windowData) drawScrollbars(screen *ebiten.Image) {
 	if win.NoScroll {
 		return
 	}
-	pad := (win.Padding + win.BorderPad) * uiScale
+	pad := (win.Padding + win.BorderPad) * win.scale()
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -254,7 +254,7 @@ func (win *windowData) drawScrollbars(screen *ebiten.Image) {
 		sbW := currentStyle.BorderPad.Slider * 2
 		drawRoundRect(screen, &roundRect{
 			Size:     point{X: sbW, Y: barH},
-			Position: point{X: win.getPosition().X + win.GetSize().X - win.BorderPad - sbW, Y: win.getPosition().Y + win.GetTitleSize() + win.BorderPad + pos},
+			Position: point{X: win.getPosition().X + win.GetSize().X - win.BorderPad*win.scale() - sbW, Y: win.getPosition().Y + win.GetTitleSize() + win.BorderPad*win.scale() + pos},
 			Fillet:   currentStyle.Fillet.Slider,
 			Filled:   true,
 			Color:    win.Theme.Window.ActiveColor,
@@ -270,7 +270,7 @@ func (win *windowData) drawScrollbars(screen *ebiten.Image) {
 		sbW := currentStyle.BorderPad.Slider * 2
 		drawRoundRect(screen, &roundRect{
 			Size:     point{X: barW, Y: sbW},
-			Position: point{X: win.getPosition().X + win.BorderPad + pos, Y: win.getPosition().Y + win.GetSize().Y - win.BorderPad - sbW},
+			Position: point{X: win.getPosition().X + win.BorderPad*win.scale() + pos, Y: win.getPosition().Y + win.GetSize().Y - win.BorderPad*win.scale() - sbW},
 			Fillet:   currentStyle.Fillet.Slider,
 			Filled:   true,
 			Color:    win.Theme.Window.ActiveColor,
@@ -279,7 +279,7 @@ func (win *windowData) drawScrollbars(screen *ebiten.Image) {
 }
 
 func (win *windowData) drawItems(screen *ebiten.Image, base point) {
-	pad := (win.Padding + win.BorderPad) * uiScale
+	pad := (win.Padding + win.BorderPad) * win.scale()
 	winPos := point{X: pad, Y: win.GetTitleSize() + pad}
 	winPos = pointSub(winPos, win.Scroll)
 	clip := win.getMainRect()
@@ -422,7 +422,7 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			flowOff := pointAdd(drawOffset, flowOffset)
 
 			if subItem.PinTo != PIN_TOP_LEFT {
-				pad := (win.Padding + win.BorderPad) * uiScale
+				pad := (win.Padding + win.BorderPad) * win.scale()
 				objOff := pointAdd(win.getPosition(), point{X: pad, Y: win.GetTitleSize() + pad})
 				objOff = pointSub(objOff, win.Scroll)
 				objOff = pointAdd(objOff, subItem.getPosition(win))

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -38,6 +38,7 @@ type windowData struct {
 	// Scroll position and behavior
 	Scroll   point
 	NoScroll bool
+	NoScale  bool
 
 	TitleHeight float32
 

--- a/game.go
+++ b/game.go
@@ -485,15 +485,15 @@ func updateGameScale() {
 	if gameWin == nil {
 		return
 	}
-	size := gameWin.GetSize()
+	size := gameWin.GetRawSize()
 	if size.X <= 0 || size.Y <= 0 {
 		return
 	}
 
 	w := float64(int(size.X))
 	h := float64(int(size.Y))
-	scaleW := w / float64(gameAreaSizeX) * float64(eui.UIScale())
-	scaleH := h / float64(gameAreaSizeY) * float64(eui.UIScale())
+	scaleW := w / float64(gameAreaSizeX)
+	scaleH := h / float64(gameAreaSizeY)
 	newScale := math.Min(scaleW, scaleH)
 	if newScale < 0.25 {
 		newScale = 0.25
@@ -509,7 +509,7 @@ func updateGameWindowSize() {
 	if gameWin == nil {
 		return
 	}
-	scale := float32(gs.GameScale) / eui.UIScale()
+	scale := float32(gs.GameScale)
 	gameWin.Size = eui.Point{X: float32(gameAreaSizeX) * scale, Y: float32(gameAreaSizeY) * scale}
 }
 
@@ -517,11 +517,10 @@ func gameContentOrigin() (int, int) {
 	if gameWin == nil {
 		return 0, 0
 	}
-	s := eui.UIScale()
-	pos := gameWin.GetPos()
-	frame := (gameWin.Margin + gameWin.Border + gameWin.BorderPad + gameWin.Padding) * s
+	pos := gameWin.GetRawPos()
+	frame := gameWin.Margin + gameWin.Border + gameWin.BorderPad + gameWin.Padding
 	x := pos.X + frame
-	y := pos.Y + frame + gameWin.GetTitleSize()
+	y := pos.Y + frame + gameWin.GetRawTitleSize()
 	return int(math.Round(float64(x))), int(math.Round(float64(y)))
 }
 
@@ -1182,6 +1181,7 @@ func makeGameWindow() {
 	gameWin.Closable = false
 	gameWin.Resizable = true
 	gameWin.Movable = true
+	gameWin.NoScale = true
 	gameWin.MarkOpen()
 }
 


### PR DESCRIPTION
## Summary
- add NoScale option to UI windows to bypass global UI scaling
- compute game scale and origin from raw window metrics
- enable NoScale on the "Clan Lord" window for consistent sizing

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b9b09196c832aad1aa1b68bfac3c2