### PR TITLE
Improve AccentLight slider visibility

### DIFF
--- a/eui/themes/palettes/AccentLight.json
+++ b/eui/themes/palettes/AccentLight.json
@@ -1,7 +1,7 @@
 {
   "Comment": "Colors use #RRGGBBAA or h,s,v",
   "Colors": {
-    "background": "0,0,1",
+    "background": "0,0,0.9",
     "panel": "0,0,0.9",
     "text": "0,0,0",
     "outline": "210.0,0.15,0.8",
@@ -76,6 +76,7 @@
     "ClickColor": "hover",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
+    "SliderFilled": "0,0,0.95",
     "SelectedColor": "disabled"
   },
   "Dropdown": {


### PR DESCRIPTION
## Summary
- dim window background to 90% in AccentLight palette
- set a dedicated filled-track color for sliders so the left side is visible

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: Xrandr.h, alsa, gtk+-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c2eb9e560832aa4e822b36ce1f6c5