### PR TITLE
Keep console input scrolled

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -17,15 +17,21 @@ func updateConsoleWindow() {
 	if inputActive {
 		inputMsg = string(inputText)
 	}
-	msgs := getConsoleMessages()
-	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
-	if messagesFlow != nil && len(msgs) > consolePrevCount {
-		// Scroll to bottom on new text; clamp occurs on Refresh.
-		messagesFlow.Scroll.Y = 1e9
-		if consoleWin != nil {
-			consoleWin.Refresh()
-		}
-	}
+        msgs := getConsoleMessages()
+        updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
+        if inputActive {
+                inputFlow.Scroll.Y = 1e9
+                if consoleWin != nil {
+                        consoleWin.Refresh()
+                }
+        }
+        if messagesFlow != nil && len(msgs) > consolePrevCount {
+                // Scroll to bottom on new text; clamp occurs on Refresh.
+                messagesFlow.Scroll.Y = 1e9
+                if consoleWin != nil {
+                        consoleWin.Refresh()
+                }
+        }
 	consolePrevCount = len(msgs)
 }
 

--- a/console_ui.go
+++ b/console_ui.go
@@ -17,21 +17,27 @@ func updateConsoleWindow() {
 	if inputActive {
 		inputMsg = string(inputText)
 	}
-        msgs := getConsoleMessages()
-        updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
-        if inputActive {
-                inputFlow.Scroll.Y = 1e9
-                if consoleWin != nil {
-                        consoleWin.Refresh()
-                }
-        }
-        if messagesFlow != nil && len(msgs) > consolePrevCount {
-                // Scroll to bottom on new text; clamp occurs on Refresh.
-                messagesFlow.Scroll.Y = 1e9
-                if consoleWin != nil {
-                        consoleWin.Refresh()
-                }
-        }
+	msgs := getConsoleMessages()
+	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
+	if inputActive {
+		if inputFlow != nil && len(inputFlow.Contents) > 0 {
+			maxScroll := inputFlow.Contents[0].Size.Y - inputFlow.Size.Y
+			if maxScroll < 0 {
+				maxScroll = 0
+			}
+			inputFlow.Scroll.Y = maxScroll
+		}
+		if consoleWin != nil {
+			consoleWin.Refresh()
+		}
+	}
+	if messagesFlow != nil && len(msgs) > consolePrevCount {
+		// Scroll to bottom on new text; clamp occurs on Refresh.
+		messagesFlow.Scroll.Y = 1e9
+		if consoleWin != nil {
+			consoleWin.Refresh()
+		}
+	}
 	consolePrevCount = len(msgs)
 }
 

