### PR TITLE
Remove image filtering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ The Go client accepts the following flags:
 - `-interp` – enable movement interpolation
 - `-onion` – cross-fade sprite animations
 - `-noFastAnimation` – draw a mobile's previous animation frame when available
-- `-linear` – use linear filtering instead of nearest-neighbor rendering
 - `-night` – force night level (0-100)
 
 ## Data and Logging

--- a/game.go
+++ b/game.go
@@ -112,7 +112,6 @@ var qualityWin *eui.WindowData
 var graphicsWin *eui.WindowData
 var soundWin *eui.WindowData
 var gameCtx context.Context
-var drawFilter = ebiten.FilterNearest
 var frameCounter int
 var gameStarted = make(chan struct{})
 
@@ -882,8 +881,7 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 		if x+half <= ox || y+half <= oy || x-half >= ox+viewW || y-half >= oy+viewH {
 			return
 		}
-		op := &ebiten.DrawImageOptions{}
-		op.Filter = drawFilter
+		op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest}
 		op.GeoM.Scale(scale, scale)
 		tx := math.Round(float64(x) - scaled/2)
 		ty := math.Round(float64(y) - scaled/2)
@@ -1046,10 +1044,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		if src != nil {
 			drawW, drawH = src.Bounds().Dx(), src.Bounds().Dy()
 		}
-		sx, sy := gs.GameScale, gs.GameScale
-		if !gs.textureFiltering {
-			sx, sy = scaleForFiltering(gs.GameScale, drawW, drawH)
-		}
+		sx, sy := scaleForFiltering(gs.GameScale, drawW, drawH)
 		scaledW := math.Round(float64(drawW) * sx)
 		scaledH := math.Round(float64(drawH) * sy)
 		sx = scaledW / float64(drawW)
@@ -1059,8 +1054,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		if x+halfW <= left || y+halfH <= top || x-halfW >= right || y-halfH >= bottom {
 			return
 		}
-		op := &ebiten.DrawImageOptions{}
-		op.Filter = drawFilter
+		op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest}
 		op.GeoM.Scale(sx, sy)
 		tx := math.Round(float64(x) - float64(drawW)*sx/2)
 		ty := math.Round(float64(y) - float64(drawH)*sy/2)

--- a/settings.go
+++ b/settings.go
@@ -64,7 +64,6 @@ var gsdef settings = settings{
 	nightEffect:      true,
 	precacheSounds:   false,
 	precacheImages:   false,
-	textureFiltering: false,
 	lateInputUpdates: false,
 	cacheWholeSheet:  true,
 	smoothMoving:     true,
@@ -124,7 +123,6 @@ type settings struct {
 	nightEffect      bool
 	precacheSounds   bool
 	precacheImages   bool
-	textureFiltering bool
 	lateInputUpdates bool
 	cacheWholeSheet  bool
 	smoothMoving     bool
@@ -184,11 +182,6 @@ func applySettings() {
 		clImages.Denoise = gs.DenoiseImages
 		clImages.DenoiseSharpness = gs.DenoiseSharpness
 		clImages.DenoisePercent = gs.DenoisePercent
-	}
-	if gs.textureFiltering {
-		drawFilter = ebiten.FilterLinear
-	} else {
-		drawFilter = ebiten.FilterNearest
 	}
 	ebiten.SetVsyncEnabled(gs.vsync)
 	ebiten.SetFullscreen(gs.Fullscreen)

--- a/ui.go
+++ b/ui.go
@@ -63,7 +63,6 @@ var (
 	precacheImageCB *eui.ItemData
 	noCacheCB       *eui.ItemData
 	potatoCB        *eui.ItemData
-	filtCB          *eui.ItemData
 )
 
 func initUI() {
@@ -1398,25 +1397,6 @@ func makeQualityWindow() {
 		}
 	}
 	flow.AddItem(potatoCB)
-
-	fCB, filtEvents := eui.NewCheckbox()
-	filtCB = fCB
-	filtCB.Text = "Image Filtering"
-	filtCB.Size = eui.Point{X: width, Y: 24}
-	filtCB.Checked = gs.textureFiltering
-	filtCB.Tooltip = "Use linear texture filtering"
-	filtEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			gs.textureFiltering = ev.Checked
-			if gs.textureFiltering {
-				drawFilter = ebiten.FilterLinear
-			} else {
-				drawFilter = ebiten.FilterNearest
-			}
-			settingsDirty = true
-		}
-	}
-	flow.AddItem(filtCB)
 
 	vsyncCB, vsyncEvents := eui.NewCheckbox()
 	vsyncCB.Text = "Vsync"


### PR DESCRIPTION
## Summary
- remove runtime image filtering setting and associated draw filter toggles
- delete unused texture filtering flag and UI checkbox
- drop `-linear` command-line mention

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689c380338c4832abe2229f05126d708