### PR TITLE
Keep clmov UPS during area changes

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -816,12 +816,16 @@ func parseDrawState(data []byte) error {
 	}
 	needAnimUpdate := (gs.MotionSmoothing || (gs.BlendMobiles && changed)) && ok
 	if needAnimUpdate {
-		const defaultInterval = time.Second / 5
-		interval := defaultInterval
+		frameMu.Lock()
+		interval := frameInterval
+		frameMu.Unlock()
 		if !state.prevTime.IsZero() && !state.curTime.IsZero() {
 			if d := state.curTime.Sub(state.prevTime); d > 0 {
 				interval = d
 			}
+		}
+		if interval <= 0 {
+			interval = time.Second / 5
 		}
 		logDebug("interp mobiles interval=%v", interval)
 		state.prevTime = time.Now()


### PR DESCRIPTION
## Summary
- Preserve recorded UPS when draw-state resets so clmov playback stays smooth under area changes.

## Testing
- `gofmt -w draw.go`
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ba5bb0524832a93a874eeed7f94fb