### PR TITLE
Streamline settings UI labels

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -707,7 +707,6 @@ func makeSettingsWindow() {
 		}
 	}
 	themeDD.Size = eui.Point{X: width, Y: 24}
-	themeDD.Tooltip = "Select interface theme"
 	themeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventDropdownSelected {
 			name := themeDD.Options[ev.Index]
@@ -730,7 +729,6 @@ func makeSettingsWindow() {
 	toggle.Text = "Click-to-toggle movement"
 	toggle.Size = eui.Point{X: width, Y: 24}
 	toggle.Checked = gs.ClickToToggle
-	toggle.Tooltip = "Click once to keep walking"
 	toggleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.ClickToToggle = ev.Checked
@@ -748,7 +746,6 @@ func makeSettingsWindow() {
 	keySpeedSlider.MaxValue = 1.0
 	keySpeedSlider.Value = float32(gs.KBWalkSpeed)
 	keySpeedSlider.Size = eui.Point{X: width - 10, Y: 24}
-	keySpeedSlider.Tooltip = "Adjust keyboard walking speed"
 	keySpeedEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.KBWalkSpeed = float64(ev.Value)
@@ -798,12 +795,11 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(label)
 
 	chatFontSlider, chatFontEvents := eui.NewSlider()
-	chatFontSlider.Label = "Chat"
+	chatFontSlider.Label = "Chat Font"
 	chatFontSlider.MinValue = 6
 	chatFontSlider.MaxValue = 24
 	chatFontSlider.Value = float32(gs.BubbleFontSize)
 	chatFontSlider.Size = eui.Point{X: width - 10, Y: 24}
-	chatFontSlider.Tooltip = "Chat bubble text size"
 	chatFontEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.BubbleFontSize = float64(ev.Value)
@@ -814,12 +810,11 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(chatFontSlider)
 
 	labelFontSlider, labelFontEvents := eui.NewSlider()
-	labelFontSlider.Label = "Labels"
+	labelFontSlider.Label = "Label Font"
 	labelFontSlider.MinValue = 6
 	labelFontSlider.MaxValue = 24
 	labelFontSlider.Value = float32(gs.MainFontSize)
 	labelFontSlider.Size = eui.Point{X: width - 10, Y: 24}
-	labelFontSlider.Tooltip = "UI label text size"
 	labelFontEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.MainFontSize = float64(ev.Value)
@@ -830,12 +825,11 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(labelFontSlider)
 
 	consoleFontSlider, consoleFontEvents := eui.NewSlider()
-	consoleFontSlider.Label = "Console"
+	consoleFontSlider.Label = "Console Font"
 	consoleFontSlider.MinValue = 6
 	consoleFontSlider.MaxValue = 24
 	consoleFontSlider.Value = float32(gs.ConsoleFontSize)
 	consoleFontSlider.Size = eui.Point{X: width - 10, Y: 24}
-	consoleFontSlider.Tooltip = "Console text size"
 	consoleFontEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.ConsoleFontSize = float64(ev.Value)
@@ -849,12 +843,11 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(consoleFontSlider)
 
 	chatWindowFontSlider, chatWindowFontEvents := eui.NewSlider()
-	chatWindowFontSlider.Label = "Chat Window"
+	chatWindowFontSlider.Label = "Chat Window Font"
 	chatWindowFontSlider.MinValue = 6
 	chatWindowFontSlider.MaxValue = 24
 	chatWindowFontSlider.Value = float32(gs.ChatFontSize)
 	chatWindowFontSlider.Size = eui.Point{X: width - 10, Y: 24}
-	chatWindowFontSlider.Tooltip = "Chat window text size"
 	chatWindowFontEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.ChatFontSize = float64(ev.Value)
@@ -874,12 +867,11 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(label)
 
 	bubbleOpSlider, bubbleOpEvents := eui.NewSlider()
-	bubbleOpSlider.Label = "Message Bubble"
+	bubbleOpSlider.Label = "Bubble Opacity"
 	bubbleOpSlider.MinValue = 0
 	bubbleOpSlider.MaxValue = 1
 	bubbleOpSlider.Value = float32(gs.BubbleOpacity)
 	bubbleOpSlider.Size = eui.Point{X: width - 10, Y: 24}
-	bubbleOpSlider.Tooltip = "Opacity of chat bubbles"
 	bubbleOpEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.BubbleOpacity = float64(ev.Value)
@@ -889,12 +881,11 @@ func makeSettingsWindow() {
 	mainFlow.AddItem(bubbleOpSlider)
 
 	nameBgSlider, nameBgEvents := eui.NewSlider()
-	nameBgSlider.Label = "Name Background"
+	nameBgSlider.Label = "Name Background Opacity"
 	nameBgSlider.MinValue = 0
 	nameBgSlider.MaxValue = 1
 	nameBgSlider.Value = float32(gs.NameBgOpacity)
 	nameBgSlider.Size = eui.Point{X: width - 10, Y: 24}
-	nameBgSlider.Tooltip = "Opacity of name backgrounds"
 	nameBgEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.NameBgOpacity = float64(ev.Value)
@@ -906,7 +897,6 @@ func makeSettingsWindow() {
 	graphicsBtn, graphicsEvents := eui.NewButton()
 	graphicsBtn.Text = "Graphics Settings"
 	graphicsBtn.Size = eui.Point{X: width, Y: 24}
-	graphicsBtn.Tooltip = "Open graphics settings"
 	graphicsEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			graphicsWin.Toggle()
@@ -917,7 +907,6 @@ func makeSettingsWindow() {
 	soundBtn, soundEvents := eui.NewButton()
 	soundBtn.Text = "Sound Settings"
 	soundBtn.Size = eui.Point{X: width, Y: 24}
-	soundBtn.Tooltip = "Open sound settings"
 	soundEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			soundWin.Toggle()
@@ -928,7 +917,6 @@ func makeSettingsWindow() {
 	debugBtn, debugEvents := eui.NewButton()
 	debugBtn.Text = "Debug Settings"
 	debugBtn.Size = eui.Point{X: width, Y: 24}
-	debugBtn.Tooltip = "Open debug settings"
 	debugEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			debugWin.Toggle()


### PR DESCRIPTION
## Summary
- remove redundant tooltips from clearly labeled settings controls
- rename font and opacity sliders for clarity

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c39e967f0832ab3c961c403b596e3