### PR TITLE
Add Discord Rich Presence using rich-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ To build release binaries for Linux and Windows, use:
 scripts/build_binaries.sh
 ```
 
+### Discord Rich Presence
+
+Set the `DISCORD_APP_ID` environment variable to enable Discord Rich Presence via [rich-go](https://github.com/hugolgst/rich-go).
+
 ## Command-line Flags
 
 The Go client accepts the following flags:

--- a/discord.go
+++ b/discord.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	client "github.com/hugolgst/rich-go/client"
+)
+
+func initDiscordRPC(ctx context.Context) {
+	appID := os.Getenv("DISCORD_APP_ID")
+	if appID == "" {
+		return
+	}
+	if err := client.Login(appID); err != nil {
+		logError("discord rpc login: %v", err)
+		return
+	}
+	if err := client.SetActivity(client.Activity{
+		State:   "GoThoom",
+		Details: "In game",
+		Timestamps: &client.Timestamps{
+			Start: time.Now(),
+		},
+	}); err != nil {
+		logError("discord rpc activity: %v", err)
+	}
+	go func() {
+		<-ctx.Done()
+		client.Logout()
+	}()
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/gopacket v1.1.19
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
+	github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/sqweek/dialog v0.0.0-20240226140203-065105509627
 	github.com/thiagokokada/dark-mode-go v0.0.1
@@ -30,4 +31,5 @@ require (
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrx
 github.com/hajimehoshi/ebiten/v2 v2.8.8/go.mod h1:durJ05+OYnio9b8q0sEtOgaNeBEQG7Yr7lRviAciYbs=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
+github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2 h1:9qOViOQGFIP5ar+2NorfAIsfuADEKXtklySC0zNnYf4=
+github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2/go.mod h1:nGaW7CGfNZnhtiFxMpc4OZdqIexGXjUlBnlmpZmjEKA=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
@@ -61,3 +63,5 @@ golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
+gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=

--- a/main.go
+++ b/main.go
@@ -96,6 +96,8 @@ func main() {
 		}()
 	}
 
+	initDiscordRPC(ctx)
+
 	clImages, err = climg.Load(filepath.Join(dataDirPath, CL_ImagesFile))
 	if err != nil {
 		logError("failed to load CL_Images: %v", err)


### PR DESCRIPTION
## Summary
- add initDiscordRPC using rich-go for Discord Rich Presence
- call initDiscordRPC during startup when DISCORD_APP_ID is set
- document Discord Rich Presence setup

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; Xrandr.h missing; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a02dc96578832aa89622d5fb5ec3b9