### PR TITLE
Refactor window sizing to rely on in-game window

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -24,9 +24,6 @@ var (
 // Update processes input and updates window state.
 // Programs embedding the UI can call this from their Ebiten Update handler.
 func Update() error {
-	w, h := ebiten.WindowSize()
-	Layout(w, h)
-
 	checkThemeStyleMods()
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyGraveAccent) &&


### PR DESCRIPTION
## Summary
- Resize game window through EUI rather than Ebiten APIs
- Initialize Clan Lord window using `gameWin.SetSize`
- Remove remaining `ebiten.WindowSize` usage from game logic and UI

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c45f94c24832a8979deb84ca2724c