### PR TITLE
eui: preserve alpha in zone overlay colors

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -89,7 +89,7 @@ func drawZoneOverlay(screen *ebiten.Image, win *windowData) {
 				Position: point{X: x - size/2, Y: y - size/2},
 				Fillet:   fillet,
 				Filled:   true,
-				Color:    Color{R: col.R, G: col.G, B: col.B},
+				Color:    Color{R: col.R, G: col.G, B: col.B, A: col.A},
 			}
 			drawRoundRect(screen, &rr)
 		}


### PR DESCRIPTION
## Summary
- ensure `drawZoneOverlay` copies the alpha channel when building roundRect colors

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`
- `go run .` *(fails: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bd990b0a8832ab3bec92c4babe470