### PR TITLE
Fix new picture sliding when smoothMoving disabled

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -723,13 +723,11 @@ func parseDrawState(data []byte) error {
 		newPics[i].Again = false
 	}
 	dx, dy, bgIdxs, ok := pictureShift(prevPics, newPics)
-	if gs.MotionSmoothing {
-		if gs.smoothMoving {
-			logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)
-			if !ok {
-				logDebug("prev pics: %v", picturesSummary(prevPics))
-				logDebug("new  pics: %v", picturesSummary(newPics))
-			}
+	if gs.MotionSmoothing && gs.smoothMoving {
+		logDebug("interp pictures again=%d prev=%d cur=%d shift=(%d,%d) ok=%t", again, len(prevPics), len(newPics), dx, dy, ok)
+		if !ok {
+			logDebug("prev pics: %v", picturesSummary(prevPics))
+			logDebug("new  pics: %v", picturesSummary(newPics))
 		}
 		if ok {
 			state.picShiftX = dx


### PR DESCRIPTION
## Summary
- compute picture shift only when smoothMoving is enabled to prevent newly received pictures from sliding in unexpectedly

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d0c3094f4832aa043251af9dd1dfe