### PR TITLE
Cache rebuilt name tags

### DIFF
--- a/game.go
+++ b/game.go
@@ -1227,6 +1227,18 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 						sm.nameTagH = ihImg
 						sm.nameTagKey = key
 						state.mobiles[m.Index] = sm
+						for i := range state.liveMobs {
+							if state.liveMobs[i].Index == m.Index {
+								state.liveMobs[i] = sm
+								break
+							}
+						}
+						for i := range state.deadMobs {
+							if state.deadMobs[i].Index == m.Index {
+								state.deadMobs[i] = sm
+								break
+							}
+						}
 					}
 					stateMu.Unlock()
 				}


### PR DESCRIPTION
## Summary
- rebuild and cache mobile name tag images when cache is invalid, storing them for reuse

## Testing
- `gofmt -w game.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a19e7b4b38832ab7109bf10bfd1e75