### PR TITLE
Close windows by default

### DIFF
--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -25,7 +25,7 @@ var defaultTheme = &windowData{
 	ShadowSize:  16,
 	ShadowColor: NewColor(0, 0, 0, 160),
 
-	Movable: true, Closable: true, Resizable: true, Open: true, AutoSize: false,
+	Movable: true, Closable: true, Resizable: true, Open: false, AutoSize: false,
 	NoBGColor: false,
 }
 


### PR DESCRIPTION
## Summary
- default windows are no longer opened automatically

## Testing
- `go fmt eui/defaults.go`
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go run .` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bdd10bb60832a9cde8b81f3a89cd9