### PR TITLE
Decode inventory names with MacRoman decoding

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -438,7 +438,7 @@ func handleInvCmdOther(cmd int, data []byte) ([]byte, bool) {
 			logError("inventory: cmd %x missing name", cmd)
 			return nil, false
 		}
-		name = string(data[:nidx])
+		name = decodeMacRoman(data[:nidx])
 		data = data[nidx+1:]
 	}
 	switch base {

--- a/inventory_packets_test.go
+++ b/inventory_packets_test.go
@@ -57,6 +57,31 @@ func TestParseInventoryOther(t *testing.T) {
 	}
 }
 
+func TestParseInventoryMacRomanName(t *testing.T) {
+	resetInventory()
+	inventoryDirty = false
+	nameBytes := []byte{'M', 0x8e, 'm', 'e'}
+	data := []byte{
+		byte(kInvCmdAdd | kInvCmdIndex), 0x00, 0x64, 0,
+	}
+	data = append(data, nameBytes...)
+	data = append(data, 0, byte(kInvCmdNone), 0x55)
+	rest, ok := parseInventory(data)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if len(rest) != 1 || rest[0] != 0x55 {
+		t.Fatalf("unexpected rest %v", rest)
+	}
+	inv := getInventory()
+	if len(inv) != 1 || inv[0].Name != decodeMacRoman(nameBytes) {
+		t.Fatalf("unexpected inventory %v", inv)
+	}
+	if !inventoryDirty {
+		t.Fatalf("inventoryDirty not set")
+	}
+}
+
 func TestParseInventoryTrailingB1(t *testing.T) {
 	resetInventory()
 	inventoryDirty = false


### PR DESCRIPTION
## Summary
- Decode item names in inventory commands using `decodeMacRoman`
- Test inventory parsing with MacRoman-encoded item names

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11 extensions and gtk+-3.0 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b12160c832a95a2c0e2f555ab68