### PR TITLE
Adjust mouse walk for window origin

### DIFF
--- a/game.go
+++ b/game.go
@@ -513,8 +513,9 @@ func (g *Game) Update() error {
 	}
 
 	mx, my := ebiten.CursorPosition()
-	baseX := int16(float64(mx)/gs.GameScale - float64(fieldCenterX))
-	baseY := int16(float64(my)/gs.GameScale - float64(fieldCenterY))
+	gx, gy := gameWindowOrigin()
+	baseX := int16(float64(mx-gx)/gs.GameScale - float64(fieldCenterX))
+	baseY := int16(float64(my-gy)/gs.GameScale - float64(fieldCenterY))
 	baseDown := ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
 	if pointInUI(mx, my) {
 		baseDown = false


### PR DESCRIPTION
## Summary
- fix mouse walk offset by accounting for game window origin

## Testing
- `go vet ./...`
- `xvfb-run go test ./...` *(fails: width snapped to 64; want 50)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c65a9263c832aa32d7fc309fb9231