### PR TITLE
Use picture shift for predictive tracking regardless of smoothing

### DIFF
--- a/movie.go
+++ b/movie.go
@@ -51,6 +51,7 @@ func parseMovie(path string, clientVersion int) ([][]byte, error) {
 		mobiles:     make(map[uint8]frameMobile),
 		prevMobiles: make(map[uint8]frameMobile),
 		prevDescs:   make(map[uint8]frameDescriptor),
+		tracks:      make(map[int]*pictureTrack),
 	}
 	initialState = cloneDrawState(state)
 	stateMu.Unlock()

--- a/settings.go
+++ b/settings.go
@@ -58,22 +58,24 @@ var gsdef settings = settings{
 	MessagesWindow:  WindowState{Open: true},
 	ChatWindow:      WindowState{Open: true},
 
-	imgPlanesDebug:      false,
-	smoothingDebug:      false,
-	pictAgainDebug:      false,
-	pictIDDebug:         false,
-	hideMoving:          false,
-	hideMobiles:         false,
-	vsync:               true,
-	nightEffect:         true,
-	precacheSounds:      false,
-	precacheImages:      false,
-	lateInputUpdates:    false,
-	cacheWholeSheet:     true,
-	smoothMoving:        false,
-	dontShiftNewSprites: false,
-	fastBars:            true,
-	recordAssetStats:    false,
+	imgPlanesDebug:        false,
+	smoothingDebug:        false,
+	pictAgainDebug:        false,
+	pictIDDebug:           false,
+	pictHistoryDebug:      false,
+	hideMoving:            false,
+	hideMobiles:           false,
+	vsync:                 true,
+	nightEffect:           true,
+	precacheSounds:        false,
+	precacheImages:        false,
+	lateInputUpdates:      false,
+	cacheWholeSheet:       true,
+	smoothMoving:          false,
+	dontShiftNewSprites:   false,
+	simplePredictiveMatch: false,
+	fastBars:              true,
+	recordAssetStats:      false,
 }
 
 type settings struct {
@@ -118,24 +120,26 @@ type settings struct {
 	MessagesWindow  WindowState
 	ChatWindow      WindowState
 
-	imgPlanesDebug      bool
-	smoothingDebug      bool
-	pictAgainDebug      bool
-	pictIDDebug         bool
-	hideMoving          bool
-	hideMobiles         bool
-	vsync               bool
-	nightEffect         bool
-	precacheSounds      bool
-	precacheImages      bool
-	lateInputUpdates    bool
-	cacheWholeSheet     bool
-	smoothMoving        bool
-	dontShiftNewSprites bool
-	fastBars            bool
-	recordAssetStats    bool
-	NoCaching           bool
-	PotatoComputer      bool
+	imgPlanesDebug        bool
+	smoothingDebug        bool
+	pictAgainDebug        bool
+	pictIDDebug           bool
+	pictHistoryDebug      bool
+	hideMoving            bool
+	hideMobiles           bool
+	vsync                 bool
+	nightEffect           bool
+	precacheSounds        bool
+	precacheImages        bool
+	lateInputUpdates      bool
+	cacheWholeSheet       bool
+	smoothMoving          bool
+	dontShiftNewSprites   bool
+	simplePredictiveMatch bool
+	fastBars              bool
+	recordAssetStats      bool
+	NoCaching             bool
+	PotatoComputer        bool
 }
 
 var (

--- a/ui.go
+++ b/ui.go
@@ -1581,6 +1581,31 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(shiftSpriteCB)
+
+	simplePredCB, simplePredEvents := eui.NewCheckbox()
+	simplePredCB.Text = "Simple predictive matching"
+	simplePredCB.Size = eui.Point{X: width, Y: 24}
+	simplePredCB.Checked = gs.simplePredictiveMatch
+	simplePredEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.simplePredictiveMatch = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(simplePredCB)
+
+	pictHistCB, pictHistEvents := eui.NewCheckbox()
+	pictHistCB.Text = "Show picture history"
+	pictHistCB.Size = eui.Point{X: width, Y: 24}
+	pictHistCB.Checked = gs.pictHistoryDebug
+	pictHistEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.pictHistoryDebug = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(pictHistCB)
+
 	cacheLabel, _ := eui.NewText()
 	cacheLabel.Text = "Caches:"
 	cacheLabel.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- capture pictureShift offsets even when motion smoothing is disabled so predictive tracking can clear stale tracks and choose the nearest sprite by picture ID

## Testing
- ⚠️ `go vet ./...` (missing Xrandr, ALSA, and GTK development headers)
- ⚠️ `go build ./...` (missing Xrandr, ALSA, and GTK development headers)
- ⚠️ `go test ./...` (missing Xrandr, ALSA, and GTK development headers)


------
https://chatgpt.com/codex/tasks/task_e_689d2a321514832a875d96310aa7591a