### PR TITLE
Disable FPS auto-detection during movie playback

### DIFF
--- a/game.go
+++ b/game.go
@@ -1407,6 +1407,9 @@ func makeGameWindow() {
 }
 
 func noteFrame() {
+	if playingMovie {
+		return
+	}
 	now := time.Now()
 	frameMu.Lock()
 	if !lastFrameTime.IsZero() {


### PR DESCRIPTION
## Summary
- Track when a movie is playing via a package-level `playingMovie` flag
- Skip frame interval tracking while playing movies and sync `frameInterval` when movie FPS changes

## Testing
- `gofmt -w movie_player.go game.go`
- `go vet ./...` *(fails: Xrandr.h, ALSA, gtk+-3.0 not found)*
- `go test ./...` *(fails: missing ALSA, gtk+-3.0, Xrandr.h)*
- `go build ./...` *(fails: missing gtk+-3.0, ALSA, Xrandr.h)*

------
https://chatgpt.com/codex/tasks/task_e_689cfeaceb98832a99a35d97a2a15269