### PR TITLE
Handle nil inventory list entries

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -29,7 +29,16 @@ func updateInventoryWindow() {
 			text = fmt.Sprintf("%s (%d)", text, it.Quantity)
 		}
 		if i < len(inventoryList.Contents) {
-			if inventoryList.Contents[i].Text != text {
+			if inventoryList.Contents[i] == nil {
+				t, _ := eui.NewText()
+				t.Text = text
+				t.Size = eui.Point{X: 256, Y: 24}
+				t.FontSize = 10
+				inventoryList.AddItem(t)
+				inventoryList.Contents[i] = t
+				inventoryList.Dirty = true
+				changed = true
+			} else if inventoryList.Contents[i].Text != text {
 				inventoryList.Contents[i].Text = text
 				changed = true
 			}


### PR DESCRIPTION
## Summary
- guard against nil `inventoryList` entries before updating text
- build a replacement text item when a slot is nil and mark the list dirty

## Testing
- `gofmt -w inventory_ui.go`
- `go vet ./...` *(fails: Package 'gtk+-3.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2526348c832a839cac9983a44d12