### PR TITLE
Prevent endless overlap loop in window tiling

### DIFF
--- a/eui/zones.go
+++ b/eui/zones.go
@@ -379,7 +379,13 @@ func preventOverlap(win *windowData) {
 	if !windowTiling {
 		return
 	}
-	for {
+	const maxIterations = 100
+	visited := map[point]bool{}
+	for i := 0; i < maxIterations; i++ {
+		if visited[win.Position] {
+			break
+		}
+		visited[win.Position] = true
 		winRect := win.getWinRect()
 		moved := false
 		for _, other := range windows {


### PR DESCRIPTION
## Summary
- guard preventOverlap with iteration limit and visited position detection
- add regression test for overlapping window between two others

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c20e9152c832a8e17a50367a7b2d1