### PR TITLE
Add window tiling to prevent overlapping windows

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -39,6 +39,9 @@ var (
 	// CacheCheck shows render counts for windows and items when enabled.
 	CacheCheck bool
 
+	// windowTiling prevents windows from overlapping when enabled.
+	windowTiling bool = true
+
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 

--- a/eui/input.go
+++ b/eui/input.go
@@ -211,6 +211,7 @@ func Update() error {
 						}
 					}
 				}
+				preventOverlap(win)
 				break
 			}
 		}

--- a/eui/public.go
+++ b/eui/public.go
@@ -9,6 +9,12 @@ import (
 // Windows returns the list of active windows.
 func Windows() []*WindowData { return windows }
 
+// WindowTiling reports whether window tiling is enabled.
+func WindowTiling() bool { return windowTiling }
+
+// SetWindowTiling enables or disables window tiling.
+func SetWindowTiling(enabled bool) { windowTiling = enabled }
+
 // SetScreenSize sets the current screen size used for layout calculations.
 func SetScreenSize(w, h int) {
 	screenWidth = w

--- a/eui/tiling_test.go
+++ b/eui/tiling_test.go
@@ -1,0 +1,45 @@
+package eui
+
+import "testing"
+
+func TestWindowTilingPreventsOverlap(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 200
+	uiScale = 1
+	windows = nil
+	SetWindowTiling(true)
+
+	win1 := &windowData{Open: true, Size: point{X: 50, Y: 50}}
+	win2 := &windowData{Open: true, Position: point{X: 25, Y: 25}, Size: point{X: 50, Y: 50}}
+
+	win1.AddWindow(false)
+	win2.AddWindow(false)
+
+	r1 := win1.getWinRect()
+	r2 := win2.getWinRect()
+	inter := intersectRect(r1, r2)
+	if inter.X1 > inter.X0 && inter.Y1 > inter.Y0 {
+		t.Fatalf("windows overlap: r1=%v r2=%v", r1, r2)
+	}
+}
+
+func TestWindowTilingDisabledAllowsOverlap(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 200
+	uiScale = 1
+	windows = nil
+	SetWindowTiling(false)
+
+	win1 := &windowData{Open: true, Size: point{X: 50, Y: 50}}
+	win2 := &windowData{Open: true, Position: point{X: 25, Y: 25}, Size: point{X: 50, Y: 50}}
+
+	win1.AddWindow(false)
+	win2.AddWindow(false)
+
+	r1 := win1.getWinRect()
+	r2 := win2.getWinRect()
+	inter := intersectRect(r1, r2)
+	if inter.X1 <= inter.X0 || inter.Y1 <= inter.Y0 {
+		t.Fatalf("expected overlap with tiling disabled")
+	}
+}

--- a/eui/window.go
+++ b/eui/window.go
@@ -40,6 +40,10 @@ func (target *windowData) AddWindow(toBack bool) {
 		}
 		windows = append(windows[:idx], append([]*windowData{target}, windows[idx:]...)...)
 	}
+	if windowTiling && target.Open {
+		target.clampToScreen()
+		preventOverlap(target)
+	}
 }
 
 // RemoveWindow removes a window from the active list. Any cached images

--- a/settings.go
+++ b/settings.go
@@ -45,6 +45,7 @@ var gsdef settings = settings{
 	GameScale:         2,
 	Theme:             "",
 	MessagesToConsole: false,
+	WindowTiling:      true,
 	AnyGameWindowSize: false,
 
 	GameWindow:      WindowState{Open: true},
@@ -102,6 +103,7 @@ type settings struct {
 	GameScale         float64
 	Theme             string
 	MessagesToConsole bool
+	WindowTiling      bool
 
 	GameWindow      WindowState
 	InventoryWindow WindowState
@@ -167,6 +169,7 @@ func loadSettings() bool {
 }
 
 func applySettings() {
+	eui.SetWindowTiling(gs.WindowTiling)
 	if clImages != nil {
 		clImages.Denoise = gs.DenoiseImages
 		clImages.DenoiseSharpness = gs.DenoiseSharpness


### PR DESCRIPTION
## Summary
- add window tiling option to settings and expose control in eui
- ensure windows avoid overlapping when tiling is enabled
- cover tiling behavior with unit tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c03fcf83c832ab640d39dfdd57e29