### PR TITLE
Disable curtain during zoom and center view

### DIFF
--- a/game.go
+++ b/game.go
@@ -645,8 +645,9 @@ func gameContentOrigin() (int, int) {
 	pad := float64(2 * gameWin.Padding)
 	w := float64(int(size.X)&^1) - pad
 	h := float64(int(size.Y)&^1) - pad
-	fw := float64(gameAreaSizeX) * gs.GameScale
-	fh := float64(gameAreaSizeY) * gs.GameScale
+	scale := viewScale()
+	fw := float64(gameAreaSizeX) * scale
+	fh := float64(gameAreaSizeY) * scale
 	if w > fw {
 		x += int(math.Round((w - fw) / 2))
 	}
@@ -1239,6 +1240,9 @@ func lerpBar(prev, cur int, alpha float64) int {
 }
 
 func drawGameCurtain(screen *ebiten.Image, ox, oy int) {
+	if gs.ZoomEnabled {
+		return
+	}
 	scale := viewScale()
 	w := int(math.Round(float64(gameAreaSizeX) * scale))
 	h := int(math.Round(float64(gameAreaSizeY) * scale))


### PR DESCRIPTION
## Summary
- Skip drawing the game curtain when scroll wheel zoom is enabled
- Center the game view using the effective zoom scale

## Testing
- `go fmt game.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d4dac8904832a82106afbbffbcb2f