### PR TITLE
Enforce minimum window size of 64x64

### DIFF
--- a/eui/const.go
+++ b/eui/const.go
@@ -20,4 +20,7 @@ const (
 	// at the top and bottom of the screen when positioning dropdown menus
 	// to leave room for overlay controls.
 	dropdownOverlayReserve = 1
+
+	// MinWindowSize defines the minimum width and height for any window.
+	MinWindowSize = 64
 )

--- a/eui/util.go
+++ b/eui/util.go
@@ -257,6 +257,12 @@ func (win *windowData) setSize(size point) bool {
 	if size.X < 1 || size.Y < 1 {
 		return false
 	}
+	if size.X < MinWindowSize {
+		size.X = MinWindowSize
+	}
+	if size.Y < MinWindowSize {
+		size.Y = MinWindowSize
+	}
 
 	old := win.Size
 	win.Size = size

--- a/settings.go
+++ b/settings.go
@@ -268,7 +268,7 @@ func clampWindowSettings() {
 }
 
 func clampWindowState(st *WindowState, sx, sy float64) {
-	if st.Size.X < 100 || st.Size.Y < 100 {
+	if st.Size.X < eui.MinWindowSize || st.Size.Y < eui.MinWindowSize {
 		st.Position = WindowPoint{}
 		st.Size = WindowPoint{}
 		return


### PR DESCRIPTION
## Summary
- Define a MinWindowSize constant and expose it via the eui package
- Clamp window resizing to maintain at least 64x64 dimensions
- Validate persisted window sizes against the new minimum

## Testing
- `go fmt ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c334834d4832ab8a3c89417e80dae