### PR TITLE
Ensure status bars stay on-screen

### DIFF
--- a/game.go
+++ b/game.go
@@ -1106,6 +1106,14 @@ func drawStatusBars(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha f
 	fieldWidth := int(float64(gameAreaSizeX) * gs.GameScale)
 	slot := (fieldWidth - 3*barWidth) / 6
 	barY := int(float64(gameAreaSizeY)*gs.GameScale-20*gs.GameScale) - barHeight
+	screenH := screen.Bounds().Dy()
+	minY := -oy
+	maxY := screenH - oy - barHeight
+	if barY < minY {
+		barY = minY
+	} else if barY > maxY {
+		barY = maxY
+	}
 	x := slot
 	step := barWidth + 2*slot
 	drawBar := func(x int, cur, max int, clr color.RGBA) {


### PR DESCRIPTION
## Summary
- Clamp status bar position so health, balance, and spirit bars stay within the visible window even if part of the game window is off-screen.

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c0364e654832ab7e2b33d999e14d2