### PR TITLE
Fix inventory unequip index handling

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -548,8 +548,15 @@ func handleInvCmdOther(cmd int, data []byte) ([]byte, bool) {
 			logError("inventory: cmd %x missing index", cmd)
 			return nil, false
 		}
-		// Server sends 1-based index; convert to 0-based for local arrays.
-		idx = int(data[0]) - 1
+		// Server uses 1-based indices for template items and 0 for
+		// non-template items. Convert to our 0-based index, mapping
+		// 0 to -1 so lookups fall back to the first matching ID.
+		b := int(data[0])
+		if b == 0 {
+			idx = -1
+		} else {
+			idx = b - 1
+		}
 		data = data[1:]
 	}
 	var name string


### PR DESCRIPTION
## Summary
- normalize inventory command indices so template items use 1-based indices and non-template items map to -1

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a064fe32bc832a8c473a3586427644