### PR TITLE
Snap windows to screen corners and neighbors

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -187,6 +187,13 @@ func Update() error {
 					dragWindowScroll(win, mpos, false)
 				}
 				win.clampToScreen()
+				if win.zone == nil {
+					if !snapToCorner(win) {
+						if snapToWindow(win) {
+							win.clampToScreen()
+						}
+					}
+				}
 				break
 			}
 		}


### PR DESCRIPTION
## Summary
- snap windows to screen corner zones when dragged near screen corners
- allow windows to snap to the edges of nearby windows
- test snapping logic for corners and adjacent windows

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bde4750f4832aa660364c466ad216