### PR TITLE
Track images during fast parsing

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -409,6 +409,7 @@ func (p *moviePlayer) seek(idx int) {
 	p.playing = false
 	resetDrawState()
 	frameCounter = 0
+	clearWantedImages()
 
 	for i := 0; i < idx; i++ {
 		m := p.frames[i]
@@ -432,6 +433,7 @@ func (p *moviePlayer) seek(idx int) {
 					id := binary.BigEndian.Uint16(payload[pos : pos+2])
 					h := int16(binary.BigEndian.Uint16(payload[pos+2 : pos+4]))
 					v := int16(binary.BigEndian.Uint16(payload[pos+4 : pos+6]))
+					recordPicture(id)
 					pics = append(pics, framePicture{PictID: id, H: h, V: v})
 					pos += 6
 				}
@@ -443,6 +445,7 @@ func (p *moviePlayer) seek(idx int) {
 		}
 		frameCounter++
 	}
+	loadWantedImages()
 	p.cur = idx
 	resetInterpolation()
 	setInterpFPS(p.fps)


### PR DESCRIPTION
## Summary
- Track picture and mobile image IDs during fast movie parsing
- Load recorded images after parsing or seeking to ensure assets are ready

## Testing
- `gofmt -w movie.go movie_player.go`
- `go vet -v ./...` *(terminated after extended output)*

------
https://chatgpt.com/codex/tasks/task_e_68a147ad26d4832abf283edcf8a47c9d