--- a/console_ui.go
+++ b/console_ui.go
@@ -20,12 +20,8 @@ func updateConsoleWindow() {
 	msgs := getConsoleMessages()
 	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
 	if inputActive {
-		if inputFlow != nil && len(inputFlow.Contents) > 0 {
-			maxScroll := inputFlow.Contents[0].Size.Y - inputFlow.Size.Y
-			if maxScroll < 0 {
-				maxScroll = 0
-			}
-			inputFlow.Scroll.Y = maxScroll
+		if inputFlow != nil {
+			inputFlow.Scroll.Y = 1e9
 		}
 		if consoleWin != nil {
 			consoleWin.Refresh()

--- a/text_window.go
+++ b/text_window.go
@@ -27,11 +27,11 @@ func makeTextWindow(title string, hz eui.HZone, vz eui.VZone, withInput bool) (*
 	list := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
 	flow.AddItem(list)
 
-        var input *eui.ItemData
-        if withInput {
-                input = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
-                flow.AddItem(input)
-        }
+	var input *eui.ItemData
+	if withInput {
+		input = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
+		flow.AddItem(input)
+	}
 
 	win.AddWindow(false)
 	return win, list, input
@@ -111,33 +111,37 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 		list.Contents = list.Contents[:len(msgs)]
 	}
 
-        if input != nil {
-                // Soft-wrap the input message to the available width.
-                _, inLines := wrapText(inputMsg, face, wrapWidthPx)
-                wrappedIn := strings.Join(inLines, "\n")
-                inLinesN := len(inLines)
-                if inLinesN < 1 {
-                        inLinesN = 1
-                }
-                input.Size.X = clientWAvail
-                input.Size.Y = rowUnits * 3
-                if len(input.Contents) == 0 {
-                        t, _ := eui.NewText()
-                        t.Text = wrappedIn
-                        t.FontSize = float32(fontSize)
-                        t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(inLinesN)}
-                        t.Filled = true
-                        input.AddItem(t)
-                } else {
-                        if input.Contents[0].Text != wrappedIn || input.Contents[0].FontSize != float32(fontSize) {
-                                input.Contents[0].Text = wrappedIn
-                                input.Contents[0].FontSize = float32(fontSize)
-                        }
-                        input.Contents[0].Size.X = clientWAvail
-                        input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
-                }
-                input.Scroll.Y = 1e9
-        }
+	if input != nil {
+		// Soft-wrap the input message to the available width.
+		_, inLines := wrapText(inputMsg, face, wrapWidthPx)
+		wrappedIn := strings.Join(inLines, "\n")
+		inLinesN := len(inLines)
+		if inLinesN < 1 {
+			inLinesN = 1
+		}
+		input.Size.X = clientWAvail
+		input.Size.Y = rowUnits * 3
+		if len(input.Contents) == 0 {
+			t, _ := eui.NewText()
+			t.Text = wrappedIn
+			t.FontSize = float32(fontSize)
+			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(inLinesN)}
+			t.Filled = true
+			input.AddItem(t)
+		} else {
+			if input.Contents[0].Text != wrappedIn || input.Contents[0].FontSize != float32(fontSize) {
+				input.Contents[0].Text = wrappedIn
+				input.Contents[0].FontSize = float32(fontSize)
+			}
+			input.Contents[0].Size.X = clientWAvail
+			input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
+		}
+		maxScroll := input.Contents[0].Size.Y - input.Size.Y
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		input.Scroll.Y = maxScroll
+	}
 
 	if win != nil {
 		// Size the flow to the client area, and the list to fill above the input.

--- a/text_window.go
+++ b/text_window.go
@@ -72,7 +72,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 		goFace = &text.GoTextFace{Size: facePx}
 	}
 	metrics := goFace.Metrics()
-	linePx := math.Ceil(metrics.HAscent + metrics.HDescent + 2) // +2 px padding
+	linePx := math.Ceil(metrics.HAscent + metrics.HDescent + metrics.HLineGap + 2) // +2 px padding
 	rowUnits := float32(linePx) / ui
 
 	// Determine scrollbar width in pixels so text doesn't render underneath it.
@@ -83,7 +83,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 
 	// Prepare wrapping parameters: use the same face for measurement.
 	var face text.Face = goFace
-	wrapWidthPx := float64(clientWAvail - sb - 3*pad)
+	wrapWidthPx := float64(clientWAvail - sb)
 	if wrapWidthPx < 0 {
 		wrapWidthPx = 0
 	}
@@ -103,11 +103,15 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			}
 			list.Contents[i].Size.Y = rowUnits * float32(linesN)
 			list.Contents[i].Size.X = clientWAvail - sb
+			list.Contents[i].Position = eui.Point{}
+			list.Contents[i].Margin = 0
 		} else {
 			t, _ := eui.NewText()
 			t.Text = wrapped
 			t.FontSize = float32(fontSize)
 			t.Size = eui.Point{X: clientWAvail - sb, Y: rowUnits * float32(linesN)}
+			t.Position = eui.Point{}
+			t.Margin = 0
 			// Append to maintain ordering with the msgs index
 			list.AddItem(t)
 		}
@@ -135,6 +139,8 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			t.FontSize = float32(fontSize)
 			t.Size = eui.Point{X: clientWAvail - sb, Y: rowUnits * float32(inLinesN)}
 			t.Filled = true
+			t.Position = eui.Point{}
+			t.Margin = 0
 			input.AddItem(t)
 		} else {
 			if input.Contents[0].Text != wrappedIn || input.Contents[0].FontSize != float32(fontSize) {
@@ -143,12 +149,10 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			}
 			input.Contents[0].Size.X = clientWAvail - sb
 			input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
+			input.Contents[0].Position = eui.Point{}
+			input.Contents[0].Margin = 0
 		}
