### PR TITLE
refactor console and chat windows into shared builder

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -2,71 +2,19 @@
 
 package main
 
-import (
-	"go_client/eui"
-)
+import "go_client/eui"
 
 var chatWin *eui.WindowData
 var chatList *eui.ItemData
-var inputBar *eui.ItemData
 
 func updateChatWindow() {
-	if chatList == nil {
-		return
-	}
-	if chatWin != nil {
-		chatList.Size.Y = chatWin.GetSize().Y
-		if inputBar != nil {
-			chatList.Size.Y -= inputBar.Size.Y
-		}
-	}
-	msgs := getChatMessages()
-	changed := false
-	for i, msg := range msgs {
-		if i < len(chatList.Contents) {
-			if chatList.Contents[i].Text != msg || chatList.Contents[i].FontSize != float32(gs.ChatFontSize) {
-				chatList.Contents[i].Text = msg
-				chatList.Contents[i].FontSize = float32(gs.ChatFontSize)
-				changed = true
-			}
-		} else {
-			t, _ := eui.NewText()
-			if t == nil {
-				logError("create chat text: eui.NewText returned nil")
-				continue
-			}
-			t.Text = msg
-			t.FontSize = float32(gs.ChatFontSize)
-			chatList.AddItem(t)
-			changed = true
-		}
-	}
-	if len(chatList.Contents) > len(msgs) {
-		for i := len(msgs); i < len(chatList.Contents); i++ {
-			chatList.Contents[i] = nil
-		}
-		chatList.Contents = chatList.Contents[:len(msgs)]
-		changed = true
-	}
-	if changed && chatWin != nil {
-		chatWin.Refresh()
-	}
+	updateTextWindow(chatWin, chatList, nil, getChatMessages(), gs.ChatFontSize, "")
 }
 
 func makeChatWindow() error {
 	if chatWin != nil {
 		return nil
 	}
-	chatWin = eui.NewWindow()
-	chatWin.Size = eui.Point{X: 410, Y: 450}
-	chatWin.Title = "Chat"
-	chatWin.Closable = true
-	chatWin.Resizable = true
-	chatWin.Movable = true
-	chatWin.SetZone(eui.HZoneRight, eui.VZoneBottom)
-
-	chatList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true}
-	chatWin.AddItem(chatList)
-	chatWin.AddWindow(false)
+	chatWin, chatList, _ = makeTextWindow("Chat", eui.HZoneRight, eui.VZoneBottom, false)
 	return nil
 }

--- a/console_ui.go
+++ b/console_ui.go
@@ -5,92 +5,21 @@ package main
 import "go_client/eui"
 
 var consoleWin *eui.WindowData
-var consoleFlow *eui.ItemData
 var messagesFlow *eui.ItemData
 var inputFlow *eui.ItemData
-var messagesDirty bool
 
 func updateConsoleWindow() {
-	if messagesFlow == nil || inputFlow == nil {
-		return
-	}
-	msgs := getConsoleMessages()
-	changed := false
-	for i, msg := range msgs {
-		if i < len(messagesFlow.Contents) {
-			if messagesFlow.Contents[i].Text != msg || messagesFlow.Contents[i].FontSize != float32(gs.ConsoleFontSize) {
-				messagesFlow.Contents[i].Text = msg
-				messagesFlow.Contents[i].FontSize = float32(gs.ConsoleFontSize)
-				changed = true
-			}
-		} else {
-			t, _ := eui.NewText()
-			t.Text = msg
-			t.FontSize = float32(gs.ConsoleFontSize)
-			messagesFlow.AddItem(t)
-			changed = true
-		}
-	}
-	if len(messagesFlow.Contents) > len(msgs) {
-		for i := len(msgs); i < len(messagesFlow.Contents); i++ {
-			messagesFlow.Contents[i] = nil
-		}
-		messagesFlow.Contents = messagesFlow.Contents[:len(msgs)]
-		changed = true
-	}
-
-	inputFlow.Size.Y = float32(gs.ConsoleFontSize) + 8
-	if consoleWin != nil {
-		messagesFlow.Size.Y = consoleWin.GetSize().Y - inputFlow.Size.Y
-	}
 	inputMsg := "[Command Input Bar] (Press enter to switch to command mode)"
 	if inputActive {
 		inputMsg = string(inputText)
 	}
-	if len(inputFlow.Contents) == 0 {
-		t, _ := eui.NewText()
-		t.Text = inputMsg
-		t.FontSize = float32(gs.ConsoleFontSize)
-		inputFlow.AddItem(t)
-		changed = true
-	} else {
-		if inputFlow.Contents[0].Text != inputMsg || inputFlow.Contents[0].FontSize != float32(gs.ConsoleFontSize) {
-			inputFlow.Contents[0].Text = inputMsg
-			inputFlow.Contents[0].FontSize = float32(gs.ConsoleFontSize)
-			changed = true
-		}
-	}
-	if changed {
-		messagesDirty = true
-		if consoleWin != nil {
-			consoleWin.Refresh()
-		}
-	}
+	updateTextWindow(consoleWin, messagesFlow, inputFlow, getConsoleMessages(), gs.ConsoleFontSize, inputMsg)
 }
 
 func makeConsoleWindow() {
 	if consoleWin != nil {
 		return
 	}
-	consoleWin = eui.NewWindow()
-	consoleWin.Title = "Console"
-	consoleWin.Size = eui.Point{X: 410, Y: 450}
-	consoleWin.Closable = true
-	consoleWin.Resizable = true
-	consoleWin.Movable = true
-	consoleWin.SetZone(eui.HZoneLeft, eui.VZoneBottom)
-
-	consoleFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
-	consoleFlow.Size = consoleWin.GetSize()
-	consoleWin.AddItem(consoleFlow)
-
-	messagesFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
-	consoleFlow.AddItem(messagesFlow)
-
-	inputFlow = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
-	inputFlow.Color = eui.ColorVeryDarkGray
-	consoleFlow.AddItem(inputFlow)
-
-	consoleWin.AddWindow(false)
+	consoleWin, messagesFlow, inputFlow = makeTextWindow("Console", eui.HZoneLeft, eui.VZoneBottom, true)
 	updateConsoleWindow()
 }

