### PR TITLE
fix playback window layout

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -220,6 +220,11 @@ func (p *moviePlayer) makePlaybackWindow() {
 
 	flow.AddItem(bFlow)
 	win.AddItem(flow)
+
+	// Recompute window dimensions now that all controls are present
+	win.Refresh()
+
+	// Add and open the fully populated window
 	win.AddWindow(false)
 	win.MarkOpen()
 


### PR DESCRIPTION
## Summary
- recompute playback window size after adding controls
- ensure all controls exist before adding and opening the window

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*
- `go run .` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689c468e7d90832a9fe1d5d37de43200