### PR TITLE
Add status bar placement setting

### DIFF
--- a/game.go
+++ b/game.go
@@ -1484,39 +1484,78 @@ func drawStatusBars(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha f
 	}
 	barWidth := int(110 * gs.GameScale)
 	barHeight := int(8 * gs.GameScale)
+
 	fieldWidth := int(float64(gameAreaSizeX) * gs.GameScale)
-	slot := (fieldWidth - 3*barWidth) / 6
-	barY := int(float64(gameAreaSizeY)*gs.GameScale-20*gs.GameScale) - barHeight
-	screenH := screen.Bounds().Dy()
-	minY := -oy
-	maxY := screenH - oy - barHeight
-	if barY < minY {
-		barY = minY
-	} else if barY > maxY {
-		barY = maxY
+	fieldHeight := int(float64(gameAreaSizeY) * gs.GameScale)
+
+	var x, y, dx, dy int
+	switch gs.BarPlacement {
+	case BarPlacementLowerLeft:
+		x = int(20 * gs.GameScale)
+		spacing := int(4 * gs.GameScale)
+		y = fieldHeight - int(20*gs.GameScale) - 3*barHeight - 2*spacing
+		dx = 0
+		dy = barHeight + spacing
+	case BarPlacementLowerRight:
+		x = fieldWidth - int(20*gs.GameScale) - barWidth
+		spacing := int(4 * gs.GameScale)
+		y = fieldHeight - int(20*gs.GameScale) - 3*barHeight - 2*spacing
+		dx = 0
+		dy = barHeight + spacing
+	case BarPlacementUpperRight:
+		x = fieldWidth - int(20*gs.GameScale) - barWidth
+		spacing := int(4 * gs.GameScale)
+		y = int(20 * gs.GameScale)
+		dx = 0
+		dy = barHeight + spacing
+	default: // BarPlacementBottom
+		slot := (fieldWidth - 3*barWidth) / 6
+		x = slot
+		y = fieldHeight - int(20*gs.GameScale) - barHeight
+		dx = barWidth + 2*slot
+		dy = 0
 	}
-	x := slot
-	step := barWidth + 2*slot
-	drawBar := func(x int, cur, max int, clr color.RGBA) {
+
+	screenW := screen.Bounds().Dx()
+	screenH := screen.Bounds().Dy()
+	minX := -ox
+	minY := -oy
+	maxX := screenW - ox - barWidth - 2*dx
+	maxY := screenH - oy - barHeight - 2*dy
+	if x < minX {
+		x = minX
+	} else if x > maxX {
+		x = maxX
+	}
+	if y < minY {
+		y = minY
+	} else if y > maxY {
+		y = maxY
+	}
+
+	drawBar := func(x, y int, cur, max int, clr color.RGBA) {
 		frameClr := color.RGBA{0xff, 0xff, 0xff, 0xff}
-		vector.StrokeRect(screen, float32(float64(ox+x)-gs.GameScale), float32(float64(oy+barY)-gs.GameScale), float32(barWidth)+float32(2*gs.GameScale), float32(barHeight)+float32(2*gs.GameScale), 1, frameClr, false)
+		vector.StrokeRect(screen, float32(float64(ox+x)-gs.GameScale), float32(float64(oy+y)-gs.GameScale), float32(barWidth)+float32(2*gs.GameScale), float32(barHeight)+float32(2*gs.GameScale), 1, frameClr, false)
 		if max > 0 && cur > 0 {
 			w := barWidth * cur / max
 			fillClr := color.RGBA{clr.R, clr.G, clr.B, 128}
-			drawRect(x, barY, w, barHeight, fillClr)
+			drawRect(x, y, w, barHeight, fillClr)
 		}
 	}
+
 	hp := lerpBar(snap.prevHP, snap.hp, alpha)
 	hpMax := lerpBar(snap.prevHPMax, snap.hpMax, alpha)
-	drawBar(x, hp, hpMax, color.RGBA{0x00, 0xff, 0, 0xff})
-	x += step
+	drawBar(x, y, hp, hpMax, color.RGBA{0x00, 0xff, 0, 0xff})
+	x += dx
+	y += dy
 	bal := lerpBar(snap.prevBalance, snap.balance, alpha)
 	balMax := lerpBar(snap.prevBalanceMax, snap.balanceMax, alpha)
-	drawBar(x, bal, balMax, color.RGBA{0x00, 0x00, 0xff, 0xff})
-	x += step
+	drawBar(x, y, bal, balMax, color.RGBA{0x00, 0x00, 0xff, 0xff})
+	x += dx
+	y += dy
 	sp := lerpBar(snap.prevSP, snap.sp, alpha)
 	spMax := lerpBar(snap.prevSPMax, snap.spMax, alpha)
-	drawBar(x, sp, spMax, color.RGBA{0xff, 0x00, 0x00, 0xff})
+	drawBar(x, y, sp, spMax, color.RGBA{0xff, 0x00, 0x00, 0xff})
 }
 
 var fpsImage *ebiten.Image

--- a/settings.go
+++ b/settings.go
@@ -14,6 +14,15 @@ import (
 
 const SETTINGS_VERSION = 4
 
+type BarPlacement int
+
+const (
+	BarPlacementBottom BarPlacement = iota
+	BarPlacementLowerLeft
+	BarPlacementLowerRight
+	BarPlacementUpperRight
+)
+
 var gs settings = gsdef
 
 var gsdef settings = settings{
@@ -48,6 +57,7 @@ var gsdef settings = settings{
 	Volume:            0.125,
 	Mute:              false,
 	GameScale:         2,
+	BarPlacement:      BarPlacementBottom,
 	Theme:             "",
 	MessagesToConsole: false,
 	WindowTiling:      false,
@@ -114,6 +124,7 @@ type settings struct {
 	Mute              bool
 	AnyGameWindowSize bool // allow arbitrary game window sizes
 	GameScale         float64
+	BarPlacement      BarPlacement
 	Theme             string
 	MessagesToConsole bool
 	WindowTiling      bool

--- a/ui.go
+++ b/ui.go
@@ -1184,6 +1184,37 @@ func makeSettingsWindow() {
 	right.AddItem(renderScale)
 
 	label, _ = eui.NewText()
+	label.Text = "\nStatus Bar Placement:"
+	label.FontSize = 15
+	label.Size = eui.Point{X: rightW, Y: 50}
+	right.AddItem(label)
+
+	placements := []struct {
+		name  string
+		value BarPlacement
+	}{
+		{"Bottom", BarPlacementBottom},
+		{"Lower Left", BarPlacementLowerLeft},
+		{"Lower Right", BarPlacementLowerRight},
+		{"Upper Right", BarPlacementUpperRight},
+	}
+	for _, p := range placements {
+		p := p
+		radio, radioEvents := eui.NewRadio()
+		radio.Text = p.name
+		radio.RadioGroup = "status-bar-placement"
+		radio.Size = eui.Point{X: rightW, Y: 24}
+		radio.Checked = gs.BarPlacement == p.value
+		radioEvents.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventRadioSelected {
+				gs.BarPlacement = p.value
+				settingsDirty = true
+			}
+		}
+		right.AddItem(radio)
+	}
+
+	label, _ = eui.NewText()
 	label.Text = "\nText Sizes:"
 	label.FontSize = 15
 	label.Size = eui.Point{X: leftW, Y: 50}


### PR DESCRIPTION
## Summary
- add BarPlacement enum and setting with default bottom
- allow choosing status bar placement via Settings radio buttons
- draw status bars at selected placement

## Testing
- `go vet ./...` *(fails: Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a188c9a92c832a932d4edbc7fb98d1