### PR TITLE
Use Clan Lord window metrics for arbitrary window sizing

### DIFF
--- a/game.go
+++ b/game.go
@@ -613,14 +613,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		drawStatusBars(offscreen, 0, 0, snap, alpha)
 		gs.GameScale = saved
 		initFont()
-		sw := screen.Bounds().Dx()
-		sh := screen.Bounds().Dy()
-		scale := math.Min(float64(sw)/float64(gameAreaSizeX*2), float64(sh)/float64(gameAreaSizeY*2))
+		ox, oy := gameContentOrigin()
+		size := gameWin.GetSize()
+		scale := math.Min(float64(size.X)/(gameAreaSizeX*2), float64(size.Y)/(gameAreaSizeY*2))
 		op := &ebiten.DrawImageOptions{Filter: ebiten.FilterLinear}
 		op.GeoM.Scale(scale, scale)
-		tx := (float64(sw) - float64(gameAreaSizeX*2)*scale) / 2
-		ty := (float64(sh) - float64(gameAreaSizeY*2)*scale) / 2
-		op.GeoM.Translate(tx, ty)
+		op.GeoM.Translate(float64(ox), float64(oy))
 		screen.DrawImage(offscreen, op)
 		eui.Draw(screen)
 		if gs.ShowFPS {


### PR DESCRIPTION
## Summary
- Use game window origin and size to scale and position the offscreen buffer when `AnyGameWindowSize` is enabled

## Testing
- `gofmt -w game.go`
- `go vet ./...`
- `go test ./...` *(fails: X11 DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c2f049550832a8f11b865de9a534d