### PR TITLE
Quantize game scale to rational or integer values

### DIFF
--- a/game.go
+++ b/game.go
@@ -501,8 +501,13 @@ func updateGameScale() {
 		newScale = 0.25
 	}
 
-	if gs.GameScale != newScale {
-		gs.GameScale = newScale
+	snapped, exact := exactScale(newScale, 8, 1e-6)
+	if !exact {
+		snapped = math.Max(1, math.Round(newScale))
+	}
+
+	if gs.GameScale != snapped {
+		gs.GameScale = snapped
 		initFont()
 	}
 }


### PR DESCRIPTION
## Summary
- snap game scale to small rational values or nearest integer when resizing
- avoid unnecessary font reinit by only updating scale on change

## Testing
- `go fmt game.go`
- `go vet ./...` *(terminated without output)*
- `go test ./...` *(fails: X11 DISPLAY missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bea7a8f40832a901edcd21e503a4a