### PR TITLE
Fix console input area height and wrapping

### DIFF
--- a/text_window.go
+++ b/text_window.go
@@ -77,11 +77,14 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 
 	// Prepare wrapping parameters: use the same face for measurement.
 	var face text.Face = goFace
-	// list.Size.X is in item units; convert to pixels for measurement.
-	wrapWidthPx := float64(list.Size.X-(3*pad)*ui) - 20
-	if wrapWidthPx < 0 {
-		wrapWidthPx = 0
+
+	// Leave a margin on the right to prevent clipped characters.
+	const rightMarginPx = 24
+	textWidthUnits := clientWAvail - float32(rightMarginPx)/ui
+	if textWidthUnits < 0 {
+		textWidthUnits = 0
 	}
+	wrapWidthPx := float64(textWidthUnits) * float64(ui)
 
 	for i, msg := range msgs {
 		// Word-wrap the message to the available width.
@@ -97,12 +100,12 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				list.Contents[i].FontSize = float32(fontSize)
 			}
 			list.Contents[i].Size.Y = rowUnits * float32(linesN)
-			list.Contents[i].Size.X = clientWAvail
+			list.Contents[i].Size.X = textWidthUnits
 		} else {
 			t, _ := eui.NewText()
 			t.Text = wrapped
 			t.FontSize = float32(fontSize)
-			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(linesN)}
+			t.Size = eui.Point{X: textWidthUnits, Y: rowUnits * float32(linesN)}
 			// Append to maintain ordering with the msgs index
 			list.AddItem(t)
 		}
@@ -122,13 +125,13 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			inLines = inLines[len(inLines)-maxInputLines:]
 		}
 		wrappedIn := strings.Join(inLines, "\n")
-		input.Size.X = clientWAvail
+		input.Size.X = textWidthUnits
 		input.Size.Y = rowUnits * float32(maxInputLines)
 		if len(input.Contents) == 0 {
 			t, _ := eui.NewText()
 			t.Text = wrappedIn
 			t.FontSize = float32(fontSize)
-			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(maxInputLines)}
+			t.Size = eui.Point{X: textWidthUnits, Y: rowUnits * float32(maxInputLines)}
 			t.Filled = true
 			input.AddItem(t)
 		} else {
@@ -136,7 +139,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				input.Contents[0].Text = wrappedIn
 				input.Contents[0].FontSize = float32(fontSize)
 			}
-			input.Contents[0].Size.X = clientWAvail
+			input.Contents[0].Size.X = textWidthUnits
 			input.Contents[0].Size.Y = rowUnits * float32(maxInputLines)
 		}
 	}

--- a/text_window.go
+++ b/text_window.go
@@ -78,7 +78,10 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	// Prepare wrapping parameters: use the same face for measurement.
 	var face text.Face = goFace
 	// list.Size.X is in item units; convert to pixels for measurement.
-	wrapWidthPx := float64(list.Size.X - (3*pad)*ui)
+	wrapWidthPx := float64(list.Size.X-(3*pad)*ui) - 20
+	if wrapWidthPx < 0 {
+		wrapWidthPx = 0
+	}
 
 	for i, msg := range msgs {
 		// Word-wrap the message to the available width.
@@ -112,20 +115,20 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	}
 
 	if input != nil {
-		// Soft-wrap the input message to the available width and grow the input area.
+		const maxInputLines = 5
+		// Soft-wrap the input message to the available width.
 		_, inLines := wrapText(inputMsg, face, wrapWidthPx)
-		wrappedIn := strings.Join(inLines, "\n")
-		inLinesN := len(inLines)
-		if inLinesN < 1 {
-			inLinesN = 1
+		if len(inLines) > maxInputLines {
+			inLines = inLines[len(inLines)-maxInputLines:]
 		}
+		wrappedIn := strings.Join(inLines, "\n")
 		input.Size.X = clientWAvail
-		input.Size.Y = rowUnits + 1*float32(inLinesN)
+		input.Size.Y = rowUnits * float32(maxInputLines)
 		if len(input.Contents) == 0 {
 			t, _ := eui.NewText()
 			t.Text = wrappedIn
 			t.FontSize = float32(fontSize)
-			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(inLinesN)}
+			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(maxInputLines)}
 			t.Filled = true
 			input.AddItem(t)
 		} else {
@@ -134,7 +137,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				input.Contents[0].FontSize = float32(fontSize)
 			}
 			input.Contents[0].Size.X = clientWAvail
-			input.Contents[0].Size.Y = rowUnits * float32(inLinesN)
+			input.Contents[0].Size.Y = rowUnits * float32(maxInputLines)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- keep text wrapping a bit shy of the window edge
- fix console input area to a constant five lines

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a197688888832a9c0256ed66d8a64a