### PR TITLE
Handle undocumented inventory opcode

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -419,6 +419,11 @@ func handleInvCmdOther(cmd int, data []byte) ([]byte, bool) {
 	defer updateInventoryWindow()
 
 	base := cmd &^ kInvCmdIndex
+	switch base {
+	case 'd':
+		logDebug("inventory: ignoring opcode 'd'")
+		return data, true
+	}
 	if len(data) < 2 {
 		logError("inventory: cmd %x missing id", cmd)
 		return nil, false


### PR DESCRIPTION
## Summary
- ignore undocumented inventory opcode 'd' in inventory command handler
- add test verifying mid-stream 'd' opcodes are skipped without errors

## Testing
- `gofmt -w draw.go inventory_packets_test.go`
- `go vet ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h: No such file or directory; Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2d306474832abe551e1a9ef3a2bc