### PR TITLE
Remove game window frame and simplify origin

### DIFF
--- a/game.go
+++ b/game.go
@@ -523,7 +523,7 @@ func gameWindowOrigin() (int, int) {
 	frame := gameWin.Margin + gameWin.Border + gameWin.BorderPad + gameWin.Padding
 	x := pos.X + frame
 	y := pos.Y + frame + gameWin.GetRawTitleSize()
-	return int(math.Round(float64(x))), int(math.Round(float64(y)))
+	return int(x), int(y)
 }
 
 func gameContentOrigin() (int, int) {
@@ -1214,6 +1214,10 @@ func makeGameWindow() {
 		return
 	}
 	gameWin = eui.NewWindow()
+	gameWin.Margin = 0
+	gameWin.Padding = 0
+	gameWin.Border = 0
+	gameWin.BorderPad = 0
 	th := *gameWin.Theme
 	th.Window.Theme = &th
 	th.Window.BGColor = eui.Color{R: 0, G: 0, B: 0, A: 0}


### PR DESCRIPTION
## Summary
- Remove margin, padding, border, and border padding to eliminate game window frame
- Cast raw window position directly instead of using math.Round to avoid off-by-one offsets

## Testing
- `go vet ./...`
- `go build`
- `go run .` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bdd20cbc0832a95bc7baa5ab838ee