### PR TITLE
fix slider track underflow

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -598,7 +598,14 @@ func (item *itemData) setSliderValue(mpos point) {
 	maxW, _ := text.Measure(maxLabel, face, 0)
 
 	knobW := item.AuxSize.X * uiScale
-	width := item.DrawRect.X1 - item.DrawRect.X0 - knobW - currentStyle.SliderValueGap - float32(maxW)
+	gap := currentStyle.SliderValueGap
+	width := item.DrawRect.X1 - item.DrawRect.X0 - knobW - gap - float32(maxW)
+	if width < knobW {
+		width = item.DrawRect.X1 - item.DrawRect.X0 - knobW
+		if width < 0 {
+			width = 0
+		}
+	}
 	if width <= 0 {
 		return
 	}

--- a/eui/render.go
+++ b/eui/render.go
@@ -953,8 +953,13 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		knobW := item.AuxSize.X * uiScale
 		knobH := item.AuxSize.Y * uiScale
 		trackWidth := maxSize.X - knobW - gap - float32(maxW)
-		if trackWidth < 0 {
-			trackWidth = 0
+		showValue := true
+		if trackWidth < knobW {
+			trackWidth = maxSize.X - knobW
+			showValue = false
+			if trackWidth < 0 {
+				trackWidth = 0
+			}
 		}
 
 		trackStart := offset.X + knobW/2
@@ -990,16 +995,18 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 			Color:    style.OutlineColor,
 		})
 
-		// value text drawn to the right of the slider track
-		loo := text.LayoutOptions{LineSpacing: 1.2, PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
-		tdop := ebiten.DrawImageOptions{}
-		tdop.GeoM.Translate(
-			float64(trackStart+trackWidth+gap),
-			float64(offset.Y+(maxSize.Y/2)),
-		)
-		top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
-		top.ColorScale.ScaleWithColor(style.TextColor)
-		text.Draw(subImg, valueText, face, top)
+		if showValue {
+			// value text drawn to the right of the slider track
+			loo := text.LayoutOptions{LineSpacing: 1.2, PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
+			tdop := ebiten.DrawImageOptions{}
+			tdop.GeoM.Translate(
+				float64(trackStart+trackWidth+gap),
+				float64(offset.Y+(maxSize.Y/2)),
+			)
+			top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
+			top.ColorScale.ScaleWithColor(style.TextColor)
+			text.Draw(subImg, valueText, face, top)
+		}
 
 	} else if item.ItemType == ITEM_DROPDOWN {
 

--- a/eui/slider_test.go
+++ b/eui/slider_test.go
@@ -1,0 +1,47 @@
+package eui
+
+import (
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+	"testing"
+)
+
+func TestSliderConstrainedWidth(t *testing.T) {
+	uiScale = 1
+	item := &itemData{
+		ItemType: ITEM_SLIDER,
+		MinValue: 0,
+		MaxValue: 1,
+		Value:    0,
+		AuxSize:  point{X: 10, Y: 10},
+		FontSize: 12,
+	}
+	item.DrawRect = rect{X0: 0, Y0: 0, X1: 30, Y1: 20}
+
+	textSize := (item.FontSize * uiScale) + 2
+	face := textFace(textSize)
+	maxW, _ := text.Measure(sliderMaxLabel, face, 0)
+	gap := currentStyle.SliderValueGap
+	knobW := item.AuxSize.X * uiScale
+
+	trackWidth := item.DrawRect.X1 - item.DrawRect.X0 - knobW - gap - float32(maxW)
+	showValue := true
+	if trackWidth < knobW {
+		trackWidth = item.DrawRect.X1 - item.DrawRect.X0 - knobW
+		showValue = false
+		if trackWidth < 0 {
+			trackWidth = 0
+		}
+	}
+	if trackWidth <= 0 {
+		t.Fatalf("trackWidth <= 0: %f", trackWidth)
+	}
+	if showValue {
+		t.Fatalf("expected value label hidden for narrow slider")
+	}
+
+	mpos := point{X: item.DrawRect.X0 + knobW + trackWidth, Y: 0}
+	item.setSliderValue(mpos)
+	if item.Value != item.MaxValue {
+		t.Fatalf("expected value to be MaxValue, got %f", item.Value)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent negative slider track widths and hide labels when space is tight
- mirror slider width logic in drag handling
- add test ensuring narrow sliders remain interactive

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c4688b834832a9f11429403ca14f1