### PR TITLE
Fix layout scaling for overlays and game window

### DIFF
--- a/eui/zones.go
+++ b/eui/zones.go
@@ -60,11 +60,12 @@ func (win *windowData) updateZonePosition() {
 	cx := hZoneCoord(win.zone.h, screenWidth)
 	cy := vZoneCoord(win.zone.v, screenHeight)
 	size := win.GetSize()
-	win.Position.X = (cx - size.X/2) / uiScale
-	win.Position.Y = (cy - size.Y/2) / uiScale
+	s := win.scale()
+	win.Position.X = (cx - size.X/2) / s
+	win.Position.Y = (cy - size.Y/2) / s
 
-	maxX := (float32(screenWidth) - size.X) / uiScale
-	maxY := (float32(screenHeight) - size.Y) / uiScale
+	maxX := (float32(screenWidth) - size.X) / s
+	maxY := (float32(screenHeight) - size.Y) / s
 	if maxX < 0 {
 		maxX = 0
 	}

--- a/game.go
+++ b/game.go
@@ -84,6 +84,9 @@ func updateGameImageSize() {
 		uis = 1
 	}
 	inv := 1 / uis
+	if gameWin != nil && gameWin.NoScale {
+		inv = 1
+	}
 
 	if gameImageItem == nil {
 		it, img := eui.NewImageItem(w, h)

--- a/game.go
+++ b/game.go
@@ -79,14 +79,19 @@ func updateGameImageSize() {
 	if w <= 0 || h <= 0 {
 		return
 	}
+	uis := eui.UIScale()
+	if uis <= 0 {
+		uis = 1
+	}
+	inv := 1 / uis
+
 	if gameImageItem == nil {
 		it, img := eui.NewImageItem(w, h)
 		gameImageItem = it
 		gameImage = img
-		gameImageItem.Position = eui.Point{X: 2, Y: 2}
 		gameWin.AddItem(gameImageItem)
-		return
 	}
+
 	// Resize backing image only when dimensions change
 	iw, ih := 0, 0
 	if gameImage != nil {
@@ -96,8 +101,16 @@ func updateGameImageSize() {
 	if iw != w || ih != h {
 		gameImage = ebiten.NewImage(w, h)
 		gameImageItem.Image = gameImage
-		gameImageItem.Size = eui.Point{X: float32(w), Y: float32(h)}
-		gameImageItem.Position = eui.Point{X: 2, Y: 2}
+		if gameWin != nil {
+			gameWin.Dirty = true
+		}
+	}
+
+	newSize := eui.Point{X: float32(w) * inv, Y: float32(h) * inv}
+	newPos := eui.Point{X: 2 * inv, Y: 2 * inv}
+	if gameImageItem.Size != newSize || gameImageItem.Position != newPos {
+		gameImageItem.Size = newSize
+		gameImageItem.Position = newPos
 		if gameWin != nil {
 			gameWin.Dirty = true
 		}

--- a/game.go
+++ b/game.go
@@ -1599,8 +1599,7 @@ func drawEquippedItems(screen *ebiten.Image, ox, oy int) {
 
 // drawInputOverlay renders the text entry box when chatting.
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
-	eui.Layout(outsideWidth, outsideHeight)
-	return outsideWidth, outsideHeight
+	return eui.Layout(outsideWidth, outsideHeight)
 }
 
 func runGame(ctx context.Context) {

--- a/ui.go
+++ b/ui.go
@@ -172,7 +172,6 @@ func makeToolbarWindow() {
 	toolbarWin.AutoSize = false
 	toolbarWin.ShowDragbar = false
 	toolbarWin.Movable = true
-	toolbarWin.NoScale = true
 	toolbarWin.NoScroll = true
 	toolbarWin.Size = eui.Point{X: 500, Y: 35}
 	toolbarWin.SetZone(eui.HZoneCenter, eui.VZoneTop)

--- a/ui.go
+++ b/ui.go
@@ -172,6 +172,7 @@ func makeToolbarWindow() {
 	toolbarWin.AutoSize = false
 	toolbarWin.ShowDragbar = false
 	toolbarWin.Movable = true
+	toolbarWin.NoScale = true
 	toolbarWin.NoScroll = true
 	toolbarWin.Size = eui.Point{X: 500, Y: 35}
 	toolbarWin.SetZone(eui.HZoneCenter, eui.VZoneTop)


### PR DESCRIPTION
## Summary
- fix double UI scaling by returning EUI's scaled dimensions in Game.Layout

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h missing; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0136c2da8832a8801d2d77b26033a