### PR TITLE
Remove test build constraint from glob globals

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -1,5 +1,3 @@
-//go:build !test
-
 package eui
 
 import (


### PR DESCRIPTION
## Summary
- remove `!test` build tag from `eui/glob.go` so globals like `windowTiling` are available under the `test` tag

## Testing
- `go fmt eui/glob.go`
- `go vet ./eui`
- `xvfb-run go test ./eui`


------
https://chatgpt.com/codex/tasks/task_e_689c163aa7ec832aab8970db303754b0