### PR TITLE
Add zone overlay for pinned windows

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -32,16 +32,25 @@ func Draw(screen *ebiten.Image) {
 
 	pendingDropdowns = pendingDropdowns[:0]
 
+	var hoverPinWin *windowData
+
 	for _, win := range windows {
 		if !win.Open {
 			continue
 		}
-
+		if win.HoverPin {
+			hoverPinWin = win
+		}
 		win.Draw(screen)
 	}
 
 	for _, dr := range pendingDropdowns {
 		drawDropdownOptions(dr.item, dr.offset, dr.clip, screen)
+	}
+
+	if hoverPinWin != nil {
+		drawZoneOverlay(screen, hoverPinWin)
+		hoverPinWin.HoverPin = false
 	}
 
 	if DumpMode && !dumpDone {
@@ -57,6 +66,37 @@ func Draw(screen *ebiten.Image) {
 		}
 		dumpDone = true
 		os.Exit(0)
+	}
+}
+
+func drawZoneOverlay(screen *ebiten.Image, win *windowData) {
+	size := float32(20) * uiScale
+	fillet := size / 4
+	dark := color.NRGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xC0}
+	red := color.NRGBA{R: 0xFF, G: 0x00, B: 0x00, A: 0xFF}
+
+	cx := win.getPosition().X + win.GetSize().X/2
+	cy := win.getPosition().Y + win.GetSize().Y/2
+	hSel := nearestHZone(cx, screenWidth)
+	vSel := nearestVZone(cy, screenHeight)
+
+	for h := HZoneLeft; h <= HZoneRight; h++ {
+		for v := VZoneTop; v <= VZoneBottom; v++ {
+			x := hZoneCoord(h, screenWidth)
+			y := vZoneCoord(v, screenHeight)
+			col := dark
+			if h == hSel && v == vSel {
+				col = red
+			}
+			rr := roundRect{
+				Size:     point{X: size, Y: size},
+				Position: point{X: x - size/2, Y: y - size/2},
+				Fillet:   fillet,
+				Filled:   true,
+				Color:    col,
+			}
+			drawRoundRect(screen, &rr)
+		}
 	}
 }
 
@@ -196,7 +236,6 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			color := win.Theme.Window.TitleColor
 			if win.HoverPin {
 				color = win.Theme.Window.HoverTitleColor
-				win.HoverPin = false
 			}
 			radius := win.GetTitleSize() / 6
 			cx := pr.X0 + (pr.X1-pr.X0)/2


### PR DESCRIPTION
## Summary
- Track windows whose pin icon is hovered and draw a zone overlay before resetting hover state
- Highlight the nearest zone to the hovered window using existing zone utilities

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; Package gtk+-3.0 was not found in the pkg-config search path; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ba7e52894832aadaa4b7dca4a2bc9