### PR TITLE
Handle unknown BEPP prefixes

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -114,10 +114,15 @@ func decodeBEPP(data []byte) string {
 		}
 	case "be":
 		parseBackend(textBytes)
+		return ""
 	case "yk":
 		if text != "" {
 			return text
 		}
+	}
+	if text != "" {
+		logDebug("unknown BEPP prefix %q: %q", prefix, text)
+		return text
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- return BEPP message text for unknown prefixes instead of discarding
- log unexpected BEPP prefixes to help detect server changes
- continue hiding backend BEPP messages

## Testing
- `gofmt -w decode.go`
- `go vet ./...` *(fails: command produced no output and required manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_689dcf7354b8832a85bd5bf053e4f186