### PR TITLE
Reautosize windows when screen size changes

### DIFF
--- a/eui/public.go
+++ b/eui/public.go
@@ -25,6 +25,7 @@ func SetWindowSnapping(enabled bool) { windowSnapping = enabled }
 func SetScreenSize(w, h int) {
 	screenWidth = w
 	screenHeight = h
+	needDirty := false
 	for _, win := range windows {
 		size := win.GetSize()
 		resized := false
@@ -44,14 +45,22 @@ func SetScreenSize(w, h int) {
 			}
 			resized = true
 		}
-		if resized {
+		if win.AutoSize {
+			win.updateAutoSize()
+			win.adjustScrollForResize()
+			needDirty = true
+		} else if resized {
 			win.resizeFlows()
 			win.adjustScrollForResize()
+			needDirty = true
 		}
 		if win.zone != nil {
 			win.updateZonePosition()
 		}
 		win.clampToScreen()
+	}
+	if needDirty {
+		markAllDirty()
 	}
 }
 


### PR DESCRIPTION
## Summary
- re-autosize windows when the Ebiten screen size changes

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c567cebf8832a9179ff96b2a4a0f1