### PR TITLE
Reset pin hover after drawing

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -244,6 +244,7 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			}
 			if win.HoverPin {
 				color = win.Theme.Window.HoverTitleColor
+				win.HoverPin = false
 			}
 			radius := win.GetTitleSize() / 6
 			cx := pr.X0 + (pr.X1-pr.X0)/2


### PR DESCRIPTION
## Summary
- reset window pin hover flag after drawing to prevent lingering pin hover state

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689bde004770832aa554f109600cb5e1