### PR TITLE
Add window shade toggle

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -120,7 +120,7 @@ func Update() error {
 					c = ebiten.CursorShapeNWSEResize
 				case PART_TOP_RIGHT, PART_BOTTOM_LEFT:
 					c = ebiten.CursorShapeNESWResize
-				case PART_SCROLL_V, PART_SCROLL_H, PART_PIN:
+				case PART_SCROLL_V, PART_SCROLL_H, PART_PIN, PART_SHADE:
 					c = ebiten.CursorShapePointer
 				}
 			}
@@ -139,6 +139,10 @@ func Update() error {
 						win.PinToClosestZone()
 					}
 					win.markDirty()
+					break
+				}
+				if part == PART_SHADE {
+					win.ToggleShade()
 					break
 				}
 				dragPart = part

--- a/eui/render.go
+++ b/eui/render.go
@@ -259,6 +259,28 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			buttonsWidth += (win.GetTitleSize())
 		}
 
+		// Shade arrow
+		{
+			sr := win.shadeRect()
+			color := win.Theme.Window.TitleColor
+			if win.HoverShade {
+				color = win.Theme.Window.HoverTitleColor
+				win.HoverShade = false
+			}
+			pad := win.GetTitleSize() / 3
+			cx := sr.X0 + (sr.X1-sr.X0)/2
+			if win.Shaded {
+				strokeLine(screen, sr.X0+pad, sr.Y0+pad, sr.X1-pad, sr.Y0+pad, uiScale, color, true)
+				strokeLine(screen, sr.X0+pad, sr.Y0+pad, cx, sr.Y1-pad, uiScale, color, true)
+				strokeLine(screen, sr.X1-pad, sr.Y0+pad, cx, sr.Y1-pad, uiScale, color, true)
+			} else {
+				strokeLine(screen, sr.X0+pad, sr.Y1-pad, sr.X1-pad, sr.Y1-pad, uiScale, color, true)
+				strokeLine(screen, sr.X0+pad, sr.Y1-pad, cx, sr.Y0+pad, uiScale, color, true)
+				strokeLine(screen, sr.X1-pad, sr.Y1-pad, cx, sr.Y0+pad, uiScale, color, true)
+			}
+			buttonsWidth += (win.GetTitleSize())
+		}
+
 		//Dragbar
 		if win.Movable && win.ShowDragbar {
 			var xThick float32 = 1

--- a/eui/shade_test.go
+++ b/eui/shade_test.go
@@ -1,0 +1,29 @@
+package eui
+
+import "testing"
+
+func TestShadeToggle(t *testing.T) {
+	uiScale = 1
+	win := &windowData{
+		Position:    point{X: 0, Y: 0},
+		Size:        point{X: 100, Y: 60},
+		TitleHeight: 10,
+		Open:        true,
+		Closable:    true,
+	}
+	sr := win.shadeRect()
+	mpos := point{X: (sr.X0 + sr.X1) / 2, Y: (sr.Y0 + sr.Y1) / 2}
+	local := point{X: mpos.X / uiScale, Y: mpos.Y / uiScale}
+	part := win.getWindowPart(local, true)
+	if part != PART_SHADE {
+		t.Fatalf("expected PART_SHADE, got %v", part)
+	}
+	win.ToggleShade()
+	if !win.Shaded {
+		t.Fatalf("expected window to be shaded")
+	}
+	win.ToggleShade()
+	if win.Shaded {
+		t.Fatalf("expected window to be unshaded")
+	}
+}

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -32,8 +32,10 @@ type windowData struct {
 
 	Open, Hovered, Flow,
 	Closable, Movable, Resizable,
-	HoverClose, HoverDragbar, HoverPin,
-	AutoSize bool
+	HoverClose, HoverDragbar, HoverPin, HoverShade,
+	AutoSize, Shaded bool
+
+	unshadeSize point
 
 	// Scroll position and behavior
 	Scroll          point
@@ -215,6 +217,7 @@ const (
 	PART_BAR
 	PART_CLOSE
 	PART_PIN
+	PART_SHADE
 
 	PART_TOP
 	PART_RIGHT


### PR DESCRIPTION
## Summary
- add a titlebar arrow that collapses windows to just their title
- restore original size when arrow clicked again
- cover shade arrow behavior with a basic unit test

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: "X11: The DISPLAY environment variable is missing")*


------
https://chatgpt.com/codex/tasks/task_e_689c0206ede0832a815581b8e99548c6