### PR TITLE
Ensure Clan Lord window renders behind UI

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -36,9 +36,10 @@ type windowData struct {
 	AutoSize bool
 
 	// Scroll position and behavior
-	Scroll   point
-	NoScroll bool
-	NoScale  bool
+	Scroll          point
+	NoScroll        bool
+	NoScale         bool
+	AlwaysDrawFirst bool
 
 	TitleHeight float32
 

--- a/eui/window.go
+++ b/eui/window.go
@@ -24,10 +24,19 @@ func (target *windowData) AddWindow(toBack bool) {
 		toBack = true
 	}
 
+	if target.AlwaysDrawFirst {
+		windows = append([]*windowData{target}, windows...)
+		return
+	}
+
 	if !toBack {
 		windows = append(windows, target)
 	} else {
-		windows = append([]*windowData{target}, windows...)
+		idx := 0
+		for idx < len(windows) && windows[idx].AlwaysDrawFirst {
+			idx++
+		}
+		windows = append(windows[:idx], append([]*windowData{target}, windows[idx:]...)...)
 	}
 }
 
@@ -158,6 +167,9 @@ func NewText() (*itemData, *EventHandler) {
 
 // Bring a window to the front
 func (target *windowData) BringForward() {
+	if target.AlwaysDrawFirst {
+		return
+	}
 	for w, win := range windows {
 		if win == target {
 			windows = append(windows[:w], windows[w+1:]...)
@@ -202,7 +214,14 @@ func (target *windowData) ToBack() {
 	for w, win := range windows {
 		if win == target {
 			windows = append(windows[:w], windows[w+1:]...)
-			windows = append([]*windowData{target}, windows...)
+			idx := 0
+			for idx < len(windows) && windows[idx].AlwaysDrawFirst {
+				idx++
+			}
+			if target.AlwaysDrawFirst {
+				idx = 0
+			}
+			windows = append(windows[:idx], append([]*windowData{target}, windows[idx:]...)...)
 		}
 	}
 	if activeWindow == target {

--- a/game.go
+++ b/game.go
@@ -1211,6 +1211,7 @@ func makeGameWindow() {
 	gameWin.Resizable = true
 	gameWin.Movable = true
 	gameWin.NoScale = true
+	gameWin.AlwaysDrawFirst = true
 	//gameWin.SetZone(eui.HZoneCenter, eui.VZoneMiddle)
 	gameWin.MarkOpen()
 }


### PR DESCRIPTION
## Summary
- add `AlwaysDrawFirst` flag to window data so certain windows render before others
- apply flag to main Clan Lord game window
- update window list helpers to respect flag

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ba8f0e050832ab9b3bdd0ff685ee2