### PR TITLE
Clear caches when performance modes enabled

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1372,8 +1372,8 @@ func makeQualityWindow() {
 				gs.precacheImages = false
 				precacheSoundCB.Checked = false
 				precacheImageCB.Checked = false
+				clearCaches()
 			}
-			clearCaches()
 			settingsDirty = true
 			if qualityPresetDD != nil {
 				qualityPresetDD.Selected = detectQualityPreset()
@@ -1391,6 +1391,9 @@ func makeQualityWindow() {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.PotatoComputer = ev.Checked
 			applySettings()
+			if ev.Checked {
+				clearCaches()
+			}
 			settingsDirty = true
 			if qualityPresetDD != nil {
 				qualityPresetDD.Selected = detectQualityPreset()


### PR DESCRIPTION
## Summary
- clear caches when "No caching" option is enabled
- clear caches when "Potato Computer" mode is enabled

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package alsa not found; Package gtk+-3.0 not found)*
- `go build ./...` *(fails: Package alsa not found; Package gtk+-3.0 not found; X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package alsa not found; Package gtk+-3.0 not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c37bae7fc832aa41157ebc000927f