-		maxScroll := input.Contents[0].Size.Y - input.Size.Y
-		if maxScroll < 0 {
-			maxScroll = 0
-		}
-		input.Scroll.Y = maxScroll
+		input.Scroll.Y = 1e9
 	}
 
 	if win != nil {

--- a/text_window.go
+++ b/text_window.go
@@ -27,11 +27,11 @@ func makeTextWindow(title string, hz eui.HZone, vz eui.VZone, withInput bool) (*
 	list := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
 	flow.AddItem(list)
 
-	var input *eui.ItemData
-	if withInput {
-		input = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
-		flow.AddItem(input)
-	}
+        var input *eui.ItemData
+        if withInput {
+                input = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
+                flow.AddItem(input)
+        }
 
 	win.AddWindow(false)
 	return win, list, input
@@ -111,32 +111,33 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 		list.Contents = list.Contents[:len(msgs)]
 	}
 
-	if input != nil {
-		// Soft-wrap the input message to the available width and grow the input area.
-		_, inLines := wrapText(inputMsg, face, wrapWidthPx)
-		wrappedIn := strings.Join(inLines, "\n")
-		inLinesN := len(inLines)
-		if inLinesN < 1 {
-			inLinesN = 1
-		}
-		input.Size.X = clientWAvail
-		input.Size.Y = rowUnits + 1*float32(inLinesN)
-		if len(input.Contents) == 0 {
-			t, _ := eui.NewText()
-			t.Text = wrappedIn
-			t.FontSize = float32(fontSize)
-			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(inLinesN)}
-			t.Filled = true
-			input.AddItem(t)
-		} else {
-			if input.Contents[0].Text != wrappedIn || input.Contents[0].FontSize != float32(fontSize) {
-				input.Contents[0].Text = wrappedIn
-				input.Contents[0].FontSize = float32(fontSize)
-			}
-			input.Contents[0].Size.X = clientWAvail
-			input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
-		}
-	}
+        if input != nil {
+                // Soft-wrap the input message to the available width.
+                _, inLines := wrapText(inputMsg, face, wrapWidthPx)
+                wrappedIn := strings.Join(inLines, "\n")
+                inLinesN := len(inLines)
+                if inLinesN < 1 {
+                        inLinesN = 1
+                }
+                input.Size.X = clientWAvail
+                input.Size.Y = rowUnits * 3
+                if len(input.Contents) == 0 {
+                        t, _ := eui.NewText()
+                        t.Text = wrappedIn
+                        t.FontSize = float32(fontSize)
+                        t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(inLinesN)}
+                        t.Filled = true
+                        input.AddItem(t)
+                } else {
+                        if input.Contents[0].Text != wrappedIn || input.Contents[0].FontSize != float32(fontSize) {
+                                input.Contents[0].Text = wrappedIn
+                                input.Contents[0].FontSize = float32(fontSize)
+                        }
+                        input.Contents[0].Size.X = clientWAvail
+                        input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
+                }
+                input.Scroll.Y = 1e9
+        }
 
 	if win != nil {
 		// Size the flow to the client area, and the list to fill above the input.

--- a/text_window.go
+++ b/text_window.go
@@ -75,10 +75,18 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	linePx := math.Ceil(metrics.HAscent + metrics.HDescent + 2) // +2 px padding
 	rowUnits := float32(linePx) / ui
 
+	// Determine scrollbar width in pixels so text doesn't render underneath it.
+	sb := float32(0)
+	if slider, _ := eui.NewSlider(); slider != nil {
+		sb = slider.BorderPad * 2 * ui
+	}
+
 	// Prepare wrapping parameters: use the same face for measurement.
 	var face text.Face = goFace
-	// list.Size.X is in item units; convert to pixels for measurement.
-	wrapWidthPx := float64(list.Size.X - (3*pad)*ui)
+	wrapWidthPx := float64(clientWAvail - sb - 3*pad)
+	if wrapWidthPx < 0 {
+		wrapWidthPx = 0
+	}
 
 	for i, msg := range msgs {
 		// Word-wrap the message to the available width.
@@ -94,12 +102,12 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				list.Contents[i].FontSize = float32(fontSize)
 			}
 			list.Contents[i].Size.Y = rowUnits * float32(linesN)
-			list.Contents[i].Size.X = clientWAvail
+			list.Contents[i].Size.X = clientWAvail - sb
 		} else {
 			t, _ := eui.NewText()
 			t.Text = wrapped
 			t.FontSize = float32(fontSize)
-			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(linesN)}
+			t.Size = eui.Point{X: clientWAvail - sb, Y: rowUnits * float32(linesN)}
 			// Append to maintain ordering with the msgs index
 			list.AddItem(t)
 		}
@@ -125,7 +133,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			t, _ := eui.NewText()
 			t.Text = wrappedIn
 			t.FontSize = float32(fontSize)
-			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(inLinesN)}
+			t.Size = eui.Point{X: clientWAvail - sb, Y: rowUnits * float32(inLinesN)}
 			t.Filled = true
 			input.AddItem(t)
 		} else {
@@ -133,7 +141,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				input.Contents[0].Text = wrappedIn
 				input.Contents[0].FontSize = float32(fontSize)
 			}
-			input.Contents[0].Size.X = clientWAvail
+			input.Contents[0].Size.X = clientWAvail - sb
 			input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
 		}
 		maxScroll := input.Contents[0].Size.Y - input.Size.Y


### PR DESCRIPTION
## Summary
- make console input field scrollable and auto-scroll to bottom when typing
- fix text window input height to three rows with internal scrolling

## Testing
- `gofmt -w text_window.go console_ui.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a18c43d80c832a8ad7d928709fdc5e