### PR TITLE
Fix inventory equip flag bit order

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -513,9 +513,12 @@ func handleInvCmdFull(data []byte) ([]byte, bool) {
 	for i := 0; i < itemCount; i++ {
 		ids[i] = binary.BigEndian.Uint16(data[equipBytes+i*2:])
 	}
+	// Inventory equip flags are transmitted with the most significant bit of each
+	// byte corresponding to the first item (big-endian bit order). Reverse the
+	// bit numbering so index 0 maps to bit 7, index 1 to bit 6, and so on.
 	eq := make([]bool, itemCount)
 	for i := 0; i < itemCount; i++ {
-		if equips[i/8]&(1<<uint(i%8)) != 0 {
+		if equips[i/8]&(1<<uint(7-i%8)) != 0 {
 			eq[i] = true
 		}
 	}

--- a/inventory_packets_test.go
+++ b/inventory_packets_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseInventoryFull(t *testing.T) {
 	resetInventory()
 	inventoryDirty = false
-	data := []byte{byte(kInvCmdFull), 2, 0x02, 0x00, 0x64, 0x00, 0xC8, byte(kInvCmdNone), 0x99}
+	data := []byte{byte(kInvCmdFull), 2, 0x40, 0x00, 0x64, 0x00, 0xC8, byte(kInvCmdNone), 0x99}
 	rest, ok := parseInventory(data)
 	if !ok {
 		t.Fatalf("parse failed")


### PR DESCRIPTION
## Summary
- decode inventory equip flags using MSB-first bit order to align with network encoding
- update tests for new equip flag layout

## Testing
- `go fmt draw.go inventory_packets_test.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a02cb5dc64832ab3886faca7603cb5