### PR TITLE
Use name lookup for inventory items

### DIFF
--- a/item_names.go
+++ b/item_names.go
@@ -1,0 +1,8 @@
+package main
+
+// defaultInventoryNames maps item IDs to fallback names. This can be
+// extended with known items so inventories have meaningful labels before
+// any rename commands are received.
+var defaultInventoryNames = map[uint16]string{
+	// Example: 1001: "Short Sword",
+}


### PR DESCRIPTION
## Summary
- Track inventory item names by ID and fall back to default lookup
- Populate inventory with proper names instead of placeholders
- Keep name map in sync on add and rename commands

## Testing
- `gofmt -w inventory.go item_names.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da6704c64832ab0a5175192f35e13