### PR TITLE
Add option to skip smoothing on moving objects

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -57,6 +57,7 @@ var (
 	qualityPresetDD *eui.ItemData
 	denoiseCB       *eui.ItemData
 	motionCB        *eui.ItemData
+	noSmoothCB      *eui.ItemData
 	animCB          *eui.ItemData
 	pictBlendCB     *eui.ItemData
 	precacheSoundCB *eui.ItemData
@@ -1148,6 +1149,20 @@ func makeQualityWindow() {
 		}
 	}
 	flow.AddItem(motionCB)
+
+	nsCB, noSmoothEvents := eui.NewCheckbox()
+	noSmoothCB = nsCB
+	noSmoothCB.Text = "Don't smooth moving objects"
+	noSmoothCB.Size = eui.Point{X: width, Y: 24}
+	noSmoothCB.Checked = !gs.smoothMoving
+	noSmoothCB.Tooltip = "Skip interpolation for moving objects"
+	noSmoothEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.smoothMoving = !ev.Checked
+			settingsDirty = true
+		}
+	}
+	flow.AddItem(noSmoothCB)
 
 	aCB, animEvents := eui.NewCheckbox()
 	animCB = aCB


### PR DESCRIPTION
## Summary
- Add "Don't smooth moving objects" checkbox in Quality Options
- Allow toggling of interpolation for moving objects via new setting

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package 'alsa' and 'gtk+-3.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c85b3c0832a9fbc832ceacf519e