### PR TITLE
Enable window snapping during resize

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -203,6 +203,9 @@ func Update() error {
 				case PART_SCROLL_H:
 					dragWindowScroll(win, mpos, false)
 				}
+				if dragPart != PART_BAR && dragPart != PART_SCROLL_V && dragPart != PART_SCROLL_H {
+					snapResize(win, dragPart)
+				}
 				win.clampToScreen()
 				if win.zone == nil {
 					if !snapToCorner(win) {

--- a/eui/zones.go
+++ b/eui/zones.go
@@ -246,3 +246,117 @@ func snapToWindow(win *windowData) bool {
 	}
 	return snapped
 }
+
+// snapResize adjusts a window's size and position when resizing so edges
+// snap to nearby screen edges or other windows within the threshold.
+// It returns true if the window size or position was adjusted.
+func snapResize(win *windowData, part dragType) bool {
+	pos := win.getPosition()
+	size := win.Size
+	snapped := false
+
+	includesLeft := part == PART_LEFT || part == PART_TOP_LEFT || part == PART_BOTTOM_LEFT
+	includesRight := part == PART_RIGHT || part == PART_TOP_RIGHT || part == PART_BOTTOM_RIGHT
+	includesTop := part == PART_TOP || part == PART_TOP_LEFT || part == PART_TOP_RIGHT
+	includesBottom := part == PART_BOTTOM || part == PART_BOTTOM_LEFT || part == PART_BOTTOM_RIGHT
+
+	// Snap to screen edges
+	if includesLeft {
+		if math.Abs(float64(pos.X)) <= float64(CornerSnapThreshold) {
+			delta := pos.X
+			win.Position.X = 0
+			win.setSize(point{X: size.X - delta, Y: size.Y})
+			pos = win.getPosition()
+			size = win.Size
+			snapped = true
+		}
+	}
+	if includesRight {
+		right := pos.X + size.X
+		sw := float32(screenWidth)
+		if math.Abs(float64(sw-right)) <= float64(CornerSnapThreshold) {
+			win.setSize(point{X: sw - pos.X, Y: size.Y})
+			size = win.Size
+			snapped = true
+		}
+	}
+	if includesTop {
+		if math.Abs(float64(pos.Y)) <= float64(CornerSnapThreshold) {
+			delta := pos.Y
+			win.Position.Y = 0
+			win.setSize(point{X: size.X, Y: size.Y - delta})
+			pos = win.getPosition()
+			size = win.Size
+			snapped = true
+		}
+	}
+	if includesBottom {
+		bottom := pos.Y + size.Y
+		sh := float32(screenHeight)
+		if math.Abs(float64(sh-bottom)) <= float64(CornerSnapThreshold) {
+			win.setSize(point{X: size.X, Y: sh - pos.Y})
+			size = win.Size
+			snapped = true
+		}
+	}
+
+	// Snap to other windows
+	for _, other := range windows {
+		if other == win || !other.Open {
+			continue
+		}
+		opos := other.getPosition()
+		osize := other.Size
+
+		if includesLeft {
+			if pos.Y < opos.Y+osize.Y && pos.Y+size.Y > opos.Y {
+				target := opos.X + osize.X
+				if math.Abs(float64(pos.X-target)) <= float64(CornerSnapThreshold) {
+					delta := pos.X - target
+					win.Position.X = target
+					win.setSize(point{X: size.X - delta, Y: size.Y})
+					pos = win.getPosition()
+					size = win.Size
+					snapped = true
+				}
+			}
+		}
+		if includesRight {
+			if pos.Y < opos.Y+osize.Y && pos.Y+size.Y > opos.Y {
+				target := opos.X
+				right := pos.X + size.X
+				if math.Abs(float64(right-target)) <= float64(CornerSnapThreshold) {
+					win.setSize(point{X: target - pos.X, Y: size.Y})
+					size = win.Size
+					snapped = true
+				}
+			}
+		}
+		if includesTop {
+			if pos.X < opos.X+osize.X && pos.X+size.X > opos.X {
+				target := opos.Y + osize.Y
+				if math.Abs(float64(pos.Y-target)) <= float64(CornerSnapThreshold) {
+					delta := pos.Y - target
+					win.Position.Y = target
+					win.setSize(point{X: size.X, Y: size.Y - delta})
+					pos = win.getPosition()
+					size = win.Size
+					snapped = true
+				}
+			}
+		}
+		if includesBottom {
+			if pos.X < opos.X+osize.X && pos.X+size.X > opos.X {
+				target := opos.Y
+				bottom := pos.Y + size.Y
+				if math.Abs(float64(bottom-target)) <= float64(CornerSnapThreshold) {
+					win.setSize(point{X: size.X, Y: target - pos.Y})
+					size = win.Size
+					snapped = true
+				}
+			}
+		}
+	}
+
+	return snapped
+}

--- a/eui/zones_test.go
+++ b/eui/zones_test.go
@@ -94,3 +94,36 @@ func TestSnapToWindow(t *testing.T) {
 	}
 	windows = nil
 }
+
+func TestSnapResizeToWindow(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 200
+	uiScale = 1
+
+	base := &windowData{Position: point{100, 50}, Size: point{20, 20}, Open: true}
+	win := &windowData{Position: point{50, 50}, Size: point{48, 20}, Open: true}
+	windows = []*windowData{base, win}
+
+	snapResize(win, PART_RIGHT)
+
+	expectedWidth := base.Position.X - win.Position.X
+	if win.Size.X != expectedWidth {
+		t.Fatalf("width snapped to %v; want %v", win.Size.X, expectedWidth)
+	}
+	windows = nil
+}
+
+func TestSnapResizeToScreen(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 200
+	uiScale = 1
+
+	win := &windowData{Position: point{50, 50}, Size: point{20, 141}, Open: true}
+
+	snapResize(win, PART_BOTTOM)
+
+	expectedHeight := float32(screenHeight) - win.Position.Y
+	if win.Size.Y != expectedHeight {
+		t.Fatalf("height snapped to %v; want %v", win.Size.Y, expectedHeight)
+	}
+}


### PR DESCRIPTION
## Summary
- add snapResize to align window edges with screen or neighbors during resizing
- invoke snapping logic when resizing
- test snapping to other windows and to screen bounds

## Testing
- `go vet ./...`
- `go build ./...`
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689c02af87c0832a8451b5e0f2700a63