### PR TITLE
Clarify labels in settings windows

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -962,7 +962,6 @@ func makeGraphicsWindow() {
 	uiScaleSlider.Value = float32(gs.UIScale)
 	uiScaleSlider.Size = eui.Point{X: width - 10, Y: 24}
 	pendingUIScale := gs.UIScale
-	uiScaleSlider.Tooltip = "Scale entire interface"
 	uiScaleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			pendingUIScale = float64(ev.Value)
@@ -971,9 +970,8 @@ func makeGraphicsWindow() {
 	flow.AddItem(uiScaleSlider)
 
 	uiScaleApplyBtn, uiScaleApplyEvents := eui.NewButton()
-	uiScaleApplyBtn.Text = "Apply"
-	uiScaleApplyBtn.Size = eui.Point{X: 60, Y: 24}
-	uiScaleApplyBtn.Tooltip = "Apply UI scale"
+	uiScaleApplyBtn.Text = "Apply UI Scale"
+	uiScaleApplyBtn.Size = eui.Point{X: 100, Y: 24}
 	uiScaleApplyEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			gs.UIScale = pendingUIScale
@@ -998,7 +996,6 @@ func makeGraphicsWindow() {
 	gameSizeSlider.Value = float32(gsVal)
 	gameSizeSlider.Size = eui.Point{X: width - 10, Y: 24}
 	gameSizeSlider.Disabled = gs.AnyGameWindowSize
-	gameSizeSlider.Tooltip = "Magnify game window without blur"
 	gameSizeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.GameScale = float64(ev.Value)
@@ -1020,7 +1017,6 @@ func makeGraphicsWindow() {
 	anySizeCB.Text = "Any size game window"
 	anySizeCB.Size = eui.Point{X: width, Y: 24}
 	anySizeCB.Checked = gs.AnyGameWindowSize
-	anySizeCB.Tooltip = "Allow any game window size (may blur)"
 	anySizeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.AnyGameWindowSize = ev.Checked
@@ -1037,7 +1033,6 @@ func makeGraphicsWindow() {
 	fullscreenCB.Text = "Fullscreen"
 	fullscreenCB.Size = eui.Point{X: width, Y: 24}
 	fullscreenCB.Checked = gs.Fullscreen
-	fullscreenCB.Tooltip = "Toggle fullscreen mode"
 	fullscreenEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.Fullscreen = ev.Checked
@@ -1053,7 +1048,6 @@ func makeGraphicsWindow() {
 	qualityPresetDD.Selected = detectQualityPreset()
 	qualityPresetDD.Label = "Presets"
 	qualityPresetDD.FontSize = 12
-	qualityPresetDD.Tooltip = "Select quality preset"
 	qpEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventDropdownSelected {
 			switch ev.Index {
@@ -1076,7 +1070,6 @@ func makeGraphicsWindow() {
 	qualityBtn, qualityEvents := eui.NewButton()
 	qualityBtn.Text = "Quality Options"
 	qualityBtn.Size = eui.Point{X: width, Y: 24}
-	qualityBtn.Tooltip = "Show detailed quality settings"
 	qualityEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			qualityWin.Toggle()
@@ -1109,7 +1102,6 @@ func makeSoundWindow() {
 	volumeSlider.MaxValue = 1
 	volumeSlider.Value = float32(gs.Volume)
 	volumeSlider.Size = eui.Point{X: width - 10, Y: 24}
-	volumeSlider.Tooltip = "Adjust sound volume"
 	volumeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			gs.Volume = float64(ev.Value)
@@ -1123,7 +1115,6 @@ func makeSoundWindow() {
 	muteCB.Text = "Mute"
 	muteCB.Size = eui.Point{X: width, Y: 24}
 	muteCB.Checked = gs.Mute
-	muteCB.Tooltip = "Mute all sounds"
 	muteEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.Mute = ev.Checked


### PR DESCRIPTION
## Summary
- refine Apply button text and remove unnecessary UI tooltips
- drop redundant tooltips from sound controls

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c39ed1c40832aaee6a519eee8915e