### PR TITLE
Handle additional BEPP prefixes

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -114,15 +114,7 @@ func decodeBEPP(data []byte) string {
 		}
 	case "be":
 		parseBackend(textBytes)
-	case "yk":
-		if text != "" {
-			return text
-		}
-	case "iv":
-		if text != "" {
-			return text
-		}
-	case "hp":
+	case "yk", "iv", "hp", "cf", "pn":
 		if text != "" {
 			return text
 		}


### PR DESCRIPTION
## Summary
- decode BEPP messages prefixed with hp, iv, cf, and pn

## Testing
- `go fmt decode.go`
- `go vet ./...` *(fails: gtk+-3.0, alsa, Xrandr.h missing)*
- `strings reference-client.pcapng | rg 'hp' | head`
- `strings reference-client.pcapng | rg 'iv' | head`
- `strings reference-client.pcapng | rg 'cf' | head`
- `strings reference-client.pcapng | rg 'pn' | head`


------
https://chatgpt.com/codex/tasks/task_e_689dd10c7bb4832a9edb93365dc1cab1