### PR TITLE
Add picture ID debug overlay

### DIFF
--- a/game.go
+++ b/game.go
@@ -1127,6 +1127,17 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		}
 		screen.DrawImage(src, op)
 
+		if gs.pictIDDebug {
+			metrics := mainFont.Metrics()
+			lbl := fmt.Sprintf("%d", p.PictID)
+			txtW, _ := text.Measure(lbl, mainFont, 0)
+			xPos := x + int(float64(w)*gs.GameScale/2) - int(math.Round(txtW))
+			opTxt := &text.DrawOptions{}
+			opTxt.GeoM.Translate(float64(xPos), float64(y)-float64(h)*gs.GameScale/2-metrics.HAscent)
+			opTxt.ColorScale.ScaleWithColor(color.White)
+			text.Draw(screen, lbl, mainFont, opTxt)
+		}
+
 		if gs.imgPlanesDebug {
 			metrics := mainFont.Metrics()
 			lbl := fmt.Sprintf("%dp", plane)
@@ -1149,6 +1160,16 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 			clr = color.RGBA{0, 0, 0xff, 0xff}
 		}
 		vector.DrawFilledRect(screen, float32(float64(x)-2*gs.GameScale), float32(float64(y)-2*gs.GameScale), float32(4*gs.GameScale), float32(4*gs.GameScale), clr, false)
+		if gs.pictIDDebug {
+			metrics := mainFont.Metrics()
+			lbl := fmt.Sprintf("%d", p.PictID)
+			txtW, _ := text.Measure(lbl, mainFont, 0)
+			xPos := x + half - int(math.Round(txtW))
+			opTxt := &text.DrawOptions{}
+			opTxt.GeoM.Translate(float64(xPos), float64(y)-float64(half)-metrics.HAscent)
+			opTxt.ColorScale.ScaleWithColor(color.White)
+			text.Draw(screen, lbl, mainFont, opTxt)
+		}
 		if gs.imgPlanesDebug {
 			metrics := mainFont.Metrics()
 			lbl := fmt.Sprintf("%dp", plane)

--- a/settings.go
+++ b/settings.go
@@ -61,6 +61,7 @@ var gsdef settings = settings{
 	imgPlanesDebug:      false,
 	smoothingDebug:      false,
 	pictAgainDebug:      false,
+	pictIDDebug:         false,
 	hideMoving:          false,
 	hideMobiles:         false,
 	vsync:               true,
@@ -120,6 +121,7 @@ type settings struct {
 	imgPlanesDebug      bool
 	smoothingDebug      bool
 	pictAgainDebug      bool
+	pictIDDebug         bool
 	hideMoving          bool
 	hideMobiles         bool
 	vsync               bool

--- a/ui.go
+++ b/ui.go
@@ -1534,6 +1534,20 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(planesCB)
+
+	pictIDCB, pictIDEvents := eui.NewCheckbox()
+	pictIDCB.Text = "Show picture IDs"
+	pictIDCB.Tooltip = "Shows picture ID on each sprite"
+	pictIDCB.Size = eui.Point{X: width, Y: 24}
+	pictIDCB.Checked = gs.pictIDDebug
+	pictIDEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.pictIDDebug = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(pictIDCB)
+
 	smoothinCB, smoothinEvents := eui.NewCheckbox()
 	smoothinCB.Text = "Tint moving objects red"
 	smoothinCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- add `Show picture IDs` debug setting
- draw picture IDs in top-right corner when enabled

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e508200832abf322bdc2c4e294c