### PR TITLE
Improve zone snapping for large windows

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -71,10 +71,10 @@ func drawZoneOverlay(screen *ebiten.Image, win *windowData) {
 	dark := color.NRGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xC0}
 	red := color.NRGBA{R: 0xFF, G: 0x00, B: 0x00, A: 0xFF}
 
-	cx := win.getPosition().X + win.GetSize().X/2
-	cy := win.getPosition().Y + win.GetSize().Y/2
-	hSel := nearestHZone(cx, screenWidth)
-	vSel := nearestVZone(cy, screenHeight)
+	pos := win.getPosition()
+	winSize := win.GetSize()
+	hSel := nearestHZone(pos.X, winSize.X, screenWidth)
+	vSel := nearestVZone(pos.Y, winSize.Y, screenHeight)
 
 	for h := HZoneLeft; h <= HZoneRight; h++ {
 		for v := VZoneTop; v <= VZoneBottom; v++ {

--- a/eui/render.go
+++ b/eui/render.go
@@ -18,7 +18,7 @@ import (
 const shadowAlphaDivisor = 16
 
 var dumpDone bool
-var hoverPinWin *windowData
+var zoneIndicatorWin *windowData
 
 type openDropdown struct {
 	item   *itemData
@@ -28,20 +28,24 @@ type openDropdown struct {
 // Draw renders the UI to the provided screen image.
 // Call this from your Ebiten Draw function.
 func Draw(screen *ebiten.Image) {
-	hoverPinWin = nil
+	zoneIndicatorWin = nil
 	dropdowns := []openDropdown{}
 	for _, win := range windows {
 		if !win.Open {
 			continue
 		}
 		if win.HoverPin {
-			hoverPinWin = win
+			zoneIndicatorWin = win
 		}
 		win.Draw(screen, &dropdowns)
 	}
 
-	if hoverPinWin != nil {
-		drawZoneOverlay(screen, hoverPinWin)
+	if dragPart == PART_BAR && dragWin != nil {
+		zoneIndicatorWin = dragWin
+	}
+
+	if zoneIndicatorWin != nil {
+		drawZoneOverlay(screen, zoneIndicatorWin)
 	}
 
 	screenClip := rect{X0: 0, Y0: 0, X1: float32(screenWidth), Y1: float32(screenHeight)}

--- a/eui/zones.go
+++ b/eui/zones.go
@@ -118,38 +118,46 @@ func vZoneCoord(z VZone, height int) float32 {
 	}
 }
 
-func nearestHZone(x float32, width int) HZone {
+func nearestHZone(x, w float32, width int) HZone {
 	zones := []HZone{HZoneLeft, HZoneLeftCenter, HZoneCenterLeft, HZoneCenter, HZoneCenterRight, HZoneRightCenter, HZoneRight}
 	closest := zones[0]
 	min := float32(math.MaxFloat32)
+	positions := []float32{x, x + w/2, x + w}
 	for _, z := range zones {
-		diff := float32(math.Abs(float64(x - hZoneCoord(z, width))))
-		if diff < min {
-			min = diff
-			closest = z
+		zx := hZoneCoord(z, width)
+		for _, px := range positions {
+			diff := float32(math.Abs(float64(px - zx)))
+			if diff < min {
+				min = diff
+				closest = z
+			}
 		}
 	}
 	return closest
 }
 
-func nearestVZone(y float32, height int) VZone {
+func nearestVZone(y, h float32, height int) VZone {
 	zones := []VZone{VZoneTop, VZoneTopMiddle, VZoneMiddleTop, VZoneCenter, VZoneMiddleBottom, VZoneBottomMiddle, VZoneBottom}
 	closest := zones[0]
 	min := float32(math.MaxFloat32)
+	positions := []float32{y, y + h/2, y + h}
 	for _, z := range zones {
-		diff := float32(math.Abs(float64(y - vZoneCoord(z, height))))
-		if diff < min {
-			min = diff
-			closest = z
+		zy := vZoneCoord(z, height)
+		for _, py := range positions {
+			diff := float32(math.Abs(float64(py - zy)))
+			if diff < min {
+				min = diff
+				closest = z
+			}
 		}
 	}
 	return closest
 }
 
 func (win *windowData) PinToClosestZone() {
-	cx := win.getPosition().X + win.GetSize().X/2
-	cy := win.getPosition().Y + win.GetSize().Y/2
-	h := nearestHZone(cx, screenWidth)
-	v := nearestVZone(cy, screenHeight)
+	pos := win.getPosition()
+	size := win.GetSize()
+	h := nearestHZone(pos.X, size.X, screenWidth)
+	v := nearestVZone(pos.Y, size.Y, screenHeight)
 	win.SetZone(h, v)
 }

--- a/eui/zones_test.go
+++ b/eui/zones_test.go
@@ -32,3 +32,33 @@ func TestPinToClosestZone(t *testing.T) {
 		}
 	}
 }
+
+func TestPinToClosestZoneLargeWindow(t *testing.T) {
+	screenWidth = 100
+	screenHeight = 100
+	uiScale = 1
+
+	size := point{80, 80}
+
+	tests := []struct {
+		pos point
+		h   HZone
+		v   VZone
+	}{
+		{point{0, 0}, HZoneLeft, VZoneTop},
+		{point{20, 0}, HZoneRight, VZoneTop},
+		{point{0, 20}, HZoneLeft, VZoneBottom},
+		{point{20, 20}, HZoneRight, VZoneBottom},
+	}
+
+	for _, tt := range tests {
+		win := &windowData{Position: tt.pos, Size: size}
+		win.PinToClosestZone()
+		if win.zone == nil {
+			t.Fatalf("zone not set")
+		}
+		if win.zone.h != tt.h || win.zone.v != tt.v {
+			t.Fatalf("pos %+v size %+v pinned to (%v,%v); want (%v,%v)", tt.pos, size, win.zone.h, win.zone.v, tt.h, tt.v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- account for window edges when computing nearest zones
- expose window size to zone calculations and overlay
- test that oversized windows snap to screen corners

## Testing
- `go vet ./...`
- `xvfb-run -a go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bde26e8e0832a9eaabb959f374315