### PR TITLE
Add pictAgain debug flag to highlight reused images

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -32,6 +32,7 @@ type framePicture struct {
 	Moving       bool
 	Background   bool
 	Owned        bool
+	Again        bool
 }
 
 type frameMobile struct {
@@ -718,6 +719,12 @@ func parseDrawState(data []byte) error {
 	newPics := make([]framePicture, again+pictCount)
 	copy(newPics, prevPics[:again])
 	copy(newPics[again:], pics)
+	for i := 0; i < again && i < len(newPics); i++ {
+		newPics[i].Again = true
+	}
+	for i := again; i < len(newPics); i++ {
+		newPics[i].Again = false
+	}
 	dx, dy, bgIdxs, ok := pictureShift(prevPics, newPics)
 	if gs.MotionSmoothing && gs.smoothMoving {
 		logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)

--- a/game.go
+++ b/game.go
@@ -1063,7 +1063,9 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		tx := math.Round(float64(x) - float64(drawW)*sx/2)
 		ty := math.Round(float64(y) - float64(drawH)*sy/2)
 		op.GeoM.Translate(tx, ty)
-		if src == img && gs.smoothingDebug && p.Moving {
+		if gs.pictAgainDebug && p.Again {
+			op.ColorM.Scale(0, 0, 1, 1)
+		} else if src == img && gs.smoothingDebug && p.Moving {
 			op.ColorM.Scale(1, 0, 0, 1)
 		}
 		screen.DrawImage(src, op)
@@ -1085,6 +1087,9 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		clr := color.RGBA{0, 0, 0xff, 0xff}
 		if gs.smoothingDebug && p.Moving {
 			clr = color.RGBA{0xff, 0, 0, 0xff}
+		}
+		if gs.pictAgainDebug && p.Again {
+			clr = color.RGBA{0, 0, 0xff, 0xff}
 		}
 		vector.DrawFilledRect(screen, float32(float64(x)-2*gs.GameScale), float32(float64(y)-2*gs.GameScale), float32(4*gs.GameScale), float32(4*gs.GameScale), clr, false)
 		if gs.imgPlanesDebug {

--- a/settings.go
+++ b/settings.go
@@ -58,6 +58,7 @@ var gsdef settings = settings{
 
 	imgPlanesDebug:   false,
 	smoothingDebug:   false,
+	pictAgainDebug:   false,
 	hideMoving:       false,
 	hideMobiles:      false,
 	vsync:            true,
@@ -117,6 +118,7 @@ type settings struct {
 
 	imgPlanesDebug   bool
 	smoothingDebug   bool
+	pictAgainDebug   bool
 	hideMoving       bool
 	hideMobiles      bool
 	vsync            bool

--- a/ui.go
+++ b/ui.go
@@ -1519,6 +1519,18 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(smoothinCB)
+	pictAgainCB, pictAgainEvents := eui.NewCheckbox()
+	pictAgainCB.Text = "Mark pictAgain images"
+	pictAgainCB.Size = eui.Point{X: width, Y: 24}
+	pictAgainCB.Checked = gs.pictAgainDebug
+	pictAgainCB.Tooltip = "Tint retained images blue"
+	pictAgainEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.pictAgainDebug = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(pictAgainCB)
 	cacheLabel, _ := eui.NewText()
 	cacheLabel.Text = "Caches:"
 	cacheLabel.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- track whether images were reused from previous frames
- add `pictAgainDebug` setting and UI toggle
- tint reused images blue when the debug flag is enabled

## Testing
- `gofmt -w draw.go game.go settings.go ui.go`
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c56e1dc28832ab986678d2a6fc72e