### PR TITLE
Initialize chat window with existing messages

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -16,5 +16,6 @@ func makeChatWindow() error {
 		return nil
 	}
 	chatWin, chatList, _ = makeTextWindow("Chat", eui.HZoneRight, eui.VZoneBottom, false)
+	updateChatWindow()
 	return nil
 }


### PR DESCRIPTION
## Summary
- call `updateChatWindow()` when creating the chat window so prior messages are shown

## Testing
- `go fmt chat_messages_ui.go`
- `go vet ./...`
- `go test ./...` *(fails: "glfw: X11: The DISPLAY environment variable is missing")*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cdf9f568c832ab8274817964e4a12