### PR TITLE
Guard autosizing in Refresh to protect manual window sizes

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -166,7 +166,9 @@ func (win *windowData) dragbarRect() rect {
 
 func (win *windowData) Refresh() {
 	win.resizeFlows()
-	win.updateAutoSize()
+	if win.AutoSize {
+		win.updateAutoSize()
+	}
 	win.markDirty()
 }
 


### PR DESCRIPTION
## Summary
- Only autosize windows in `Refresh` when `AutoSize` is enabled

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_689c1a8860f8832aa927713bcb451ea6