### PR TITLE
refactor server message handling

### DIFF
--- a/game.go
+++ b/game.go
@@ -1597,16 +1597,7 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			lastInputSent = time.Time{}
 		}
 		latencyMu.Unlock()
-		if tag == 2 { // kMsgDrawState
-			noteFrame()
-			handleDrawState(m)
-			continue
-		}
-		if txt := decodeMessage(m); txt != "" {
-			consoleMessage("udpReadLoop: decodeMessage: " + txt)
-		} else {
-			logDebug("udp msg tag %d len %d", tag, len(m))
-		}
+		processServerMessage(m)
 	}
 }
 
@@ -1671,17 +1662,7 @@ loop:
 				}
 			}
 		}
-		if tag == 2 { // kMsgDrawState
-			noteFrame()
-			handleDrawState(m)
-			continue
-		}
-		if txt := decodeMessage(m); txt != "" {
-			//fmt.Println(txt)
-			consoleMessage("tcpReadLoop: decodeMessage: " + txt)
-		} else {
-			logDebug("msg tag %d len %d", tag, len(m))
-		}
+		processServerMessage(m)
 		select {
 		case <-ctx.Done():
 			break loop

--- a/pcap.go
+++ b/pcap.go
@@ -141,15 +141,5 @@ func (s *pcapStream) Reassembled(rs []tcpassembly.Reassembly) {
 func (s *pcapStream) ReassemblyComplete() {}
 
 func dispatchMessage(msg []byte) {
-	if len(msg) < 2 {
-		return
-	}
-	tag := binary.BigEndian.Uint16(msg[:2])
-	if tag == 2 {
-		handleDrawState(msg)
-		return
-	}
-	if txt := decodeMessage(msg); txt != "" {
-		consoleMessage("pcap: " + txt)
-	}
+	processServerMessage(msg)
 }


### PR DESCRIPTION
## Summary
- centralize server message tag dispatching in new `processServerMessage`
- use helper in UDP/TCP read loops so draw-state and other messages share logic
- ensure PCAP replay routes messages through the same handler for consistent side effects

## Testing
- `gofmt -w network.go game.go pcap.go`
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; Xrandr.h missing)*
- `go run . -pcap reference-client.pcapng` *(fails: Package alsa was not found in the pkg-config search path; gtk+-3.0 and Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c9a256c832aa5a5731cc5620e4c