### PR TITLE
Add PrependItem helpers

### DIFF
--- a/eui/public.go
+++ b/eui/public.go
@@ -96,6 +96,12 @@ func (parent *ItemData) AddItem(child *ItemData) { parent.addItemTo(child) }
 // AddItem appends a child item to the window.
 func (win *WindowData) AddItem(child *ItemData) { win.addItemTo(child) }
 
+// PrependItem prepends a child item to the parent item.
+func (parent *ItemData) PrependItem(child *ItemData) { parent.prependItemTo(child) }
+
+// PrependItem prepends a child item to the window.
+func (win *WindowData) PrependItem(child *ItemData) { win.prependItemTo(child) }
+
 // ListThemes returns the available palette names.
 func ListThemes() ([]string, error) { return listThemes() }
 

--- a/eui/util.go
+++ b/eui/util.go
@@ -72,11 +72,33 @@ func (parent *itemData) addItemTo(item *itemData) {
 	}
 }
 
+func (parent *itemData) prependItemTo(item *itemData) {
+	item.Parent = parent
+	if item.Theme == nil {
+		item.Theme = parent.Theme
+	}
+	item.setParentWindow(parent.ParentWindow)
+	parent.Contents = append([]*itemData{item}, parent.Contents...)
+	if parent.ItemType == ITEM_FLOW {
+		parent.resizeFlow(parent.GetSize())
+	}
+}
+
 func (parent *windowData) addItemTo(item *itemData) {
 	if item.Theme == nil {
 		item.Theme = parent.Theme
 	}
 	parent.Contents = append(parent.Contents, item)
+	item.setParentWindow(parent)
+	item.resizeFlow(parent.GetSize())
+	parent.markDirty()
+}
+
+func (parent *windowData) prependItemTo(item *itemData) {
+	if item.Theme == nil {
+		item.Theme = parent.Theme
+	}
+	parent.Contents = append([]*itemData{item}, parent.Contents...)
 	item.setParentWindow(parent)
 	item.resizeFlow(parent.GetSize())
 	parent.markDirty()


### PR DESCRIPTION
## Summary
- add PrependItem methods for windows and items to insert children at the start
- support prepending in internal helpers

## Testing
- `go vet ./...`
- `xvfb-run -a go test ./...` *(fails: width snapped to 64; want 50, height snapped to 64; want 50)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cfa268c4c832ab51eaf47441dac5d