### PR TITLE
Align speech bubbles with top of mobile sprites

### DIFF
--- a/game.go
+++ b/game.go
@@ -690,6 +690,15 @@ func drawScene(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha float6
 			}
 			x := int((math.Round(hpos) + float64(fieldCenterX)) * gs.GameScale)
 			y := int((math.Round(vpos) + float64(fieldCenterY)) * gs.GameScale)
+			if !b.Far {
+				if d, ok := descMap[b.Index]; ok {
+					if size := mobileSize(d.PictID); size > 0 {
+						scaled := math.Round(float64(size) * gs.GameScale)
+						tailHeight := int(10 * gs.GameScale)
+						y += tailHeight - int(scaled/2)
+					}
+				}
+			}
 			x += ox
 			y += oy
 			borderCol, bgCol, textCol := bubbleColors(b.Type)

--- a/images.go
+++ b/images.go
@@ -255,6 +255,16 @@ func loadMobileFrame(id uint16, state uint8, colors []byte) *ebiten.Image {
 	return frame
 }
 
+// mobileSize returns the dimension of a single mobile frame for the given
+// image ID. If the image cannot be loaded, 0 is returned.
+func mobileSize(id uint16) int {
+	sheet := loadSheet(id, nil, true)
+	if sheet == nil {
+		return 0
+	}
+	return (sheet.Bounds().Dx() - 2) / 16
+}
+
 func mobileBlendFrame(from, to mobileKey, prevImg, img *ebiten.Image, step, total int) *ebiten.Image {
 	if prevImg == nil || img == nil {
 		return nil


### PR DESCRIPTION
## Summary
- offset speech bubbles to the top of the associated mobile sprite
- expose mobileSize helper to query sprite frame dimensions from CL_Images

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_689c00e27c90832aa29baaafa7f9b80d