### PR TITLE
Increase resize hitbox tolerances

### DIFF
--- a/eui/const.go
+++ b/eui/const.go
@@ -6,10 +6,10 @@ const (
 
 	// scrollTolerance defines the padding around window edges used to detect
 	// resize drags along the sides.
-	scrollTolerance = 2
+	scrollTolerance = 4
 	// cornerTolerance defines the larger area around window corners used to
 	// detect diagonal resizing.
-	cornerTolerance = 16
+	cornerTolerance = 24
 
 	// sliderMaxLabel defines the formatted text used to measure the value
 	// field of sliders. Using a constant ensures int and float sliders have


### PR DESCRIPTION
## Summary
- expand scroll resize padding to 4px
- enlarge corner resize tolerance to 24px

## Testing
- `go fmt eui/const.go`
- `go vet ./eui`
- `go test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c1ab6ce04832a9e137d68d0a0c2a0