### PR TITLE
Track inventory quantities

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"gothoom/eui"
 )
 
@@ -20,6 +21,9 @@ func updateInventoryWindow() {
 		text := it.Name
 		if it.Equipped {
 			text = "* " + text
+		}
+		if it.Quantity > 1 {
+			text = fmt.Sprintf("%s (%d)", text, it.Quantity)
 		}
 		if i < len(inventoryList.Contents) {
 			if inventoryList.Contents[i].Text != text {


### PR DESCRIPTION
## Summary
- Add Quantity field to inventory items and manage counts on add/remove
- Aggregate duplicates in full inventory updates
- Show item counts in inventory window when greater than one

## Testing
- `gofmt -w inventory.go inventory_ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689dbf8a2094832a876eafcc4bf83441