### PR TITLE
Cache static background map tiles for UI access

### DIFF
--- a/map.go
+++ b/map.go
@@ -1,0 +1,12 @@
+package main
+
+// GetMapTiles returns a snapshot of cached map tiles for UI consumption.
+func GetMapTiles() []mapTile {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	tiles := make([]mapTile, 0, len(state.mapTiles))
+	for _, t := range state.mapTiles {
+		tiles = append(tiles, t)
+	}
+	return tiles
+}


### PR DESCRIPTION
## Summary
- track and snapshot background, non-moving pictures as map tiles
- deduplicate and cache map tiles during snapshot capture
- expose `GetMapTiles` for UI layer

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_689d08886a14832ab4fad1bea2b12097