### PR TITLE
Avoid bringing windows forward when focus shifts

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -219,6 +219,7 @@ func Update() error {
 
 		// Window items
 		prevWinHovered := win.Hovered
+		prevActiveWindow := activeWindow
 		win.Hovered = false
 		win.clickWindowItems(mpos, click)
 		if win.Hovered != prevWinHovered {
@@ -230,8 +231,10 @@ func Update() error {
 		// event.
 		if win.getWinRect().containsPoint(mpos) || dropdownOpenContains(win.Contents, mpos) {
 			if click || midClick {
-				if activeWindow != win || windows[len(windows)-1] != win {
-					win.BringForward()
+				if activeWindow == prevActiveWindow {
+					if activeWindow != win || windows[len(windows)-1] != win {
+						win.BringForward()
+					}
 				}
 			}
 			break


### PR DESCRIPTION
## Summary
- Track previously active window before processing clicks
- Only bring a window forward if the active window hasn't changed

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bf9dd5ca0832abf5599011fd927e0