### PR TITLE
Add configurable value-based bar colors

### DIFF
--- a/game.go
+++ b/game.go
@@ -1502,7 +1502,19 @@ func drawStatusBars(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha f
 		vector.StrokeRect(screen, float32(float64(ox+x)-gs.GameScale), float32(float64(oy+barY)-gs.GameScale), float32(barWidth)+float32(2*gs.GameScale), float32(barHeight)+float32(2*gs.GameScale), 1, frameClr, false)
 		if max > 0 && cur > 0 {
 			w := barWidth * cur / max
-			fillClr := color.RGBA{clr.R, clr.G, clr.B, 128}
+			base := clr
+			if gs.BarColorByValue {
+				ratio := float64(cur) / float64(max)
+				switch {
+				case ratio <= 0.33:
+					base = color.RGBA{0xff, 0x00, 0x00, 0xff}
+				case ratio <= 0.66:
+					base = color.RGBA{0xff, 0xff, 0x00, 0xff}
+				default:
+					base = color.RGBA{0x00, 0xff, 0x00, 0xff}
+				}
+			}
+			fillClr := color.RGBA{base.R, base.G, base.B, 128}
 			drawRect(x, barY, w, barHeight, fillClr)
 		}
 	}

--- a/settings.go
+++ b/settings.go
@@ -78,6 +78,7 @@ var gsdef settings = settings{
 	smoothMoving:        false,
 	dontShiftNewSprites: false,
 	fastBars:            true,
+	BarColorByValue:     false,
 	recordAssetStats:    false,
 }
 
@@ -141,6 +142,7 @@ type settings struct {
 	smoothMoving        bool
 	dontShiftNewSprites bool
 	fastBars            bool
+	BarColorByValue     bool
 	recordAssetStats    bool
 	NoCaching           bool
 	PotatoComputer      bool

--- a/ui.go
+++ b/ui.go
@@ -1064,6 +1064,18 @@ func makeSettingsWindow() {
 	}
 	left.AddItem(keySpeedSlider)
 
+	barColorCB, barColorEvents := eui.NewCheckbox()
+	barColorCB.Text = "Color bars by value"
+	barColorCB.Size = eui.Point{X: leftW, Y: 24}
+	barColorCB.Checked = gs.BarColorByValue
+	barColorEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.BarColorByValue = ev.Checked
+			settingsDirty = true
+		}
+	}
+	left.AddItem(barColorCB)
+
 	label, _ = eui.NewText()
 	label.Text = "\nWindow Behavior:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- add `BarColorByValue` setting with default disabled
- expose "Color bars by value" checkbox in Settings
- color status bars based on current value when enabled

## Testing
- `go fmt settings.go ui.go game.go`
- `go vet ./...` *(fails: inventory_ui.go:197:32 invalid operation nameW / uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_68a188b78bec832abe869ee8c35eec5d