### PR TITLE
Clear zone when dragging windows

### DIFF
--- a/eui/drag_test.go
+++ b/eui/drag_test.go
@@ -1,0 +1,24 @@
+package eui
+
+import "testing"
+
+func TestDragClearsZone(t *testing.T) {
+	screenWidth = 100
+	screenHeight = 100
+	uiScale = 1
+
+	win := &windowData{Movable: true}
+	win.SetZone(HZoneLeft, VZoneTop)
+	oldPos := win.Position
+	delta := point{X: 5, Y: 5}
+
+	dragWindowMove(win, delta)
+
+	if win.zone != nil {
+		t.Fatalf("zone not cleared")
+	}
+	expect := pointAdd(oldPos, delta)
+	if win.Position != expect {
+		t.Fatalf("expected position %+v, got %+v", expect, win.Position)
+	}
+}

--- a/eui/input.go
+++ b/eui/input.go
@@ -149,9 +149,7 @@ func Update() error {
 			} else if (clickDrag || midClickDrag) && dragPart != PART_NONE && dragWin == win {
 				switch dragPart {
 				case PART_BAR:
-					if win.zone == nil {
-						win.Position = pointAdd(win.Position, posCh)
-					}
+					dragWindowMove(win, posCh)
 				case PART_TOP:
 					posCh.X = 0
 					sizeCh.X = 0
@@ -783,6 +781,15 @@ func scrollWindow(win *windowData, delta point) bool {
 		win.markDirty()
 	}
 	return handled
+}
+
+func dragWindowMove(win *windowData, delta point) {
+	if win.zone != nil && win.Movable {
+		win.ClearZone()
+	}
+	if win.zone == nil {
+		win.Position = pointAdd(win.Position, delta)
+	}
 }
 
 func dragWindowScroll(win *windowData, mpos point, vert bool) {


### PR DESCRIPTION
## Summary
- Automatically clear window zone when a movable window is dragged
- Add test verifying zone is cleared on drag

## Testing
- `go vet ./...`
- `xvfb-run go test ./...`
- `xvfb-run go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bfd70cea0832a89b0d127ca24deba