### PR TITLE
Handle undocumented inventory opcode

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -511,6 +511,10 @@ func parseInventory(data []byte) ([]byte, bool) {
 			cmd = kInvCmdNone
 		}
 	}
+	// After processing known commands a single trailing opcode may remain.
+	// Some captures include an undocumented 0x64 ('d') value.  Treat it as
+	// padding and ignore any other unknown values while logging at debug
+	// level to aid future reverse-engineering efforts.
 	switch cmd {
 	case kInvCmdNone:
 	case kInvCmdNone | kInvCmdIndex:
@@ -520,8 +524,11 @@ func parseInventory(data []byte) ([]byte, bool) {
 		data = data[1:]
 	case kInvCmdLegacyPadding:
 		// ignore legacy padding byte
+	case 'd':
+		// observed but undocumented opcode
+		logDebug("inventory: ignoring opcode 'd'")
 	default:
-		logError("inventory: unexpected trailing cmd %d", cmd)
+		logDebug("inventory: ignoring trailing cmd %d", cmd)
 	}
 	for len(data) > 0 && (data[0] == 0 || data[0] == kInvCmdLegacyPadding) {
 		data = data[1:]

--- a/inventory_packets_test.go
+++ b/inventory_packets_test.go
@@ -100,3 +100,22 @@ func TestParseInventoryTrailingB1(t *testing.T) {
 		t.Fatalf("inventoryDirty not set")
 	}
 }
+
+func TestParseInventoryTrailingD(t *testing.T) {
+	resetInventory()
+	inventoryDirty = false
+	data := []byte{
+		byte(kInvCmdFull), 1, 0x00, 0x00, 0x64,
+		'd', byte(kInvCmdNone), 0x55,
+	}
+	rest, ok := parseInventory(data)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if len(rest) != 1 || rest[0] != 0x55 {
+		t.Fatalf("unexpected rest %v", rest)
+	}
+	if !inventoryDirty {
+		t.Fatalf("inventoryDirty not set")
+	}
+}


### PR DESCRIPTION
## Summary
- ignore undocumented inventory opcode `0x64` ('d') and log unknown trailing opcodes at debug level
- add unit test covering trailing `0x64` inventory opcode

## Testing
- `gofmt -w draw.go inventory_packets_test.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e10f4b928832abb84d14068f475e4