### PR TITLE
Offset new sprites when smoothing disabled

### DIFF
--- a/game.go
+++ b/game.go
@@ -1015,8 +1015,15 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 	offX := float64(int(p.PrevH)-int(p.H)) * (1 - alpha)
 	offY := float64(int(p.PrevV)-int(p.V)) * (1 - alpha)
 	if p.Moving && !gs.smoothMoving {
-		offX = 0
-		offY = 0
+		if int(p.PrevH) == int(p.H)-shiftX && int(p.PrevV) == int(p.V)-shiftY {
+			if gs.dontShiftNewSprites {
+				offX = 0
+				offY = 0
+			}
+		} else {
+			offX = 0
+			offY = 0
+		}
 	}
 
 	frame := 0

--- a/settings.go
+++ b/settings.go
@@ -58,20 +58,21 @@ var gsdef settings = settings{
 	MessagesWindow:  WindowState{Open: true},
 	ChatWindow:      WindowState{Open: true},
 
-	imgPlanesDebug:   false,
-	smoothingDebug:   false,
-	pictAgainDebug:   false,
-	hideMoving:       false,
-	hideMobiles:      false,
-	vsync:            true,
-	nightEffect:      true,
-	precacheSounds:   false,
-	precacheImages:   false,
-	lateInputUpdates: false,
-	cacheWholeSheet:  true,
-	smoothMoving:     false,
-	fastBars:         true,
-	recordAssetStats: false,
+	imgPlanesDebug:      false,
+	smoothingDebug:      false,
+	pictAgainDebug:      false,
+	hideMoving:          false,
+	hideMobiles:         false,
+	vsync:               true,
+	nightEffect:         true,
+	precacheSounds:      false,
+	precacheImages:      false,
+	lateInputUpdates:    false,
+	cacheWholeSheet:     true,
+	smoothMoving:        false,
+	dontShiftNewSprites: false,
+	fastBars:            true,
+	recordAssetStats:    false,
 }
 
 type settings struct {
@@ -116,22 +117,23 @@ type settings struct {
 	MessagesWindow  WindowState
 	ChatWindow      WindowState
 
-	imgPlanesDebug   bool
-	smoothingDebug   bool
-	pictAgainDebug   bool
-	hideMoving       bool
-	hideMobiles      bool
-	vsync            bool
-	nightEffect      bool
-	precacheSounds   bool
-	precacheImages   bool
-	lateInputUpdates bool
-	cacheWholeSheet  bool
-	smoothMoving     bool
-	fastBars         bool
-	recordAssetStats bool
-	NoCaching        bool
-	PotatoComputer   bool
+	imgPlanesDebug      bool
+	smoothingDebug      bool
+	pictAgainDebug      bool
+	hideMoving          bool
+	hideMobiles         bool
+	vsync               bool
+	nightEffect         bool
+	precacheSounds      bool
+	precacheImages      bool
+	lateInputUpdates    bool
+	cacheWholeSheet     bool
+	smoothMoving        bool
+	dontShiftNewSprites bool
+	fastBars            bool
+	recordAssetStats    bool
+	NoCaching           bool
+	PotatoComputer      bool
 }
 
 var (

--- a/ui.go
+++ b/ui.go
@@ -1556,6 +1556,17 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(pictAgainCB)
+	shiftSpriteCB, shiftSpriteEvents := eui.NewCheckbox()
+	shiftSpriteCB.Text = "Don't shift new sprites"
+	shiftSpriteCB.Size = eui.Point{X: width, Y: 24}
+	shiftSpriteCB.Checked = gs.dontShiftNewSprites
+	shiftSpriteEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.dontShiftNewSprites = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(shiftSpriteCB)
 	cacheLabel, _ := eui.NewText()
 	cacheLabel.Text = "Caches:"
 	cacheLabel.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- Offset newly created sprites by pictShift when smoothing is off
- Add debug toggle "Don't shift new sprites"

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d103ace48832a81f3b860d290148c