### PR TITLE
Add sound settings window and relocate debug options

### DIFF
--- a/game.go
+++ b/game.go
@@ -109,6 +109,7 @@ var settingsWin *eui.WindowData
 var debugWin *eui.WindowData
 var qualityWin *eui.WindowData
 var graphicsWin *eui.WindowData
+var soundWin *eui.WindowData
 var gameCtx context.Context
 var drawFilter = ebiten.FilterNearest
 var frameCounter int

--- a/ui.go
+++ b/ui.go
@@ -79,6 +79,7 @@ func initUI() {
 	makeConsoleWindow()
 	makeSettingsWindow()
 	makeGraphicsWindow()
+	makeSoundWindow()
 	makeQualityWindow()
 	makeDebugWindow()
 	makeWindowsWindow()
@@ -862,6 +863,26 @@ func makeSettingsWindow() {
 	}
 	mainFlow.AddItem(graphicsBtn)
 
+	soundBtn, soundEvents := eui.NewButton()
+	soundBtn.Text = "Sound Settings"
+	soundBtn.Size = eui.Point{X: width, Y: 24}
+	soundEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			soundWin.Toggle()
+		}
+	}
+	mainFlow.AddItem(soundBtn)
+
+	debugBtn, debugEvents := eui.NewButton()
+	debugBtn.Text = "Debug Settings"
+	debugBtn.Size = eui.Point{X: width, Y: 24}
+	debugEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			debugWin.Toggle()
+		}
+	}
+	mainFlow.AddItem(debugBtn)
+
 	settingsWin.AddItem(mainFlow)
 	settingsWin.AddWindow(false)
 }
@@ -986,18 +1007,55 @@ func makeGraphicsWindow() {
 	}
 	flow.AddItem(qualityBtn)
 
-	debugBtn, debugEvents := eui.NewButton()
-	debugBtn.Text = "Debug Settings"
-	debugBtn.Size = eui.Point{X: width, Y: 24}
-	debugEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			debugWin.Toggle()
-		}
-	}
-	flow.AddItem(debugBtn)
-
 	graphicsWin.AddItem(flow)
 	graphicsWin.AddWindow(false)
+}
+
+func makeSoundWindow() {
+	if soundWin != nil {
+		return
+	}
+	var width float32 = 250
+	soundWin = eui.NewWindow()
+	soundWin.Title = "Sound Settings"
+	soundWin.Closable = true
+	soundWin.Resizable = false
+	soundWin.AutoSize = true
+	soundWin.Movable = true
+	soundWin.SetZone(eui.HZoneCenterLeft, eui.VZoneMiddleTop)
+
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
+
+	volumeSlider, volumeEvents := eui.NewSlider()
+	volumeSlider.Label = "Volume"
+	volumeSlider.MinValue = 0
+	volumeSlider.MaxValue = 1
+	volumeSlider.Value = float32(gs.Volume)
+	volumeSlider.Size = eui.Point{X: width - 10, Y: 24}
+	volumeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.Volume = float64(ev.Value)
+			settingsDirty = true
+			updateSoundVolume()
+		}
+	}
+	flow.AddItem(volumeSlider)
+
+	muteCB, muteEvents := eui.NewCheckbox()
+	muteCB.Text = "Mute"
+	muteCB.Size = eui.Point{X: width, Y: 24}
+	muteCB.Checked = gs.Mute
+	muteEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.Mute = ev.Checked
+			settingsDirty = true
+			updateSoundVolume()
+		}
+	}
+	flow.AddItem(muteCB)
+
+	soundWin.AddItem(flow)
+	soundWin.AddWindow(false)
 }
 
 func makeQualityWindow() {


### PR DESCRIPTION
## Summary
- add dedicated sound settings window with volume and mute controls
- move debug settings button to bottom of the main settings window
- wire up initialization for the new sound settings window

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c19c402ac832ab70f8c01f13b5101