### PR TITLE
Show zone markers only during drag

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -34,9 +34,6 @@ func Draw(screen *ebiten.Image) {
 		if !win.Open {
 			continue
 		}
-		if win.HoverPin {
-			zoneIndicatorWin = win
-		}
 		win.Draw(screen, &dropdowns)
 	}
 


### PR DESCRIPTION
## Summary
- Show zone marker overlay only while a window is being dragged

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689beceec114832ab462a72527d7dc77