### PR TITLE
Apply game scale on game window creation

### DIFF
--- a/game.go
+++ b/game.go
@@ -1229,6 +1229,7 @@ func makeGameWindow() {
 	gameWin.AlwaysDrawFirst = true
 	gameWin.SetZone(eui.HZoneCenter, eui.VZoneTop)
 	gameWin.MarkOpen()
+	updateGameWindowSize()
 }
 
 func noteFrame() {


### PR DESCRIPTION
## Summary
- call `updateGameWindowSize` immediately after `gameWin.MarkOpen`

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bd21ca2fc832a8df7d441963938c9