### PR TITLE
Throttle slider update events

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -98,6 +98,8 @@ type itemData struct {
 	FlowType flowType
 	Scroll   point
 
+	lastSliderEmit time.Time
+
 	// Dropdown specific
 	Options    []string
 	Selected   int


### PR DESCRIPTION
## Summary
- Throttle slider change events to five per second while dragging
- Ensure a final slider event fires when releasing the pointer
- Track last slider emission time on UI items

## Testing
- `go vet ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*
- `go test ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*
- `go build ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_689c1a356354832a872a48fd01cd3d20