--- a/text_window.go
+++ b/text_window.go
@@ -1,0 +1,78 @@
+package main
+
+import "go_client/eui"
+
+// makeTextWindow creates a standardized text window with optional input bar.
+func makeTextWindow(title string, hz eui.HZone, vz eui.VZone, withInput bool) (*eui.WindowData, *eui.ItemData, *eui.ItemData) {
+	win := eui.NewWindow()
+	win.Size = eui.Point{X: 410, Y: 450}
+	win.Title = title
+	win.Closable = true
+	win.Resizable = true
+	win.Movable = true
+	win.SetZone(hz, vz)
+
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	flow.Size = win.GetSize()
+	win.AddItem(flow)
+
+	list := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
+	flow.AddItem(list)
+
+	var input *eui.ItemData
+	if withInput {
+		input = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+		input.Color = eui.ColorVeryDarkGray
+		flow.AddItem(input)
+	}
+
+	win.AddWindow(false)
+	return win, list, input
+}
+
+// updateTextWindow refreshes a text window's content and optional input message.
+func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []string, fontSize float64, inputMsg string) {
+	if list == nil {
+		return
+	}
+
+	for i, msg := range msgs {
+		if i < len(list.Contents) {
+			if list.Contents[i].Text != msg || list.Contents[i].FontSize != float32(fontSize) {
+				list.Contents[i].Text = msg
+				list.Contents[i].FontSize = float32(fontSize)
+			}
+		} else {
+			t, _ := eui.NewText()
+			t.Text = msg
+			t.FontSize = float32(fontSize)
+			list.AddItem(t)
+		}
+	}
+	if len(list.Contents) > len(msgs) {
+		for i := len(msgs); i < len(list.Contents); i++ {
+			list.Contents[i] = nil
+		}
+		list.Contents = list.Contents[:len(msgs)]
+	}
+
+	if input != nil {
+		input.Size.Y = float32(fontSize) + 8
+		if win != nil {
+			list.Size.Y = win.GetSize().Y - input.Size.Y
+		}
+		if len(input.Contents) == 0 {
+			t, _ := eui.NewText()
+			t.Text = inputMsg
+			t.FontSize = float32(fontSize)
+			input.AddItem(t)
+		} else if input.Contents[0].Text != inputMsg || input.Contents[0].FontSize != float32(fontSize) {
+			input.Contents[0].Text = inputMsg
+			input.Contents[0].FontSize = float32(fontSize)
+		}
+	}
+
+	if win != nil {
+		win.Refresh()
+	}
+}


### PR DESCRIPTION
## Summary
- add reusable text window creation and update helpers
- rebuild console window on top of shared text window code
- rebuild chat window using shared helper

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package alsa not found; Package gtk+-3.0 not found)*
- `go test ./...` *(fails: missing alsa, gtk+-3.0, X11 headers)*
- `go build ./...` *(fails: missing alsa, gtk+-3.0, X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_689c524d810c832a9b113340f2e3f685