### PR TITLE
Replace sound settings button with quality options

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -80,7 +80,6 @@ func initUI() {
 	makeConsoleWindow()
 	makeSettingsWindow()
 	makeGraphicsWindow()
-	makeSoundWindow()
 	makeQualityWindow()
 	makeDebugWindow()
 	makeWindowsWindow()
@@ -914,16 +913,16 @@ func makeSettingsWindow() {
 	}
 	mainFlow.AddItem(graphicsBtn)
 
-	soundBtn, soundEvents := eui.NewButton()
-	soundBtn.Text = "Sound Settings"
-	soundBtn.Size = eui.Point{X: width, Y: 24}
-	soundBtn.Tooltip = "Open sound settings"
-	soundEvents.Handle = func(ev eui.UIEvent) {
+	qualityBtn, qualityEvents := eui.NewButton()
+	qualityBtn.Text = "Quality Options"
+	qualityBtn.Size = eui.Point{X: width, Y: 24}
+	qualityBtn.Tooltip = "Show detailed quality settings"
+	qualityEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-			soundWin.Toggle()
+			qualityWin.Toggle()
 		}
 	}
-	mainFlow.AddItem(soundBtn)
+	mainFlow.AddItem(qualityBtn)
 
 	debugBtn, debugEvents := eui.NewButton()
 	debugBtn.Text = "Debug Settings"
@@ -1072,17 +1071,6 @@ func makeGraphicsWindow() {
 		}
 	}
 	flow.AddItem(qualityPresetDD)
-
-	qualityBtn, qualityEvents := eui.NewButton()
-	qualityBtn.Text = "Quality Options"
-	qualityBtn.Size = eui.Point{X: width, Y: 24}
-	qualityBtn.Tooltip = "Show detailed quality settings"
-	qualityEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			qualityWin.Toggle()
-		}
-	}
-	flow.AddItem(qualityBtn)
 
 	graphicsWin.AddItem(flow)
 	graphicsWin.AddWindow(false)


### PR DESCRIPTION
## Summary
- replace sound settings button in the settings window with quality options access
- drop unused quality button from graphics settings and stop creating sound settings window on init

## Testing
- `go vet ./...`
- `xvfb-run go test ./...` *(fails: TestSnapResizeToWindow, TestSnapResizeToScreenScaled)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c38b87d3c832a911af4b814f4a6f3