### PR TITLE
Use 547x540 playfield size

### DIFF
--- a/game.go
+++ b/game.go
@@ -22,7 +22,7 @@ import (
 )
 
 const lateRatio = 85
-const gameAreaSizeX, gameAreaSizeY = 640, 480
+const gameAreaSizeX, gameAreaSizeY = 547, 540
 const fieldCenterX, fieldCenterY = gameAreaSizeX / 2, gameAreaSizeY / 2
 const defaultHandPictID = 6
 
@@ -101,7 +101,7 @@ var (
 )
 
 // gameWin represents the main playfield window. Its size corresponds to the
-// classic client field box dimensions defined in old_mac_client/client/source/
+// classic client field box (547×540) defined in old_mac_client/client/source/
 // GameWin_cl.cp and Public_cl.h (Layout.layoFieldBox).
 var gameWin *eui.WindowData
 var settingsWin *eui.WindowData


### PR DESCRIPTION
## Summary
- Update base playfield dimensions to 547×540 to match classic layout
- Document playfield size in game window comment

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred; panic: glfw: The GLFW library is not initialized: the GLFW library is not initialized)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bed3db0b0832ab884530fe544d35b