### PR TITLE
Ensure caching options trigger refresh and sync

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -51,6 +51,10 @@ var (
 	// enabled by default and can be disabled if needed.
 	AutoHiDPI       bool    = true
 	lastDeviceScale float64 = 1.0
+
+	// WindowStateChanged is an optional callback fired when any window
+	// is opened or closed.
+	WindowStateChanged func()
 )
 
 func init() {

--- a/eui/window.go
+++ b/eui/window.go
@@ -238,6 +238,9 @@ func (target *windowData) MarkOpen() {
 		target.BringForward()
 	}
 	target.Refresh()
+	if WindowStateChanged != nil {
+		WindowStateChanged()
+	}
 }
 
 // MarkOpen sets the window to open and brings it forward if necessary.
@@ -253,6 +256,9 @@ func (target *windowData) Close() {
 	target.deallocate()
 	target.Open = false
 	target.RemoveWindow()
+	if WindowStateChanged != nil {
+		WindowStateChanged()
+	}
 }
 
 // Send a window to the back

--- a/ui.go
+++ b/ui.go
@@ -65,6 +65,14 @@ var (
 	potatoCB        *eui.ItemData
 )
 
+func init() {
+	eui.WindowStateChanged = func() {
+		if windowsWin != nil {
+			windowsWin.Refresh()
+		}
+	}
+}
+
 func initUI() {
 	status, err := checkDataFiles(clientVersion)
 	if err != nil {
@@ -904,7 +912,7 @@ func makeSettingsWindow() {
 			qualityWin.Toggle()
 		}
 	}
-	mainFlow.AddItem(qualityBtn)
+	mainFlow.AddItem(soundBtn)
 
 	debugBtn, debugEvents := eui.NewButton()
 	debugBtn.Text = "Debug Settings"
@@ -1308,9 +1316,22 @@ func makeQualityWindow() {
 	precacheSoundEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.precacheSounds = ev.Checked
-			settingsDirty = true
-			if ev.Checked && !gs.NoCaching {
+			if ev.Checked {
+				gs.NoCaching = false
+				if noCacheCB != nil {
+					noCacheCB.Checked = false
+				}
 				go precacheAssets()
+			}
+			settingsDirty = true
+			if qualityWin != nil {
+				qualityWin.Refresh()
+			}
+			if graphicsWin != nil {
+				graphicsWin.Refresh()
+			}
+			if debugWin != nil {
+				debugWin.Refresh()
 			}
 		}
 	}
@@ -1326,9 +1347,22 @@ func makeQualityWindow() {
 	precacheImageEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.precacheImages = ev.Checked
-			settingsDirty = true
-			if ev.Checked && !gs.NoCaching {
+			if ev.Checked {
+				gs.NoCaching = false
+				if noCacheCB != nil {
+					noCacheCB.Checked = false
+				}
 				go precacheAssets()
+			}
+			settingsDirty = true
+			if qualityWin != nil {
+				qualityWin.Refresh()
+			}
+			if graphicsWin != nil {
+				graphicsWin.Refresh()
+			}
+			if debugWin != nil {
+				debugWin.Refresh()
 			}
 		}
 	}
@@ -1354,6 +1388,15 @@ func makeQualityWindow() {
 			settingsDirty = true
 			if qualityPresetDD != nil {
 				qualityPresetDD.Selected = detectQualityPreset()
+			}
+			if qualityWin != nil {
+				qualityWin.Refresh()
+			}
+			if graphicsWin != nil {
+				graphicsWin.Refresh()
+			}
+			if debugWin != nil {
+				debugWin.Refresh()
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Refresh the Windows list whenever any window opens or closes
- Make precache sound/image options disable No Caching and refresh settings windows
- Fix sound settings button reference in settings window

## Testing
- `go vet ./...`
- `xvfb-run go test ./...` (fails: width snapped to 64; want 50)
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c3f790818832ab3680081b17900aa