### PR TITLE
Wait for game start before opening PCAP

### DIFF
--- a/pcap.go
+++ b/pcap.go
@@ -14,6 +14,15 @@ import (
 )
 
 func replayPCAP(ctx context.Context, path string) error {
+	// Ebiten must be running before ReadPixels is invoked, so wait for the game
+	// to start before opening the PCAP. Propagate context cancellation so that
+	// shutdown does not deadlock while waiting.
+	select {
+	case <-gameStarted:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- block replayPCAP until the game has started
- allow context cancellation while waiting for game start
- add comment about Ebiten needing to run before ReadPixels

## Testing
- `gofmt -w pcap.go`
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; X11/extensions/Xrandr.h: No such file or directory; Package gtk+-3.0 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_689e0ecc54a0832aa167e1cad2ef675a