### PR TITLE
Add embedded help window and F1 shortcut

### DIFF
--- a/data/help.txt
+++ b/data/help.txt
@@ -1,16 +1,27 @@
 Movement
 --------
-* Move using WASD or arrow keys; hold Shift for normal-speed movement.
-* Left-click to walk; if "Click To Toggle" is enabled, a single click sets a
-  walk target.
+- Move using WASD or arrow keys. Hold Shift to run.
+- Left-click to walk toward the cursor. When "Click-to-Toggle Walk" is enabled, a single click sets a walk target.
 
 Communication
 -------------
-* Enter starts chat; Enter sends; Esc cancels; Up/Down browse history;
-  use `/play` for tunes.
+- Press Enter to start typing. Enter again sends the message.
+- Press Esc to cancel typing. Up/Down browse previous messages.
+- Use /who to see who is online. /play <tune> plays a tune.
 
-General Tips
-------------
-* `/who` shows who is online.
-* Explore with friends and share your adventures.
+Inventory
+---------
+- Open the Inventory window from the toolbar or Windows list.
+- Drag items between hands or inventory slots. Click items to equip or use.
 
+UI Navigation
+-------------
+- Use the Windows menu or toolbar buttons to toggle windows.
+- Drag window title bars to move; resize by dragging edges.
+- Mouse wheel scrolls lists and text windows.
+- Press F1 to open this help window.
+
+Basics
+------
+- Settings are accessible from the Settings button; changes save automatically.
+- Explore with friends and share adventures.

--- a/game.go
+++ b/game.go
@@ -592,6 +592,12 @@ func (g *Game) Update() error {
 		}
 	}
 
+	if inpututil.IsKeyJustPressed(ebiten.KeyF1) {
+		if helpWin != nil {
+			helpWin.Toggle()
+		}
+	}
+
 	/* WASD / ARROWS */
 
 	var keyWalk bool

--- a/help_ui.go
+++ b/help_ui.go
@@ -3,7 +3,25 @@
 package main
 
 import (
+	_ "embed"
+	"strings"
+
 	"gothoom/eui"
 )
 
+//go:embed data/help.txt
+var helpText string
+
 var helpWin *eui.WindowData
+var helpList *eui.ItemData
+var helpLines []string
+
+func initHelpUI() {
+	if helpWin != nil {
+		return
+	}
+	helpWin, helpList, _ = makeTextWindow("Help", eui.HZoneCenter, eui.VZoneMiddleTop, false)
+	helpLines = strings.Split(strings.ReplaceAll(helpText, "\r\n", "\n"), "\n")
+	helpWin.OnResize = func() { updateTextWindow(helpWin, helpList, nil, helpLines, 15, "") }
+	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "")
+}

--- a/ui.go
+++ b/ui.go
@@ -54,6 +54,7 @@ var windowsPlayersCB *eui.ItemData
 var windowsInventoryCB *eui.ItemData
 var windowsChatCB *eui.ItemData
 var windowsConsoleCB *eui.ItemData
+var windowsHelpCB *eui.ItemData
 var hudWin *eui.WindowData
 var rightHandImg *eui.ItemData
 var leftHandImg *eui.ItemData
@@ -106,6 +107,10 @@ func init() {
 			windowsConsoleCB.Checked = consoleWin != nil && consoleWin.IsOpen()
 			windowsConsoleCB.Dirty = true
 		}
+		if windowsHelpCB != nil {
+			windowsHelpCB.Checked = helpWin != nil && helpWin.IsOpen()
+			windowsHelpCB.Dirty = true
+		}
 		if windowsWin != nil {
 			windowsWin.Refresh()
 		}
@@ -138,10 +143,10 @@ func initUI() {
 	makeSettingsWindow()
 	makeQualityWindow()
 	makeDebugWindow()
+	initHelpUI()
 	makeWindowsWindow()
 	makeInventoryWindow()
 	makePlayersWindow()
-	makeHelpWindow()
 	makeToolbar()
 
 	// Load any persisted players data (e.g., from prior sessions) so
@@ -2387,6 +2392,22 @@ func makeWindowsWindow() {
 	}
 	flow.AddItem(consoleBox)
 
+	helpBox, helpBoxEvents := eui.NewCheckbox()
+	windowsHelpCB = helpBox
+	helpBox.Text = "Help"
+	helpBox.Size = eui.Point{X: 128, Y: 24}
+	helpBox.Checked = helpWin != nil && helpWin.IsOpen()
+	helpBoxEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			if ev.Checked {
+				helpWin.MarkOpenNear(ev.Item)
+			} else {
+				helpWin.Close()
+			}
+		}
+	}
+	flow.AddItem(helpBox)
+
 	windowsWin.AddItem(flow)
 	windowsWin.AddWindow(false)
 
@@ -2409,35 +2430,4 @@ func makePlayersWindow() {
 	// Refresh contents on resize so word-wrapping and row sizing stay correct.
 	playersWin.OnResize = func() { updatePlayersWindow() }
 	updatePlayersWindow()
-}
-
-func makeHelpWindow() {
-	if helpWin != nil {
-		return
-	}
-	helpWin = eui.NewWindow()
-	helpWin.Title = "Help"
-	helpWin.Closable = true
-	helpWin.Resizable = false
-	helpWin.AutoSize = true
-	helpWin.Movable = true
-	//helpWin.SetZone(eui.HZoneCenterLeft, eui.VZoneMiddleTop)
-	helpFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
-	helpTexts := []string{
-		"WASD or Arrow Keys - Walk",
-		"Shift + Movement - Run",
-		"Left Click - Walk toward cursor",
-		"Click-to-Toggle Walk - Left click toggles walking",
-		"Enter - Start typing / send command",
-		"Escape - Cancel typing",
-	}
-	for _, line := range helpTexts {
-		t, _ := eui.NewText()
-		t.Text = line
-		t.Size = eui.Point{X: 300, Y: 24}
-		t.FontSize = 15
-		helpFlow.AddItem(t)
-	}
-	helpWin.AddItem(helpFlow)
-	helpWin.AddWindow(false)
 }


### PR DESCRIPTION
## Summary
- Embed expanded help text and create reusable help window
- Add menu checkbox and F1 keybinding to toggle help window

## Testing
- `gofmt -w help_ui.go ui.go game.go`
- `go vet ./...` *(fails: Package 'alsa'/'gtk+-3.0'/'Xrandr.h' not found)*
- `go build ./...` *(fails: Package 'alsa'/'gtk+-3.0'/'Xrandr.h' not found)*
- `go run .` *(fails: Package 'alsa'/'gtk+-3.0'/'Xrandr.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18a46d924832ab3b64ce8c5b6e32a