### PR TITLE
Gray pin icon when window is unpinned

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -233,6 +233,13 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 		{
 			pr := win.pinRect()
 			color := win.Theme.Window.TitleColor
+			if win.zone == nil {
+				if c, ok := namedColors["disabled"]; ok {
+					color = c
+				} else {
+					color = ColorGray
+				}
+			}
 			if win.HoverPin {
 				color = win.Theme.Window.HoverTitleColor
 			}


### PR DESCRIPTION
## Summary
- Show title bar pin in disabled gray when window is not pinned

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689bdbbfb948832ab88e552705551e13