### PR TITLE
Add status bar transparency slider

### DIFF
--- a/game.go
+++ b/game.go
@@ -1538,8 +1538,13 @@ func drawStatusBars(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha f
 	}
 
 	drawBar := func(x, y int, cur, max int, clr color.RGBA) {
-		frameClr := color.RGBA{0xff, 0xff, 0xff, 0xff}
-		vector.StrokeRect(screen, float32(float64(ox+x)-gs.GameScale), float32(float64(oy+y)-gs.GameScale), float32(barWidth)+float32(2*gs.GameScale), float32(barHeight)+float32(2*gs.GameScale), 1, frameClr, false)
+		alpha := uint8(gs.BarOpacity * 255)
+		frameClr := color.RGBA{0xff, 0xff, 0xff, alpha}
+		pad := int(gs.GameScale)
+		drawRect(x-pad, y-pad, barWidth+2*pad, pad, frameClr)
+		drawRect(x-pad, y+barHeight, barWidth+2*pad, pad, frameClr)
+		drawRect(x-pad, y, pad, barHeight, frameClr)
+		drawRect(x+barWidth, y, pad, barHeight, frameClr)
 		if max > 0 && cur > 0 {
 			w := barWidth * cur / max
 			base := clr
@@ -1554,7 +1559,7 @@ func drawStatusBars(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha f
 					base = color.RGBA{0x00, 0xff, 0x00, 0xff}
 				}
 			}
-			fillClr := color.RGBA{base.R, base.G, base.B, 128}
+			fillClr := color.RGBA{base.R, base.G, base.B, alpha}
 			drawRect(x, y, w, barHeight, fillClr)
 		}
 	}

--- a/settings.go
+++ b/settings.go
@@ -39,6 +39,7 @@ var gsdef settings = settings{
 	PlayersFontSize:   18,
 	BubbleOpacity:     0.7,
 	NameBgOpacity:     0.7,
+	BarOpacity:        0.5,
 	SpeechBubbles:     true,
 
 	MotionSmoothing:   true,
@@ -106,6 +107,7 @@ type settings struct {
 	PlayersFontSize   float64
 	BubbleOpacity     float64
 	NameBgOpacity     float64
+	BarOpacity        float64
 	SpeechBubbles     bool
 
 	MotionSmoothing   bool

--- a/ui.go
+++ b/ui.go
@@ -1114,6 +1114,20 @@ func makeSettingsWindow() {
 	}
 	left.AddItem(barColorCB)
 
+	barOpacitySlider, barOpacityEvents := eui.NewSlider()
+	barOpacitySlider.Label = "Status bar opacity"
+	barOpacitySlider.MinValue = 0.0
+	barOpacitySlider.MaxValue = 1.0
+	barOpacitySlider.Value = float32(gs.BarOpacity)
+	barOpacitySlider.Size = eui.Point{X: leftW - 10, Y: 24}
+	barOpacityEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.BarOpacity = float64(ev.Value)
+			settingsDirty = true
+		}
+	}
+	left.AddItem(barOpacitySlider)
+
 	label, _ = eui.NewText()
 	label.Text = "\nWindow Behavior:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- allow configuring health/balance/spirit bar opacity via new slider
- draw status bars with 1px sprite and color transform for alpha support

## Testing
- `go fmt game.go settings.go ui.go`
- `go vet ./...` *(fails: Package alsa was not found; Xrandr.h missing; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a190f21cc8832ab87c7becef0c4dbd