### PR TITLE
Refactor console window flows and expand history buffer

### DIFF
--- a/console.go
+++ b/console.go
@@ -3,7 +3,7 @@ package main
 import "sync"
 
 const (
-	maxMessages = 5
+	maxMessages = 1000
 )
 
 var (


### PR DESCRIPTION
## Summary
- Increase console history to 1000 messages
- Split console window into scrollable messages flow and pinned input flow
- Update console rendering logic for separate message and input handling

## Testing
- `go vet ./...`
- `go test ./...` (fails: glfw: X11: The DISPLAY environment variable is missing)
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c09e97d54832a9d20bb0b0b71d400