### PR TITLE
Fix undefined variables by retrieving window origin

### DIFF
--- a/game.go
+++ b/game.go
@@ -551,6 +551,7 @@ func gameContentOrigin() (int, int) {
 
 func (g *Game) Draw(screen *ebiten.Image) {
 	ox, oy := gameContentOrigin()
+	wx, wy := gameWindowOrigin()
 	if clmov == "" && tcpConn == nil {
 		drawSplash(screen, ox, oy)
 		eui.Draw(screen)


### PR DESCRIPTION
## Summary
- Initialize window origin variables in `Draw` to resolve undefined references

## Testing
- `go vet ./...` *(fails: Xrandr.h missing; ALSA, GTK+ dev packages not found)*
- `go test ./...` *(fails: Xrandr.h missing; ALSA, GTK+ dev packages not found)*
- `go build ./...` *(fails: Xrandr.h missing; ALSA, GTK+ dev packages not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb6bd61e4832a8dfc6709897f5411