### PR TITLE
Fix console flow sizing

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -41,6 +41,9 @@ func updateConsoleWindow() {
 	}
 
 	inputFlow.Size.Y = float32(gs.ConsoleFontSize) + 8
+	if consoleWin != nil {
+		messagesFlow.Size.Y = consoleWin.GetSize().Y - inputFlow.Size.Y
+	}
 	inputMsg := "[Command Input Bar] (Press enter to switch to command mode)"
 	if inputActive {
 		inputMsg = string(inputText)
@@ -79,10 +82,11 @@ func makeConsoleWindow() {
 	consoleWin.Movable = true
 	consoleWin.SetZone(eui.HZoneLeft, eui.VZoneBottom)
 
-	consoleFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true}
+	consoleFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	consoleFlow.Size = consoleWin.GetSize()
 	consoleWin.AddItem(consoleFlow)
 
-	messagesFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true}
+	messagesFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
 	consoleFlow.AddItem(messagesFlow)
 
 	inputFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}


### PR DESCRIPTION
## Summary
- make consoleFlow fixed to window size
- keep messagesFlow scrollable and size it to window height minus input bar
- ensure inputFlow remains fixed at the bottom

## Testing
- `go fmt console_ui.go`
- `go vet .`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689c38633d10832aaa2ca0c1aeabe2e7