### PR TITLE
Revert text AutoSize behavior

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -37,7 +37,6 @@ func updateChatWindow() {
 			}
 			t.Text = msg
 			t.FontSize = float32(gs.ChatFontSize)
-			t.AutoSize = true
 			chatList.AddItem(t)
 			changed = true
 		}

--- a/console_ui.go
+++ b/console_ui.go
@@ -27,7 +27,6 @@ func updateConsoleWindow() {
 			t, _ := eui.NewText()
 			t.Text = msg
 			t.FontSize = float32(gs.ConsoleFontSize)
-			t.AutoSize = true
 			messagesFlow.AddItem(t)
 			changed = true
 		}
@@ -52,7 +51,6 @@ func updateConsoleWindow() {
 		t, _ := eui.NewText()
 		t.Text = inputMsg
 		t.FontSize = float32(gs.ConsoleFontSize)
-		t.AutoSize = true
 		inputFlow.AddItem(t)
 		changed = true
 	} else {

--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -62,8 +62,6 @@ var defaultText = &itemData{
 	Padding:   0,
 	Margin:    2,
 	TextColor: NewColor(255, 255, 255, 255),
-	Fixed:     false,
-	AutoSize:  true,
 }
 
 var defaultCheckbox = &itemData{

--- a/eui/render.go
+++ b/eui/render.go
@@ -1090,17 +1090,11 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 			subImg.DrawImage(item.Image, op)
 		}
 	} else if item.ItemType == ITEM_TEXT {
+
 		textSize := (item.FontSize * uiScale) + 2
 		face := textFace(textSize)
-		maxW := float64(item.Size.X * uiScale)
-		_, lines := wrapText(item.Text, face, maxW)
-		wrapped := strings.Join(lines, "\n")
-		lineSpace := item.LineSpace
-		if lineSpace == 0 {
-			lineSpace = 1.2
-		}
 		loo := text.LayoutOptions{
-			LineSpacing:    float64(textSize) * float64(lineSpace),
+			LineSpacing:    float64(textSize) * 1.2,
 			PrimaryAlign:   text.AlignStart,
 			SecondaryAlign: text.AlignStart,
 		}
@@ -1111,7 +1105,7 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 
 		top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
 		top.ColorScale.ScaleWithColor(style.TextColor)
-		text.Draw(subImg, wrapped, face, top)
+		text.Draw(subImg, item.Text, face, top)
 	}
 
 	if item.Outlined && item.Border > 0 && item.ItemType != ITEM_CHECKBOX && item.ItemType != ITEM_RADIO {

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -112,7 +112,7 @@ type itemData struct {
 	OnSelect func(int)
 	OnHover  func(int)
 
-	Fixed, Scrollable, AutoSize bool
+	Fixed, Scrollable bool
 
 	ImageName string
 	Image     *ebiten.Image

--- a/eui/util.go
+++ b/eui/util.go
@@ -3,7 +3,6 @@ package eui
 import (
 	"image/color"
 	"math"
-	"strings"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
@@ -14,82 +13,6 @@ var (
 	strokeLineFn = vector.StrokeLine
 	strokeRectFn = vector.StrokeRect
 )
-
-// wrapText splits s into lines that do not exceed maxWidth when rendered with
-// the provided face. Words are kept intact when possible; if a single word
-// exceeds maxWidth it will be broken across lines.
-func wrapText(s string, face text.Face, maxWidth float64) (int, []string) {
-	var (
-		lines         []string
-		maxUsed       float64
-		runesBuffer   []rune
-		spaceWidth, _ = text.Measure(" ", face, 0)
-	)
-	for _, para := range strings.Split(s, "\n") {
-		words := strings.Fields(para)
-		if len(words) == 0 {
-			lines = append(lines, "")
-			continue
-		}
-		wordWidths := make([]float64, len(words))
-		for i, w := range words {
-			ww, _ := text.Measure(w, face, 0)
-			wordWidths[i] = ww
-		}
-
-		var builder strings.Builder
-		builder.WriteString(words[0])
-		curWidth := wordWidths[0]
-
-		for i := 1; i < len(words); i++ {
-			w := words[i]
-			wWidth := wordWidths[i]
-			candWidth := curWidth + spaceWidth + wWidth
-			if candWidth <= maxWidth {
-				builder.WriteByte(' ')
-				builder.WriteString(w)
-				curWidth = candWidth
-				continue
-			}
-
-			if curWidth > maxUsed {
-				maxUsed = curWidth
-			}
-			lines = append(lines, builder.String())
-
-			if wWidth > maxWidth {
-				runesBuffer = runesBuffer[:0]
-				partWidth := 0.0
-				for _, r := range w {
-					rw, _ := text.Measure(string(r), face, 0)
-					if partWidth+rw > maxWidth && len(runesBuffer) > 0 {
-						part := string(runesBuffer)
-						if partWidth > maxUsed {
-							maxUsed = partWidth
-						}
-						lines = append(lines, part)
-						runesBuffer = runesBuffer[:0]
-						partWidth = 0
-					}
-					runesBuffer = append(runesBuffer, r)
-					partWidth += rw
-				}
-				builder.Reset()
-				builder.WriteString(string(runesBuffer))
-				curWidth = partWidth
-			} else {
-				builder.Reset()
-				builder.WriteString(w)
-				curWidth = wWidth
-			}
-		}
-		if curWidth > maxUsed {
-			maxUsed = curWidth
-		}
-		lines = append(lines, builder.String())
-	}
-	return int(math.Ceil(maxUsed)), lines
-}
 
 func (item *itemData) themeStyle() *itemData {
 	if item == nil || item.Theme == nil {
@@ -897,18 +820,7 @@ func (item *itemData) resizeFlow(parentSize point) {
 
 		item.Size = point{X: size.X / uiScale, Y: size.Y / uiScale}
 		available = item.GetSize()
-	} else if item.ItemType == ITEM_TEXT && item.AutoSize {
-		item.Size.X = parentSize.X / uiScale
-		textSize := (item.FontSize * uiScale) + 2
-		face := textFace(textSize)
-		_, lines := wrapText(item.Text, face, float64(parentSize.X))
-		lineHeight := textSize * item.LineSpace
-		item.Size.Y = float32(len(lines)) * lineHeight / uiScale
-		available = item.GetSize()
 	} else {
-		if item.AutoSize {
-			item.Size = point{X: available.X / uiScale, Y: item.Size.Y}
-		}
 		available = item.GetSize()
 	}
 


### PR DESCRIPTION
## Summary
- remove AutoSize support for text items and restore explicit sizing
- drop AutoSize usage in chat and console text elements

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c4f1de4d8832a82f6fb9b24be0e6f