### PR TITLE
Fix corner snapping with UI scale

### DIFF
--- a/eui/zones.go
+++ b/eui/zones.go
@@ -174,10 +174,12 @@ func (win *windowData) PinToClosestZone() {
 // corner. It returns true if a zone was applied.
 func snapToCorner(win *windowData) bool {
 	pos := win.getPosition()
-	size := win.GetSize()
+	size := win.Size
 
-	sw := float32(screenWidth)
-	sh := float32(screenHeight)
+	// Convert screen dimensions to the same (unscaled) unit system as
+	// window positions and sizes.
+	sw := float32(screenWidth) / uiScale
+	sh := float32(screenHeight) / uiScale
 
 	// Top-left
 	if pos.X <= CornerSnapThreshold && pos.Y <= CornerSnapThreshold {

--- a/eui/zones_test.go
+++ b/eui/zones_test.go
@@ -64,6 +64,41 @@ func TestSnapToCorner(t *testing.T) {
 	}
 }
 
+// TestSnapToCornerScaled verifies corner snapping when a uiScale other than 1 is in use.
+func TestSnapToCornerScaled(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 200
+	uiScale = 2
+
+	winSize := point{X: 10, Y: 10}
+	offset := CornerSnapThreshold - 1
+
+	sw := float32(screenWidth) / uiScale
+	sh := float32(screenHeight) / uiScale
+
+	tests := []struct {
+		pos point
+		h   HZone
+		v   VZone
+	}{
+		{point{offset, offset}, HZoneLeft, VZoneTop},
+		{point{sw - winSize.X - offset, offset}, HZoneRight, VZoneTop},
+		{point{offset, sh - winSize.Y - offset}, HZoneLeft, VZoneBottom},
+		{point{sw - winSize.X - offset, sh - winSize.Y - offset}, HZoneRight, VZoneBottom},
+	}
+
+	for _, tt := range tests {
+		win := &windowData{Position: tt.pos, Size: winSize}
+		snapToCorner(win)
+		if win.zone == nil {
+			t.Fatalf("zone not set for pos %+v", tt.pos)
+		}
+		if win.zone.h != tt.h || win.zone.v != tt.v {
+			t.Fatalf("pos %+v snapped to (%v,%v); want (%v,%v)", tt.pos, win.zone.h, win.zone.v, tt.h, tt.v)
+		}
+	}
+}
+
 func TestSnapToWindow(t *testing.T) {
 	screenWidth = 200
 	screenHeight = 200


### PR DESCRIPTION
## Summary
- fix snapToCorner to compare window and screen coordinates in the same unit system
- add regression test verifying corner snapping when uiScale != 1

## Testing
- `go vet ./...`
- `xvfb-run -a go test ./eui`


------
https://chatgpt.com/codex/tasks/task_e_689c20e2ff70832a880234ad237daa59