### PR TITLE
Trigger asset precache on selection

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1338,6 +1338,9 @@ func makeQualityWindow() {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.precacheSounds = ev.Checked
 			settingsDirty = true
+			if ev.Checked && !gs.NoCaching {
+				go precacheAssets()
+			}
 		}
 	}
 	flow.AddItem(precacheSoundCB)
@@ -1353,6 +1356,9 @@ func makeQualityWindow() {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.precacheImages = ev.Checked
 			settingsDirty = true
+			if ev.Checked && !gs.NoCaching {
+				go precacheAssets()
+			}
 		}
 	}
 	flow.AddItem(precacheImageCB)


### PR DESCRIPTION
## Summary
- Start precaching when "Precache Sounds" or "Precache Images" is toggled

## Testing
- `go vet ./...` *(fails: X11, ALSA and GTK development headers missing)*
- `go build ./...` *(fails: X11, ALSA and GTK development headers missing)*
- `go test ./...` *(fails: X11, ALSA and GTK development headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c37d2d298832a9cf384a6225220fd