### PR TITLE
Remove fixed console item sizes for auto-width

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -26,7 +26,7 @@ func updateConsoleWindow() {
 			t, _ := eui.NewText()
 			t.Text = msg
 			t.FontSize = float32(gs.ConsoleFontSize)
-			t.Size = eui.Point{X: 500, Y: 24}
+			t.AutoSize = true
 			messagesFlow.AddItem(t)
 			changed = true
 		}
@@ -47,7 +47,7 @@ func updateConsoleWindow() {
 		t, _ := eui.NewText()
 		t.Text = inputMsg
 		t.FontSize = float32(gs.ConsoleFontSize)
-		t.Size = eui.Point{X: 500, Y: 24}
+		t.AutoSize = true
 		inputFlow.AddItem(t)
 		changed = true
 	} else {


### PR DESCRIPTION
## Summary
- Drop hardcoded size on console message and input lines so items auto-size to window width
- Enable auto-sizing on new text items for message flow and input bar

## Testing
- `go vet ./...` *(fails: command hung)*
- `go build ./...` *(fails: missing/misaligned dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689c2a93f2c8832aa9c659507cb3102e