### PR TITLE
Skip descriptor lookup when think target is known

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1149,23 +1149,27 @@ func parseDrawState(data []byte) error {
 		bubbleData := stateData[:p+end+1]
 		if verb, txt, bubbleName, lang, code, target := decodeBubble(bubbleData); txt != "" || code != kBubbleCodeKnown {
 			name := bubbleName
-			if bubbleName == ThinkUnknownName {
-				name = "Someone"
-			} else {
-				stateMu.Lock()
-				if d, ok := state.descriptors[idx]; ok {
-					if bubbleName != "" {
-						if d.Name != "" {
-							name = d.Name
+			if target == thinkNone {
+				if bubbleName == ThinkUnknownName {
+					name = "Someone"
+				} else {
+					stateMu.Lock()
+					if d, ok := state.descriptors[idx]; ok {
+						if bubbleName != "" {
+							if d.Name != "" {
+								name = d.Name
+							} else {
+								d.Name = bubbleName
+								name = bubbleName
+							}
 						} else {
-							d.Name = bubbleName
-							name = bubbleName
+							name = d.Name
 						}
-					} else {
-						name = d.Name
 					}
+					stateMu.Unlock()
 				}
-				stateMu.Unlock()
+			} else if bubbleName == ThinkUnknownName {
+				name = "Someone"
 			}
 			if gs.SpeechBubbles && txt != "" && !blockBubbles {
 				b := bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter}


### PR DESCRIPTION
## Summary
- Use bubble-provided name when a think bubble has an explicit target and skip descriptor lookup
- Fall back to descriptor-based name resolution only when there is no think target and still substitute "Someone" for unknown names

## Testing
- `gofmt -w draw.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1782ca2f4832a8e0c5661094cb480