### PR TITLE
Auto-size help window on open

### DIFF
--- a/game.go
+++ b/game.go
@@ -593,9 +593,7 @@ func (g *Game) Update() error {
 	}
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyF1) {
-		if helpWin != nil {
-			helpWin.Toggle()
-		}
+		toggleHelpWindow(nil)
 	}
 
 	/* WASD / ARROWS */

--- a/help_ui.go
+++ b/help_ui.go
@@ -21,7 +21,32 @@ func initHelpUI() {
 		return
 	}
 	helpWin, helpList, _ = makeTextWindow("Help", eui.HZoneCenter, eui.VZoneMiddleTop, false)
+	helpWin.AutoSize = true
 	helpLines = strings.Split(strings.ReplaceAll(helpText, "\r\n", "\n"), "\n")
 	helpWin.OnResize = func() { updateTextWindow(helpWin, helpList, nil, helpLines, 15, "") }
+}
+
+func openHelpWindow(anchor *eui.ItemData) {
+	if helpWin == nil {
+		return
+	}
 	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "")
+	if anchor != nil {
+		helpWin.MarkOpenNear(anchor)
+	} else {
+		helpWin.MarkOpen()
+	}
+	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "")
+	helpWin.Refresh()
+}
+
+func toggleHelpWindow(anchor *eui.ItemData) {
+	if helpWin == nil {
+		return
+	}
+	if helpWin.IsOpen() {
+		helpWin.Close()
+		return
+	}
+	openHelpWindow(anchor)
 }

--- a/ui.go
+++ b/ui.go
@@ -200,7 +200,7 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	helpBtn.FontSize = toolFontSize
 	helpEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-			helpWin.ToggleNear(ev.Item)
+			toggleHelpWindow(ev.Item)
 		}
 	}
 	row1.AddItem(helpBtn)
@@ -2476,7 +2476,7 @@ func makeWindowsWindow() {
 	helpBoxEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			if ev.Checked {
-				helpWin.MarkOpenNear(ev.Item)
+				openHelpWindow(ev.Item)
 			} else {
 				helpWin.Close()
 			}


### PR DESCRIPTION
## Summary
- auto-size help window and refresh content when opened
- centralize help window toggling to handle resizing

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; X11/extensions/Xrandr.h: No such file or directory; Package gtk+-3.0 was not found in the pkg-config search path)*


------
https://chatgpt.com/codex/tasks/task_e_68a18cd505e0832aac58d632c64cfa7f