### PR TITLE
Persist and expose theme selection

### DIFF
--- a/game.go
+++ b/game.go
@@ -1199,10 +1199,13 @@ func initGame() {
 	ebiten.SetTPS(ebiten.SyncWithFPS)
 	ebiten.SetCursorShape(ebiten.CursorShapeDefault)
 
-	eui.LoadTheme("AccentDark")
-	eui.LoadStyle("RoundHybrid")
-
 	loadSettings()
+	theme := gs.Theme
+	if theme == "" {
+		theme = "AccentDark"
+	}
+	eui.LoadTheme(theme)
+	eui.LoadStyle("RoundHybrid")
 	initUI()
 	updateCharacterButtons()
 

--- a/settings.go
+++ b/settings.go
@@ -41,6 +41,7 @@ var gsdef settings = settings{
 	Volume:            0.5,
 	Mute:              false,
 	GameScale:         2,
+	Theme:             "AccentDark",
 	MessagesToConsole: false,
 	AnyGameWindowSize: false,
 
@@ -95,6 +96,7 @@ type settings struct {
 	Mute              bool
 	AnyGameWindowSize bool
 	GameScale         float64
+	Theme             string
 
 	GameWindow      WindowState
 	InventoryWindow WindowState
@@ -147,6 +149,9 @@ func loadSettings() bool {
 	newGS := gsdef
 	if err := json.Unmarshal(data, &newGS); err != nil {
 		return false
+	}
+	if newGS.Theme == "" {
+		newGS.Theme = gsdef.Theme
 	}
 
 	if gs.Version == 2 {

--- a/ui.go
+++ b/ui.go
@@ -682,6 +682,31 @@ func makeSettingsWindow() {
 	mainFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 	var width float32 = 250
 
+	themeDD, themeEvents := eui.NewDropdown()
+	themeDD.Label = "Theme"
+	if opts, err := eui.ListThemes(); err == nil {
+		themeDD.Options = opts
+		cur := eui.CurrentThemeName()
+		for i, n := range opts {
+			if n == cur {
+				themeDD.Selected = i
+				break
+			}
+		}
+	}
+	themeDD.Size = eui.Point{X: width, Y: 24}
+	themeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventDropdownSelected {
+			name := themeDD.Options[ev.Index]
+			if err := eui.LoadTheme(name); err == nil {
+				gs.Theme = name
+				settingsDirty = true
+				settingsWin.Refresh()
+			}
+		}
+	}
+	mainFlow.AddItem(themeDD)
+
 	label, _ := eui.NewText()
 	label.Text = "\nControls:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- Store selected UI theme in settings with default AccentDark
- Load saved theme at startup and allow switching via settings dropdown
- Refresh settings window immediately when theme changes

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bddd038a0832a9c6d24180ea22991