### PR TITLE
Rename caching option and add unmanaged potato mode

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -14,7 +14,7 @@ import (
 var whiteImage *ebiten.Image
 
 func init() {
-	whiteImage = ebiten.NewImage(1, 1)
+	whiteImage = newImage(1, 1)
 	whiteImage.Fill(color.White)
 }
 

--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"container/list"
 	"runtime"
 	"time"
 
@@ -21,6 +22,11 @@ func clearCaches() {
 	pixelCountCache = make(map[uint16]int)
 	pixelCountMu.Unlock()
 
+	pixelDataMu.Lock()
+	pixelDataCache = make(map[uint16]*list.Element)
+	pixelDataList.Init()
+	pixelDataMu.Unlock()
+
 	soundMu.Lock()
 	pcmCache = make(map[uint16][]byte)
 	soundMu.Unlock()
@@ -36,6 +42,9 @@ func clearCaches() {
 var assetsPrecached = false
 
 func precacheAssets() {
+	if gs.NoCaching {
+		return
+	}
 
 	for {
 		if (gs.precacheImages && clImages == nil) || (gs.precacheSounds && clSounds == nil) {

--- a/climg/climg.go
+++ b/climg/climg.go
@@ -514,7 +514,7 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 		denoiseImage(img, c.DenoiseSharpness, c.DenoisePercent)
 	}
 
-	eimg := ebiten.NewImageFromImage(img)
+	eimg := newImageFromImage(img)
 	c.mu.Lock()
 	c.cache[key] = eimg
 	c.mu.Unlock()

--- a/climg/potato.go
+++ b/climg/potato.go
@@ -1,0 +1,21 @@
+package climg
+
+import (
+	"image"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+var potatoMode bool
+
+// SetPotatoMode toggles creation of unmanaged ebiten images.
+func SetPotatoMode(v bool) {
+	potatoMode = v
+}
+
+func newImageFromImage(src image.Image) *ebiten.Image {
+	if potatoMode {
+		return ebiten.NewImageFromImageWithOptions(src, &ebiten.NewImageFromImageOptions{Unmanaged: true})
+	}
+	return ebiten.NewImageFromImage(src)
+}

--- a/eui/color_wheel.go
+++ b/eui/color_wheel.go
@@ -12,9 +12,9 @@ import (
 // color on the outer edge.
 func colorWheelImage(size int) *ebiten.Image {
 	if size <= 0 {
-		return ebiten.NewImage(1, 1)
+		return newImage(1, 1)
 	}
-	img := ebiten.NewImage(size, size)
+	img := newImage(size, size)
 	r := float64(size) / 2
 	// Use a 4x4 grid of subpixel samples for smoother edges
 	offsets := []float64{0.125, 0.375, 0.625, 0.875}

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -43,7 +43,7 @@ var (
 	// windowSnapping snaps windows to screen edges or other windows when enabled.
 	windowSnapping bool = true
 
-	whiteImage    = ebiten.NewImage(3, 3)
+	whiteImage    = newImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 
 	// AutoHiDPI enables automatic scaling when the device scale factor

--- a/eui/potato.go
+++ b/eui/potato.go
@@ -1,0 +1,28 @@
+package eui
+
+import (
+	"image"
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+var potatoMode bool
+
+// SetPotatoMode toggles creation of unmanaged ebiten images.
+func SetPotatoMode(v bool) {
+	if potatoMode == v {
+		return
+	}
+	potatoMode = v
+	whiteImage = newImage(3, 3)
+	whiteImage.Fill(color.White)
+	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
+}
+
+func newImage(w, h int) *ebiten.Image {
+	if potatoMode {
+		return ebiten.NewImageWithOptions(image.Rect(0, 0, w, h), &ebiten.NewImageOptions{Unmanaged: true})
+	}
+	return ebiten.NewImage(w, h)
+}

--- a/eui/render.go
+++ b/eui/render.go
@@ -107,7 +107,7 @@ func (win *windowData) Draw(screen *ebiten.Image, dropdowns *[]openDropdown) {
 			if size.X < 1 || size.Y < 1 {
 				return
 			}
-			win.Render = ebiten.NewImage(int(size.X), int(size.Y))
+			win.Render = newImage(int(size.X), int(size.Y))
 		} else {
 			win.Render.Clear()
 		}

--- a/eui/window.go
+++ b/eui/window.go
@@ -192,7 +192,7 @@ func NewImageItem(w, h int) (*itemData, *ebiten.Image) {
 		Size:     point{X: float32(w), Y: float32(h)},
 		Theme:    currentTheme,
 	}
-	newItem.Image = ebiten.NewImage(w, h)
+	newItem.Image = newImage(w, h)
 	return &newItem, newItem.Image
 }
 

--- a/game.go
+++ b/game.go
@@ -590,7 +590,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	if gs.AnyGameWindowSize {
 		updateGameScale()
 		if offscreen == nil {
-			offscreen = ebiten.NewImage(gameAreaSizeX*2, gameAreaSizeY*2)
+			offscreen = newImage(gameAreaSizeX*2, gameAreaSizeY*2)
 		}
 		offscreen.Clear()
 		saved := gs.GameScale
@@ -1130,7 +1130,7 @@ func drawGameCurtain(screen *ebiten.Image, ox, oy int) {
 	sh := screen.Bounds().Dy()
 
 	if blackPixel == nil {
-		blackPixel = ebiten.NewImage(1, 1)
+		blackPixel = newImage(1, 1)
 		blackPixel.Fill(color.Black)
 	}
 

--- a/imageutil.go
+++ b/imageutil.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"image"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func newImage(w, h int) *ebiten.Image {
+	if gs.PotatoComputer {
+		return ebiten.NewImageWithOptions(image.Rect(0, 0, w, h), &ebiten.NewImageOptions{Unmanaged: true})
+	}
+	return ebiten.NewImage(w, h)
+}
+
+func newImageFromImage(src image.Image) *ebiten.Image {
+	if gs.PotatoComputer {
+		return ebiten.NewImageFromImageWithOptions(src, &ebiten.NewImageFromImageOptions{Unmanaged: true})
+	}
+	return ebiten.NewImageFromImage(src)
+}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		return
 	}
 
-	if gs.precacheSounds || gs.precacheImages {
+	if (gs.precacheSounds || gs.precacheImages) && !gs.NoCaching {
 		go precacheAssets()
 	}
 

--- a/night.go
+++ b/night.go
@@ -169,7 +169,7 @@ func init() {
 		b := img.Bounds()
 		withBorder := image.NewRGBA(image.Rect(0, 0, b.Dx()+2, b.Dy()+2))
 		draw.Draw(withBorder, image.Rect(1, 1, b.Dx()+1, b.Dy()+1), img, b.Min, draw.Src)
-		nightImg = ebiten.NewImageFromImage(withBorder)
+		nightImg = newImageFromImage(withBorder)
 	}
 }
 

--- a/splash.go
+++ b/splash.go
@@ -26,7 +26,7 @@ func init() {
 	b := img.Bounds()
 	withBorder := image.NewRGBA(image.Rect(0, 0, b.Dx()+2, b.Dy()+2))
 	draw.Draw(withBorder, image.Rect(1, 1, b.Dx()+1, b.Dy()+1), img, b.Min, draw.Src)
-	splashImg = ebiten.NewImageFromImage(withBorder)
+	splashImg = newImageFromImage(withBorder)
 }
 
 func drawSplash(screen *ebiten.Image, ox, oy int) {

--- a/ui.go
+++ b/ui.go
@@ -61,6 +61,8 @@ var (
 	pictBlendCB     *eui.ItemData
 	precacheSoundCB *eui.ItemData
 	precacheImageCB *eui.ItemData
+	noCacheCB       *eui.ItemData
+	potatoCB        *eui.ItemData
 	filtCB          *eui.ItemData
 )
 
@@ -1021,7 +1023,7 @@ func makeGraphicsWindow() {
 	flow.AddItem(fullscreenCB)
 
 	qualityPresetDD, qpEvents := eui.NewDropdown()
-	qualityPresetDD.Options = []string{"Low", "Standard", "High", "Ultimate", "Custom"}
+	qualityPresetDD.Options = []string{"Ultra Low", "Low", "Standard", "High", "Ultimate", "Custom"}
 	qualityPresetDD.Size = eui.Point{X: width, Y: 24}
 	qualityPresetDD.Selected = detectQualityPreset()
 	qualityPresetDD.Label = "Presets"
@@ -1030,12 +1032,14 @@ func makeGraphicsWindow() {
 		if ev.Type == eui.EventDropdownSelected {
 			switch ev.Index {
 			case 0:
-				applyQualityPreset("Low")
+				applyQualityPreset("Ultra Low")
 			case 1:
-				applyQualityPreset("Standard")
+				applyQualityPreset("Low")
 			case 2:
-				applyQualityPreset("High")
+				applyQualityPreset("Standard")
 			case 3:
+				applyQualityPreset("High")
+			case 4:
 				applyQualityPreset("Ultimate")
 			}
 			qualityPresetDD.Selected = detectQualityPreset()
@@ -1288,6 +1292,7 @@ func makeQualityWindow() {
 	precacheSoundCB.Text = "Precache Sounds"
 	precacheSoundCB.Size = eui.Point{X: width, Y: 24}
 	precacheSoundCB.Checked = gs.precacheSounds
+	precacheSoundCB.Disabled = gs.NoCaching
 	precacheSoundEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.precacheSounds = ev.Checked
@@ -1301,6 +1306,7 @@ func makeQualityWindow() {
 	precacheImageCB.Text = "Precache Images"
 	precacheImageCB.Size = eui.Point{X: width, Y: 24}
 	precacheImageCB.Checked = gs.precacheImages
+	precacheImageCB.Disabled = gs.NoCaching
 	precacheImageEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.precacheImages = ev.Checked
@@ -1308,6 +1314,48 @@ func makeQualityWindow() {
 		}
 	}
 	flow.AddItem(precacheImageCB)
+
+	ncCB, noCacheEvents := eui.NewCheckbox()
+	noCacheCB = ncCB
+	noCacheCB.Text = "No caching (low ram)"
+	noCacheCB.Size = eui.Point{X: width, Y: 24}
+	noCacheCB.Checked = gs.NoCaching
+	noCacheEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.NoCaching = ev.Checked
+			precacheSoundCB.Disabled = ev.Checked
+			precacheImageCB.Disabled = ev.Checked
+			if ev.Checked {
+				gs.precacheSounds = false
+				gs.precacheImages = false
+				precacheSoundCB.Checked = false
+				precacheImageCB.Checked = false
+			}
+			clearCaches()
+			settingsDirty = true
+			if qualityPresetDD != nil {
+				qualityPresetDD.Selected = detectQualityPreset()
+			}
+		}
+	}
+	flow.AddItem(noCacheCB)
+
+	pcCB, potatoEvents := eui.NewCheckbox()
+	potatoCB = pcCB
+	potatoCB.Text = "Potato Computer"
+	potatoCB.Size = eui.Point{X: width, Y: 24}
+	potatoCB.Checked = gs.PotatoComputer
+	potatoEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.PotatoComputer = ev.Checked
+			applySettings()
+			settingsDirty = true
+			if qualityPresetDD != nil {
+				qualityPresetDD.Selected = detectQualityPreset()
+			}
+		}
+	}
+	flow.AddItem(potatoCB)
 
 	fCB, filtEvents := eui.NewCheckbox()
 	filtCB = fCB


### PR DESCRIPTION
## Summary
- rename caching toggle to "No caching (low ram)" and make it independent of presets
- add new "Potato Computer" option that creates unmanaged Ebiten images
- route image creation through helpers so potato mode applies across packages

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; missing alsa and gtk+-3.0 packages)*
- `go build ./...` *(fails: missing gtk+-3.0, alsa, and Xrandr development libraries)*
- `go test ./...` *(fails: missing gtk+-3.0, alsa, and Xrandr development libraries)*

------
https://chatgpt.com/codex/tasks/task_e_689c29eeda00832a8f6e083cdec3caec