### PR TITLE
Allow windows to move away from snapped corners

### DIFF
--- a/eui/drag_test.go
+++ b/eui/drag_test.go
@@ -22,3 +22,42 @@ func TestDragClearsZone(t *testing.T) {
 		t.Fatalf("expected position %+v, got %+v", expect, win.Position)
 	}
 }
+
+func TestDragUnsnapThreshold(t *testing.T) {
+	screenWidth = 100
+	screenHeight = 100
+	uiScale = 1
+
+	win := &windowData{Movable: true}
+	// Snap to the top-left corner
+	if !snapToCorner(win) {
+		t.Fatalf("expected window to snap")
+	}
+
+	// Drag slightly within the unsnap threshold
+	dragWindowMove(win, point{X: UnsnapThreshold - 1, Y: 0})
+	if win.zone != nil {
+		t.Fatalf("zone not cleared")
+	}
+	if !win.snapAnchorActive {
+		t.Fatalf("snap anchor deactivated too soon")
+	}
+	if !win.snapAnchorActive {
+		snapToCorner(win)
+	}
+	if win.zone != nil {
+		t.Fatalf("window resnapped prematurely")
+	}
+
+	// Move further to exceed the unsnap threshold
+	dragWindowMove(win, point{X: 2, Y: 0})
+	if win.snapAnchorActive {
+		t.Fatalf("snap anchor should deactivate after threshold")
+	}
+	if !win.snapAnchorActive {
+		snapToCorner(win)
+	}
+	if win.zone != nil {
+		t.Fatalf("window snapped after moving away")
+	}
+}

--- a/eui/input.go
+++ b/eui/input.go
@@ -208,9 +208,11 @@ func Update() error {
 				}
 				win.clampToScreen()
 				if win.zone == nil {
-					if !snapToCorner(win) {
-						if snapToWindow(win) {
-							win.clampToScreen()
+					if !win.snapAnchorActive {
+						if !snapToCorner(win) {
+							if snapToWindow(win) {
+								win.clampToScreen()
+							}
 						}
 					}
 				}
@@ -793,6 +795,13 @@ func dragWindowMove(win *windowData, delta point) {
 	}
 	if win.zone == nil {
 		win.Position = pointAdd(win.Position, delta)
+		if win.snapAnchorActive {
+			dx := float32(math.Abs(float64(win.Position.X - win.snapAnchor.X)))
+			dy := float32(math.Abs(float64(win.Position.Y - win.snapAnchor.Y)))
+			if dx > UnsnapThreshold || dy > UnsnapThreshold {
+				win.snapAnchorActive = false
+			}
+		}
 	}
 }
 

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -23,6 +23,9 @@ type windowData struct {
 
 	zone *windowZone
 
+	snapAnchor       point
+	snapAnchorActive bool
+
 	Padding   float32
 	Margin    float32
 	Border    float32

--- a/eui/zones.go
+++ b/eui/zones.go
@@ -6,6 +6,10 @@ import "math"
 // snap to a screen corner or another window.
 const CornerSnapThreshold float32 = 10
 
+// UnsnapThreshold defines how far a window must move from its snapped
+// position before corner snapping is re-enabled.
+const UnsnapThreshold float32 = 12
+
 // HZone defines the horizontal zone positions.
 type HZone int
 
@@ -178,21 +182,29 @@ func snapToCorner(win *windowData) bool {
 	// Top-left
 	if pos.X <= CornerSnapThreshold && pos.Y <= CornerSnapThreshold {
 		win.SetZone(HZoneLeft, VZoneTop)
+		win.snapAnchor = win.Position
+		win.snapAnchorActive = true
 		return true
 	}
 	// Top-right
 	if pos.X+size.X >= sw-CornerSnapThreshold && pos.Y <= CornerSnapThreshold {
 		win.SetZone(HZoneRight, VZoneTop)
+		win.snapAnchor = win.Position
+		win.snapAnchorActive = true
 		return true
 	}
 	// Bottom-left
 	if pos.X <= CornerSnapThreshold && pos.Y+size.Y >= sh-CornerSnapThreshold {
 		win.SetZone(HZoneLeft, VZoneBottom)
+		win.snapAnchor = win.Position
+		win.snapAnchorActive = true
 		return true
 	}
 	// Bottom-right
 	if pos.X+size.X >= sw-CornerSnapThreshold && pos.Y+size.Y >= sh-CornerSnapThreshold {
 		win.SetZone(HZoneRight, VZoneBottom)
+		win.snapAnchor = win.Position
+		win.snapAnchorActive = true
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- add `UnsnapThreshold` to govern when corner snapping reactivates
- track snap anchors and skip corner snapping until moved beyond the threshold
- test that windows can be dragged away after exceeding `UnsnapThreshold`

## Testing
- `go vet ./eui`
- `go test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689c1c97f914832aa6ff39924cc3f335