### PR TITLE
Allow lenient IMA4 length check for historical assets

### DIFF
--- a/clsnd/clsnd.go
+++ b/clsnd/clsnd.go
@@ -251,11 +251,11 @@ func decodeHeader(data []byte, hdr int, id uint32) (*Sound, error) {
 			expected := frames * int(chans) * (int(bits) / 8)
 			if len(pcm) != expected {
 				if id != 0 {
-					log.Printf("sound %d: ima4 decoded %d bytes, expected %d", id, len(pcm), expected)
+					log.Printf("sound %d: ima4 decoded %d bytes, expected %d; continuing", id, len(pcm), expected)
 				} else {
-					log.Printf("ima4 decoded %d bytes, expected %d", len(pcm), expected)
+					log.Printf("ima4 decoded %d bytes, expected %d; continuing", len(pcm), expected)
 				}
-				return nil, fmt.Errorf("ima4 length mismatch: have %d bytes, expected %d", len(pcm), expected)
+				// Intentionally lenient: historical assets sometimes report incorrect lengths.
 			}
 			s := &Sound{
 				Data:       pcm,


### PR DESCRIPTION
## Summary
- relax IMA4 ADPCM length check to log a warning and continue decoding
- note why mismatched lengths are accepted for old assets

## Testing
- `go vet -v ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d2a9ff14c832a9161690eebd10891