### PR TITLE
Refresh inventory display without infinite updates

### DIFF
--- a/game.go
+++ b/game.go
@@ -371,6 +371,11 @@ func (g *Game) Update() error {
 		initGame()
 	})
 
+	if inventoryDirty {
+		updateInventoryWindow()
+		inventoryDirty = false
+	}
+
 	if syncWindowSettings() {
 		settingsDirty = true
 	}

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -44,6 +44,6 @@ func updateInventoryWindow() {
 		changed = true
 	}
 	if changed {
-		inventoryDirty = true
+		inventoryList.Dirty = true
 	}
 }


### PR DESCRIPTION
## Summary
- Update Game.Update to refresh the inventory UI when dirty and reset the flag
- Mark the inventory list itself dirty instead of the global flag

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go run .` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689cfa2c2d34832aa96eaa465f9a401b