### PR TITLE
Add image item type to EUI with update helper

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -937,6 +937,16 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		drawFilledRect(subImg, sx, sy, sw, sw, color.RGBA(item.WheelColor), true)
 		strokeRect(subImg, sx, sy, sw, sw, 1, color.Black, true)
 
+	} else if item.ItemType == ITEM_IMAGE {
+		if item.Image != nil {
+			iw, ih := item.Image.Bounds().Dx(), item.Image.Bounds().Dy()
+			op := &ebiten.DrawImageOptions{}
+			if int(maxSize.X) != iw || int(maxSize.Y) != ih {
+				op.GeoM.Scale(float64(maxSize.X)/float64(iw), float64(maxSize.Y)/float64(ih))
+			}
+			op.GeoM.Translate(float64(offset.X), float64(offset.Y))
+			subImg.DrawImage(item.Image, op)
+		}
 	} else if item.ItemType == ITEM_TEXT {
 
 		textSize := (item.FontSize * uiScale) + 2

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -242,6 +242,7 @@ const (
 	ITEM_SLIDER
 	ITEM_DROPDOWN
 	ITEM_COLORWHEEL
+	ITEM_IMAGE
 )
 
 // Exported type aliases for library consumers

--- a/eui/tree.go
+++ b/eui/tree.go
@@ -88,6 +88,8 @@ func itemTypeName(t itemTypeData) string {
 		return "dropdown"
 	case ITEM_COLORWHEEL:
 		return "colorwheel"
+	case ITEM_IMAGE:
+		return "image"
 	default:
 		return "unknown"
 	}

--- a/eui/util.go
+++ b/eui/util.go
@@ -562,6 +562,21 @@ func (item *itemData) markDirty() {
 	}
 }
 
+// UpdateImage replaces the item's image and adjusts size if needed.
+func (item *itemData) UpdateImage(img *ebiten.Image) {
+	if item == nil {
+		return
+	}
+	item.Image = img
+	if img != nil {
+		w, h := img.Size()
+		if item.Size.X != float32(w) || item.Size.Y != float32(h) {
+			item.Size = point{X: float32(w), Y: float32(h)}
+		}
+	}
+	item.markDirty()
+}
+
 func (item *itemData) setParentWindow(win *windowData) {
 	item.ParentWindow = win
 	for _, child := range item.Contents {

--- a/eui/window.go
+++ b/eui/window.go
@@ -2,6 +2,8 @@ package eui
 
 import (
 	"log"
+
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 // Add window to window list
@@ -151,6 +153,20 @@ func NewColorWheel() (*itemData, *EventHandler) {
 	newItem.Handler = h
 	newItem.Theme = currentTheme
 	return &newItem, h
+}
+
+// Create a new image item with a new image buffer
+func NewImageItem(w, h int) (*itemData, *ebiten.Image) {
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := itemData{
+		ItemType: ITEM_IMAGE,
+		Size:     point{X: float32(w), Y: float32(h)},
+		Theme:    currentTheme,
+	}
+	newItem.Image = ebiten.NewImage(w, h)
+	return &newItem, newItem.Image
 }
 
 // Create a new textbox from the default theme


### PR DESCRIPTION
## Summary
- support image-based widgets via new `ITEM_IMAGE` type
- provide `NewImageItem` constructor returning the image pointer
- allow `ItemData.UpdateImage` to refresh size and mark dirty

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*


------
https://chatgpt.com/codex/tasks/task_e_689bb1e88c38832a9dbbfeb5a4bc5725