### PR TITLE
Skip game window in pointInUI

### DIFF
--- a/input_ui.go
+++ b/input_ui.go
@@ -16,6 +16,9 @@ func pointInUI(x, y int) bool {
 	wins := eui.Windows()
 	for i := len(wins) - 1; i >= 0; i-- {
 		win := wins[i]
+		if win == gameWin {
+			continue
+		}
 		if !win.IsOpen() {
 			continue
 		}


### PR DESCRIPTION
## Summary
- ignore the main game window when checking whether a point lies inside any UI window

## Testing
- `go fmt input_ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c161c57e8832a8343aa41761994df