### PR TITLE
Initialize map tiles map when parsing movie

### DIFF
--- a/movie.go
+++ b/movie.go
@@ -51,6 +51,7 @@ func parseMovie(path string, clientVersion int) ([][]byte, error) {
 		mobiles:     make(map[uint8]frameMobile),
 		prevMobiles: make(map[uint8]frameMobile),
 		prevDescs:   make(map[uint8]frameDescriptor),
+		mapTiles:    make(map[mapTileKey]mapTile),
 	}
 	initialState = cloneDrawState(state)
 	stateMu.Unlock()


### PR DESCRIPTION
## Summary
- ensure `state.mapTiles` is allocated when resetting draw state during movie parsing to prevent nil map panic

## Testing
- `go vet ./...`
- `go build`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d0d026300832aa8698e0d044ee297