### PR TITLE
Allow overlapping during drags and add snapping settings

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -40,6 +40,9 @@ var (
 	// windowTiling prevents windows from overlapping when enabled.
 	windowTiling bool = true
 
+	// windowSnapping snaps windows to screen edges or other windows when enabled.
+	windowSnapping bool = true
+
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 

--- a/eui/input.go
+++ b/eui/input.go
@@ -72,6 +72,9 @@ func Update() error {
 	midPressed := ebiten.IsMouseButtonPressed(ebiten.MouseButtonMiddle)
 
 	if !pointerPressed() && !midPressed {
+		if dragPart == PART_BAR && dragWin != nil {
+			preventOverlap(dragWin)
+		}
 		dragPart = PART_NONE
 		dragWin = nil
 		activeItem = nil
@@ -204,10 +207,12 @@ func Update() error {
 					dragWindowScroll(win, mpos, false)
 				}
 				if dragPart != PART_BAR && dragPart != PART_SCROLL_V && dragPart != PART_SCROLL_H {
-					snapResize(win, dragPart)
+					if windowSnapping {
+						snapResize(win, dragPart)
+					}
 				}
 				win.clampToScreen()
-				if win.zone == nil {
+				if windowSnapping && win.zone == nil {
 					if !win.snapAnchorActive {
 						if !snapToCorner(win) {
 							if snapToWindow(win) {
@@ -216,7 +221,9 @@ func Update() error {
 						}
 					}
 				}
-				preventOverlap(win)
+				if dragPart != PART_BAR {
+					preventOverlap(win)
+				}
 				break
 			}
 		}
@@ -795,7 +802,7 @@ func dragWindowMove(win *windowData, delta point) {
 	}
 	if win.zone == nil {
 		win.Position = pointAdd(win.Position, delta)
-		if win.snapAnchorActive {
+		if windowSnapping && win.snapAnchorActive {
 			dx := float32(math.Abs(float64(win.Position.X - win.snapAnchor.X)))
 			dy := float32(math.Abs(float64(win.Position.Y - win.snapAnchor.Y)))
 			if dx > UnsnapThreshold || dy > UnsnapThreshold {

--- a/eui/public.go
+++ b/eui/public.go
@@ -15,6 +15,12 @@ func WindowTiling() bool { return windowTiling }
 // SetWindowTiling enables or disables window tiling.
 func SetWindowTiling(enabled bool) { windowTiling = enabled }
 
+// WindowSnapping reports whether window snapping is enabled.
+func WindowSnapping() bool { return windowSnapping }
+
+// SetWindowSnapping enables or disables window snapping.
+func SetWindowSnapping(enabled bool) { windowSnapping = enabled }
+
 // SetScreenSize sets the current screen size used for layout calculations.
 func SetScreenSize(w, h int) {
 	screenWidth = w

--- a/eui/tiling_test.go
+++ b/eui/tiling_test.go
@@ -43,3 +43,34 @@ func TestWindowTilingDisabledAllowsOverlap(t *testing.T) {
 		t.Fatalf("expected overlap with tiling disabled")
 	}
 }
+
+func TestWindowTilingResolvesOverlapAfterDrag(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 200
+	uiScale = 1
+	windows = nil
+	SetWindowTiling(true)
+	SetWindowSnapping(true)
+
+	win1 := &windowData{Open: true, Size: point{X: 50, Y: 50}}
+	win2 := &windowData{Open: true, Position: point{X: 100, Y: 100}, Size: point{X: 50, Y: 50}, Movable: true}
+
+	win1.AddWindow(false)
+	win2.AddWindow(false)
+
+	dragWindowMove(win2, point{X: -60, Y: -60})
+
+	r1 := win1.getWinRect()
+	r2 := win2.getWinRect()
+	inter := intersectRect(r1, r2)
+	if inter.X1 <= inter.X0 || inter.Y1 <= inter.Y0 {
+		t.Fatalf("expected overlap during drag")
+	}
+
+	preventOverlap(win2)
+	r2 = win2.getWinRect()
+	inter = intersectRect(r1, r2)
+	if inter.X1 > inter.X0 && inter.Y1 > inter.Y0 {
+		t.Fatalf("windows still overlap after preventOverlap")
+	}
+}

--- a/eui/zones.go
+++ b/eui/zones.go
@@ -173,6 +173,9 @@ func (win *windowData) PinToClosestZone() {
 // snapToCorner assigns a zone when a window is dragged close to a screen
 // corner. It returns true if a zone was applied.
 func snapToCorner(win *windowData) bool {
+	if !windowSnapping {
+		return false
+	}
 	pos := win.getPosition()
 	size := win.GetSize()
 
@@ -213,6 +216,9 @@ func snapToCorner(win *windowData) bool {
 // snapToWindow snaps a window's edges to nearby windows within the threshold.
 // It returns true if the window position was adjusted.
 func snapToWindow(win *windowData) bool {
+	if !windowSnapping {
+		return false
+	}
 	pos := win.getPosition()
 	size := win.Size
 	snapped := false
@@ -263,6 +269,9 @@ func snapToWindow(win *windowData) bool {
 // snap to nearby screen edges or other windows within the threshold.
 // It returns true if the window size or position was adjusted.
 func snapResize(win *windowData, part dragType) bool {
+	if !windowSnapping {
+		return false
+	}
 	pos := win.getPosition()
 	size := win.Size
 	snapped := false

--- a/settings.go
+++ b/settings.go
@@ -46,6 +46,7 @@ var gsdef settings = settings{
 	Theme:             "",
 	MessagesToConsole: false,
 	WindowTiling:      true,
+	WindowSnapping:    true,
 	AnyGameWindowSize: false, // allow arbitrary game window sizes
 
 	GameWindow:      WindowState{Open: true},
@@ -104,6 +105,7 @@ type settings struct {
 	Theme             string
 	MessagesToConsole bool
 	WindowTiling      bool
+	WindowSnapping    bool
 
 	GameWindow      WindowState
 	InventoryWindow WindowState
@@ -170,6 +172,7 @@ func loadSettings() bool {
 
 func applySettings() {
 	eui.SetWindowTiling(gs.WindowTiling)
+	eui.SetWindowSnapping(gs.WindowSnapping)
 	if clImages != nil {
 		clImages.Denoise = gs.DenoiseImages
 		clImages.DenoiseSharpness = gs.DenoiseSharpness

--- a/ui.go
+++ b/ui.go
@@ -748,6 +748,38 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(keySpeedSlider)
 
 	label, _ = eui.NewText()
+	label.Text = "\nWindow Behavior:"
+	label.FontSize = 15
+	label.Size = eui.Point{X: 150, Y: 50}
+	mainFlow.AddItem(label)
+
+	tilingCB, tilingEvents := eui.NewCheckbox()
+	tilingCB.Text = "Tiling window mode"
+	tilingCB.Size = eui.Point{X: width, Y: 24}
+	tilingCB.Checked = gs.WindowTiling
+	tilingEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.WindowTiling = ev.Checked
+			eui.SetWindowTiling(ev.Checked)
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(tilingCB)
+
+	snapCB, snapEvents := eui.NewCheckbox()
+	snapCB.Text = "Window snapping"
+	snapCB.Size = eui.Point{X: width, Y: 24}
+	snapCB.Checked = gs.WindowSnapping
+	snapEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.WindowSnapping = ev.Checked
+			eui.SetWindowSnapping(ev.Checked)
+			settingsDirty = true
+		}
+	}
+	mainFlow.AddItem(snapCB)
+
+	label, _ = eui.NewText()
 	label.Text = "\nText Sizes:"
 	label.FontSize = 15
 	label.Size = eui.Point{X: 100, Y: 50}


### PR DESCRIPTION
## Summary
- Let windows overlap while being dragged and resolve after release
- Add user settings and API for window snapping
- Expose toggles in Settings UI for tiling mode and snapping

## Testing
- `go vet ./...`
- `xvfb-run --auto-servernum go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c20d78164832abfbf14c6e61a9e6c