### PR TITLE
Add option to shift only border sprites

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -771,12 +771,28 @@ func parseDrawState(data []byte) error {
 		prevPics[i].Owned = false
 	}
 	for i := range newPics {
+		needsShift := true
 		if _, skip := skipPictShift[newPics[i].PictID]; skip {
-			newPics[i].PrevH = newPics[i].H
-			newPics[i].PrevV = newPics[i].V
-		} else {
+			needsShift = false
+		} else if gs.shiftBorderSpritesOnly {
+			if clImages != nil {
+				w, h := clImages.Size(uint32(newPics[i].PictID))
+				halfW := w / 2
+				halfH := h / 2
+				if int(newPics[i].H)-halfW >= -fieldCenterX &&
+					int(newPics[i].H)+halfW <= fieldCenterX &&
+					int(newPics[i].V)-halfH >= -fieldCenterY &&
+					int(newPics[i].V)+halfH <= fieldCenterY {
+					needsShift = false
+				}
+			}
+		}
+		if needsShift {
 			newPics[i].PrevH = int16(int(newPics[i].H) - state.picShiftX)
 			newPics[i].PrevV = int16(int(newPics[i].V) - state.picShiftY)
+		} else {
+			newPics[i].PrevH = newPics[i].H
+			newPics[i].PrevV = newPics[i].V
 		}
 		moving := true
 		var owner *framePicture

--- a/settings.go
+++ b/settings.go
@@ -58,22 +58,23 @@ var gsdef settings = settings{
 	MessagesWindow:  WindowState{Open: true},
 	ChatWindow:      WindowState{Open: true},
 
-	imgPlanesDebug:      false,
-	smoothingDebug:      false,
-	pictAgainDebug:      false,
-	pictIDDebug:         false,
-	hideMoving:          false,
-	hideMobiles:         false,
-	vsync:               true,
-	nightEffect:         true,
-	precacheSounds:      false,
-	precacheImages:      false,
-	lateInputUpdates:    false,
-	cacheWholeSheet:     true,
-	smoothMoving:        false,
-	dontShiftNewSprites: false,
-	fastBars:            true,
-	recordAssetStats:    false,
+	imgPlanesDebug:         false,
+	smoothingDebug:         false,
+	pictAgainDebug:         false,
+	pictIDDebug:            false,
+	hideMoving:             false,
+	hideMobiles:            false,
+	vsync:                  true,
+	nightEffect:            true,
+	precacheSounds:         false,
+	precacheImages:         false,
+	lateInputUpdates:       false,
+	cacheWholeSheet:        true,
+	smoothMoving:           false,
+	dontShiftNewSprites:    false,
+	shiftBorderSpritesOnly: false,
+	fastBars:               true,
+	recordAssetStats:       false,
 }
 
 type settings struct {
@@ -118,24 +119,25 @@ type settings struct {
 	MessagesWindow  WindowState
 	ChatWindow      WindowState
 
-	imgPlanesDebug      bool
-	smoothingDebug      bool
-	pictAgainDebug      bool
-	pictIDDebug         bool
-	hideMoving          bool
-	hideMobiles         bool
-	vsync               bool
-	nightEffect         bool
-	precacheSounds      bool
-	precacheImages      bool
-	lateInputUpdates    bool
-	cacheWholeSheet     bool
-	smoothMoving        bool
-	dontShiftNewSprites bool
-	fastBars            bool
-	recordAssetStats    bool
-	NoCaching           bool
-	PotatoComputer      bool
+	imgPlanesDebug         bool
+	smoothingDebug         bool
+	pictAgainDebug         bool
+	pictIDDebug            bool
+	hideMoving             bool
+	hideMobiles            bool
+	vsync                  bool
+	nightEffect            bool
+	precacheSounds         bool
+	precacheImages         bool
+	lateInputUpdates       bool
+	cacheWholeSheet        bool
+	smoothMoving           bool
+	dontShiftNewSprites    bool
+	shiftBorderSpritesOnly bool
+	fastBars               bool
+	recordAssetStats       bool
+	NoCaching              bool
+	PotatoComputer         bool
 }
 
 var (

--- a/ui.go
+++ b/ui.go
@@ -1581,6 +1581,18 @@ func makeDebugWindow() {
 		}
 	}
 	debugFlow.AddItem(shiftSpriteCB)
+
+	borderShiftCB, borderShiftEvents := eui.NewCheckbox()
+	borderShiftCB.Text = "Only shift border sprites"
+	borderShiftCB.Size = eui.Point{X: width, Y: 24}
+	borderShiftCB.Checked = gs.shiftBorderSpritesOnly
+	borderShiftEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.shiftBorderSpritesOnly = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(borderShiftCB)
 	cacheLabel, _ := eui.NewText()
 	cacheLabel.Text = "Caches:"
 	cacheLabel.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- allow pictShift only for new sprites crossing the game area border
- expose border-only shift as a debug checkbox

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_689d47f44734832aa93d4fbb38040f8f