### PR TITLE
Enable auto-sizing for chat messages

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -8,7 +8,6 @@ import (
 
 var chatWin *eui.WindowData
 var chatList *eui.ItemData
-var chatDirty bool
 
 func updateChatWindow() {
 	if chatList == nil {
@@ -31,7 +30,7 @@ func updateChatWindow() {
 			}
 			t.Text = msg
 			t.FontSize = float32(gs.ChatFontSize)
-			t.Size = eui.Point{X: 256, Y: 24}
+			t.AutoSize = true
 			chatList.AddItem(t)
 			changed = true
 		}
@@ -43,8 +42,8 @@ func updateChatWindow() {
 		chatList.Contents = chatList.Contents[:len(msgs)]
 		changed = true
 	}
-	if changed {
-		chatDirty = true
+	if changed && chatWin != nil {
+		chatWin.Refresh()
 	}
 }
 

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -111,7 +111,7 @@ type itemData struct {
 	OnSelect func(int)
 	OnHover  func(int)
 
-	Fixed, Scrollable bool
+	Fixed, Scrollable, AutoSize bool
 
 	ImageName string
 	Image     *ebiten.Image

--- a/eui/util.go
+++ b/eui/util.go
@@ -805,6 +805,9 @@ func (item *itemData) resizeFlow(parentSize point) {
 		item.Size = point{X: size.X / uiScale, Y: size.Y / uiScale}
 		available = item.GetSize()
 	} else {
+		if item.AutoSize {
+			item.Size = point{X: available.X / uiScale, Y: item.Size.Y}
+		}
 		available = item.GetSize()
 	}
 


### PR DESCRIPTION
## Summary
- allow chat message text elements to auto-size
- recalc chat list layout after updates
- add AutoSize support for UI items

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c2a950a34832aa116b461c78af1cd