### PR TITLE
Add console and chat window font size sliders

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -18,8 +18,9 @@ func updateChatWindow() {
 	changed := false
 	for i, msg := range msgs {
 		if i < len(chatList.Contents) {
-			if chatList.Contents[i].Text != msg {
+			if chatList.Contents[i].Text != msg || chatList.Contents[i].FontSize != float32(gs.ChatFontSize) {
 				chatList.Contents[i].Text = msg
+				chatList.Contents[i].FontSize = float32(gs.ChatFontSize)
 				changed = true
 			}
 		} else {
@@ -29,7 +30,7 @@ func updateChatWindow() {
 				continue
 			}
 			t.Text = msg
-			t.FontSize = 10
+			t.FontSize = float32(gs.ChatFontSize)
 			t.Size = eui.Point{X: 256, Y: 24}
 			chatList.AddItem(t)
 			changed = true

--- a/console_ui.go
+++ b/console_ui.go
@@ -20,14 +20,15 @@ func updateConsoleWindow() {
 	changed := false
 	for i, msg := range msgs {
 		if i < len(messagesList.Contents) {
-			if messagesList.Contents[i].Text != msg {
+			if messagesList.Contents[i].Text != msg || messagesList.Contents[i].FontSize != float32(gs.ConsoleFontSize) {
 				messagesList.Contents[i].Text = msg
+				messagesList.Contents[i].FontSize = float32(gs.ConsoleFontSize)
 				changed = true
 			}
 		} else {
 			t, _ := eui.NewText()
 			t.Text = msg
-			t.FontSize = 10
+			t.FontSize = float32(gs.ConsoleFontSize)
 			t.Size = eui.Point{X: 500, Y: 24}
 			messagesList.AddItem(t)
 			changed = true
@@ -35,14 +36,15 @@ func updateConsoleWindow() {
 	}
 	inputIdx := len(msgs)
 	if inputIdx < len(messagesList.Contents) {
-		if messagesList.Contents[inputIdx].Text != inputMsg {
+		if messagesList.Contents[inputIdx].Text != inputMsg || messagesList.Contents[inputIdx].FontSize != float32(gs.ConsoleFontSize) {
 			messagesList.Contents[inputIdx].Text = inputMsg
+			messagesList.Contents[inputIdx].FontSize = float32(gs.ConsoleFontSize)
 			changed = true
 		}
 	} else {
 		t, _ := eui.NewText()
 		t.Text = inputMsg
-		t.FontSize = 10
+		t.FontSize = float32(gs.ConsoleFontSize)
 		t.Size = eui.Point{X: 500, Y: 24}
 		messagesList.AddItem(t)
 		changed = true

--- a/settings.go
+++ b/settings.go
@@ -16,14 +16,16 @@ var gs settings = gsdef
 var gsdef settings = settings{
 	Version: 2,
 
-	LastCharacter:  "",
-	ClickToToggle:  false,
-	KBWalkSpeed:    0.25,
-	MainFontSize:   8,
-	BubbleFontSize: 6,
-	BubbleOpacity:  0.7,
-	NameBgOpacity:  0.7,
-	SpeechBubbles:  true,
+	LastCharacter:   "",
+	ClickToToggle:   false,
+	KBWalkSpeed:     0.25,
+	MainFontSize:    8,
+	BubbleFontSize:  6,
+	ConsoleFontSize: 10,
+	ChatFontSize:    10,
+	BubbleOpacity:   0.7,
+	NameBgOpacity:   0.7,
+	SpeechBubbles:   true,
 
 	MotionSmoothing:   true,
 	BlendMobiles:      false,
@@ -70,14 +72,16 @@ var gsdef settings = settings{
 type settings struct {
 	Version int
 
-	LastCharacter  string
-	ClickToToggle  bool
-	KBWalkSpeed    float64
-	MainFontSize   float64
-	BubbleFontSize float64
-	BubbleOpacity  float64
-	NameBgOpacity  float64
-	SpeechBubbles  bool
+	LastCharacter   string
+	ClickToToggle   bool
+	KBWalkSpeed     float64
+	MainFontSize    float64
+	BubbleFontSize  float64
+	ConsoleFontSize float64
+	ChatFontSize    float64
+	BubbleOpacity   float64
+	NameBgOpacity   float64
+	SpeechBubbles   bool
 
 	MotionSmoothing   bool
 	BlendMobiles      bool

--- a/ui.go
+++ b/ui.go
@@ -775,6 +775,42 @@ func makeSettingsWindow() {
 	}
 	mainFlow.AddItem(labelFontSlider)
 
+	consoleFontSlider, consoleFontEvents := eui.NewSlider()
+	consoleFontSlider.Label = "Console"
+	consoleFontSlider.MinValue = 6
+	consoleFontSlider.MaxValue = 24
+	consoleFontSlider.Value = float32(gs.ConsoleFontSize)
+	consoleFontSlider.Size = eui.Point{X: width - 10, Y: 24}
+	consoleFontEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.ConsoleFontSize = float64(ev.Value)
+			updateConsoleWindow()
+			if consoleWin != nil {
+				consoleWin.Refresh()
+			}
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(consoleFontSlider)
+
+	chatWindowFontSlider, chatWindowFontEvents := eui.NewSlider()
+	chatWindowFontSlider.Label = "Chat Window"
+	chatWindowFontSlider.MinValue = 6
+	chatWindowFontSlider.MaxValue = 24
+	chatWindowFontSlider.Value = float32(gs.ChatFontSize)
+	chatWindowFontSlider.Size = eui.Point{X: width - 10, Y: 24}
+	chatWindowFontEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.ChatFontSize = float64(ev.Value)
+			updateChatWindow()
+			if chatWin != nil {
+				chatWin.Refresh()
+			}
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(chatWindowFontSlider)
+
 	label, _ = eui.NewText()
 	label.Text = "\nOpacity Settings:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- allow customizing console and chat window text sizes through new settings
- apply font size settings in console and chat message windows
- expose sliders for console and chat window font sizes in settings menu

## Testing
- `go fmt settings.go console_ui.go chat_messages_ui.go ui.go`
- `go vet ./...`
- `xvfb-run -a go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bfaa8162c832a9d3ab084c19bd591