### PR TITLE
Clone game window theme and remove background fill

### DIFF
--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -26,6 +26,7 @@ var defaultTheme = &windowData{
 	ShadowColor: NewColor(0, 0, 0, 160),
 
 	Movable: true, Closable: true, Resizable: true, Open: true, AutoSize: false,
+	NoBGColor: false,
 }
 
 var defaultButton = &itemData{

--- a/eui/render.go
+++ b/eui/render.go
@@ -127,6 +127,9 @@ func (win *windowData) drawBG(screen *ebiten.Image) {
 		}
 		drawDropShadow(screen, &rr, win.ShadowSize, win.ShadowColor)
 	}
+	if win.NoBGColor {
+		return
+	}
 	r := rect{
 		X0: win.getPosition().X + win.BorderPad*win.scale(),
 		Y0: win.getPosition().Y + win.BorderPad*win.scale(),

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -39,6 +39,7 @@ type windowData struct {
 	Scroll          point
 	NoScroll        bool
 	NoScale         bool
+	NoBGColor       bool
 	AlwaysDrawFirst bool
 
 	TitleHeight float32

--- a/game.go
+++ b/game.go
@@ -531,15 +531,7 @@ func gameContentOrigin() (int, int) {
 }
 
 func (g *Game) Draw(screen *ebiten.Image) {
-
 	ox, oy := gameContentOrigin()
-	if gameWin != nil {
-		size := gameWin.GetSize()
-		w := float32(int(size.X) &^ 1)
-		h := float32(int(size.Y) &^ 1)
-		bg := color.RGBA(gameWin.Theme.Window.BGColor)
-		vector.DrawFilledRect(screen, float32(ox), float32(oy), w, h, bg, false)
-	}
 	if clmov == "" && tcpConn == nil {
 		drawSplash(screen, ox, oy)
 		eui.Draw(screen)
@@ -1206,6 +1198,13 @@ func makeGameWindow() {
 		return
 	}
 	gameWin = eui.NewWindow()
+	th := *gameWin.Theme
+	th.Window.Theme = &th
+	th.Window.BGColor = eui.Color{R: 0, G: 0, B: 0, A: 0}
+	th.Window.ShadowColor = eui.Color{R: 0, G: 0, B: 0, A: 0}
+	gameWin.Theme = &th
+	gameWin.ShadowColor = eui.Color{R: 0, G: 0, B: 0, A: 0}
+	gameWin.NoBGColor = true
 	gameWin.Title = "Clan Lord"
 	gameWin.Closable = false
 	gameWin.Resizable = true


### PR DESCRIPTION
## Summary
- clone game window theme and make its background fully transparent
- add `NoBGColor` flag so eui can skip drawing window backgrounds
- drop redundant Draw() fill so window borders and title render over game content

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689baf6196a4832ab7222b6791a920f2