### PR TITLE
Auto-size movie controls window

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -42,16 +42,13 @@ func newMoviePlayer(frames [][]byte, fps int, cancel context.CancelFunc) *movieP
 
 // makePlaybackWindow creates the playback control window.
 func (p *moviePlayer) makePlaybackWindow() {
-	ps := eui.Point{X: 800, Y: 95}
-
 	win := eui.NewWindow()
 	win.Title = "Movie Controls"
 	win.Closable = false
 	win.Resizable = false
-	win.AutoSize = false
+	win.AutoSize = true
 	win.NoScroll = true
 	win.SetZone(eui.HZoneCenter, eui.VZoneBottomMiddle)
-	win.Size = ps
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 


### PR DESCRIPTION
## Summary
- auto-size Movie Controls window to fit its contents instead of using fixed dimensions

## Testing
- `go fmt movie_player.go`
- `go vet ./...` *(fails: undefined: qualityBtn)*
- `go build ./...` *(fails: undefined: qualityBtn)*
- `go test ./...` *(fails: undefined: qualityBtn and missing -lXxf86vm)*

------
https://chatgpt.com/codex/tasks/task_e_689c3dd2c238832ab4a4826ab6af5ae4