### PR TITLE
Apply pictShift to legacy backgrounds

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -55,9 +55,11 @@ const (
 	maxBubbles     = 128
 )
 
-var skipPictShift = map[uint16]struct{}{
-	3037: {},
-}
+// skipPictShift lists picture IDs that should be ignored when
+// calculating the common motion between frames. Historically this
+// excluded some background images, but older backgrounds still require
+// pictShift so the list is currently empty.
+var skipPictShift = map[uint16]struct{}{}
 
 func sortPictures(pics []framePicture) {
 	sort.Slice(pics, func(i, j int) bool {


### PR DESCRIPTION
## Summary
- ensure picture shift runs for older background images by clearing skip list

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d698efbc8832aaa9f946698bc9b43