### PR TITLE
Track map adjacency via player offsets

### DIFF
--- a/game.go
+++ b/game.go
@@ -151,6 +151,10 @@ type drawState struct {
 	lightingFlags               uint8
 }
 
+type coord struct {
+	H, V int16
+}
+
 var (
 	state = drawState{
 		descriptors: make(map[uint8]frameDescriptor),
@@ -160,6 +164,11 @@ var (
 	}
 	initialState drawState
 	stateMu      sync.Mutex
+
+	heroPrev      coord
+	heroCur       coord
+	lastAreaID    AreaID
+	lastStateTime time.Time
 )
 
 // bubble stores temporary bubble debug information.
@@ -360,6 +369,37 @@ func computeInterpolation(prevTime, curTime time.Time, mobileRate, pictRate floa
 	return alpha, mobileFade, pictFade
 }
 
+func trackHeroPosition() {
+	snap := captureDrawSnapshot()
+	if snap.curTime == lastStateTime {
+		return
+	}
+	lastStateTime = snap.curTime
+	var hero *frameMobile
+	for i := range snap.mobiles {
+		if snap.mobiles[i].Index == playerIndex {
+			hero = &snap.mobiles[i]
+			break
+		}
+	}
+	if hero == nil {
+		return
+	}
+	heroPrev = heroCur
+	heroCur = coord{H: hero.H, V: hero.V}
+	areaID := backgroundKey(snap.pictures)
+	if lastAreaID == "" {
+		lastAreaID = areaID
+		return
+	}
+	if areaID != lastAreaID {
+		dx := int(heroCur.H) - int(heroPrev.H)
+		dy := int(heroCur.V) - int(heroPrev.V)
+		addAdjacency(lastAreaID, areaID, dx, dy)
+		lastAreaID = areaID
+	}
+}
+
 type Game struct{}
 
 var once sync.Once
@@ -370,6 +410,8 @@ func (g *Game) Update() error {
 	once.Do(func() {
 		initGame()
 	})
+
+	trackHeroPosition()
 
 	if inventoryDirty {
 		updateInventoryWindow()

--- a/map.go
+++ b/map.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type AreaID string
+
+// AreaAdjacency records the offset between two connected areas.
+type AreaAdjacency struct {
+	FromAreaID AreaID
+	ToAreaID   AreaID
+	OffsetX    int
+	OffsetY    int
+}
+
+var (
+	adjMu       sync.Mutex
+	adjacencies []AreaAdjacency
+)
+
+// backgroundKey generates a stable identifier for the current set of
+// background tiles. The key is used as an AreaID.
+func backgroundKey(pics []framePicture) AreaID {
+	ids := make([]string, 0)
+	for _, p := range pics {
+		if p.Background {
+			ids = append(ids, fmt.Sprintf("%d@%d,%d", p.PictID, p.H, p.V))
+		}
+	}
+	sort.Strings(ids)
+	return AreaID(strings.Join(ids, "|"))
+}
+
+// addAdjacency records an offset between two areas.
+func addAdjacency(from, to AreaID, dx, dy int) {
+	if from == "" || to == "" || from == to {
+		return
+	}
+	adjMu.Lock()
+	defer adjMu.Unlock()
+	for _, a := range adjacencies {
+		if a.FromAreaID == from && a.ToAreaID == to {
+			return
+		}
+	}
+	adjacencies = append(adjacencies, AreaAdjacency{
+		FromAreaID: from,
+		ToAreaID:   to,
+		OffsetX:    dx,
+		OffsetY:    dy,
+	})
+}


### PR DESCRIPTION
## Summary
- track local hero frameMobile before and after each state update
- detect background tile set changes and record area offsets
- add map adjacency storage for later map assembly

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw X11 DISPLAY missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d08832b74832aa23f801ef7ccb124