### PR TITLE
Align text window list size with window

### DIFF
--- a/text_window.go
+++ b/text_window.go
@@ -58,9 +58,6 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 
 	if input != nil {
 		input.Size.Y = float32(fontSize) + 8
-		if win != nil {
-			list.Size.Y = win.GetSize().Y - input.Size.Y
-		}
 		if len(input.Contents) == 0 {
 			t, _ := eui.NewText()
 			t.Text = inputMsg
@@ -73,6 +70,12 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	}
 
 	if win != nil {
+		list.Size.X = win.GetSize().X
+		if input != nil {
+			list.Size.Y = win.GetSize().Y - input.Size.Y
+		} else {
+			list.Size.Y = win.GetSize().Y
+		}
 		win.Refresh()
 	}
 }


### PR DESCRIPTION
## Summary
- Align text window list width to window width and compute height based on input presence

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; pkg-config can't find alsa, gtk+3.0)*
- `go test ./...` *(fails: pkg-config can't find gtk+3.0, alsa, X11 headers)*
- `go build ./...` *(fails: pkg-config can't find alsa, gtk+3.0, X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf9a54ec832abff69efc9a8b8e18