### PR TITLE
Disable mobile and picture culling

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -285,54 +285,6 @@ func pictureOnEdge(p framePicture) bool {
 	return false
 }
 
-// pictureVisible reports whether a picture's bounding box intersects
-// the visible playfield in game coordinates.
-func pictureVisible(p framePicture) bool {
-	if clImages == nil {
-		// Without metadata, conservatively keep.
-		return true
-	}
-	w, h := clImages.Size(uint32(p.PictID))
-	halfW := w / 2
-	halfH := h / 2
-	// Intersect against [-fieldCenterX, fieldCenterX] × [-fieldCenterY, fieldCenterY].
-	minX := int(p.H) - halfW
-	maxX := int(p.H) + halfW
-	minY := int(p.V) - halfH
-	maxY := int(p.V) + halfH
-	if maxX <= -fieldCenterX || minX >= fieldCenterX || maxY <= -fieldCenterY || minY >= fieldCenterY {
-		return false
-	}
-	return true
-}
-
-// mobileVisible reports whether a mobile's bounding box intersects the
-// visible playfield. It uses descriptor info for size when available.
-func mobileVisible(m frameMobile, descByIndex map[uint8]frameDescriptor) bool {
-	if clImages == nil {
-		return true
-	}
-	d, ok := descByIndex[m.Index]
-	if !ok {
-		// No descriptor yet; keep to avoid over-culling.
-		return true
-	}
-	size := mobileSize(d.PictID)
-	if size <= 0 {
-		// Fallback: unknown size, keep.
-		return true
-	}
-	half := size / 2
-	minX := int(m.H) - half
-	maxX := int(m.H) + half
-	minY := int(m.V) - half
-	maxY := int(m.V) + half
-	if maxX <= -fieldCenterX || minX >= fieldCenterX || maxY <= -fieldCenterY || minY >= fieldCenterY {
-		return false
-	}
-	return true
-}
-
 // buildNameTagImage creates a cached image for a mobile name tag using the
 // current font and settings. Returns the image and its width/height in pixels.
 func buildNameTagImage(name string, colorCode uint8, opacity uint8, style uint8) (*ebiten.Image, int, int) {
@@ -1003,20 +955,8 @@ func parseDrawState(data []byte) error {
 		}
 	}
 
+	// Keep all pictures without culling.
 	state.pictures = newPics
-	// Build descriptor index → descriptor map for visibility checks.
-	descByIndex := make(map[uint8]frameDescriptor, len(state.descriptors))
-	for idx, d := range state.descriptors {
-		descByIndex[idx] = d
-	}
-	// Cull pictures that are entirely outside the field of view.
-	kept := newPics[:0]
-	for _, p := range newPics {
-		if pictureVisible(p) {
-			kept = append(kept, p)
-		}
-	}
-	state.pictures = kept
 
 	needPrev := (gs.MotionSmoothing || gs.BlendMobiles) && ok
 	if needPrev {
@@ -1054,10 +994,8 @@ func parseDrawState(data []byte) error {
 			delete(state.mobiles, k)
 		}
 	}
+	// Retain all mobiles without culling.
 	for _, m := range mobiles {
-		if !mobileVisible(m, descByIndex) {
-			continue
-		}
 		if d, ok := state.descriptors[m.Index]; ok && d.Name != "" {
 			style := styleRegular
 			playersMu.RLock()

--- a/game.go
+++ b/game.go
@@ -1071,7 +1071,7 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 	y := roundToInt((v + float64(fieldCenterY)) * gs.GameScale)
 	x += ox
 	y += oy
-	// view bounds culling is handled during state parse; no per-frame check here
+	// No per-frame bounds check.
 	var img *ebiten.Image
 	plane := 0
 	var d frameDescriptor
@@ -1145,7 +1145,7 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 		scale := gs.GameScale
 		scaled := float64(roundToInt(float64(drawSize) * scale))
 		scale = scaled / float64(drawSize)
-		// No per-frame bounds check (culled earlier).
+		// No per-frame bounds check.
 		op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
 		op.GeoM.Scale(scale, scale)
 		tx := float64(x) - scaled/2
@@ -1289,7 +1289,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 	x += ox
 	y += oy
 
-	// No per-frame bounds check (culled earlier).
+	// No per-frame bounds check.
 
 	img := loadImageFrame(p.PictID, frame)
 	var prevImg *ebiten.Image
@@ -1337,7 +1337,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		scaledH := float64(roundToInt(float64(drawH) * sy))
 		sx = scaledW / float64(drawW)
 		sy = scaledH / float64(drawH)
-		// No per-frame bounds check (culled earlier).
+		// No per-frame bounds check.
 		op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
 		op.GeoM.Scale(sx, sy)
 		tx := float64(x) - scaledW/2
@@ -1371,7 +1371,7 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 			text.Draw(screen, lbl, mainFont, opTxt)
 		}
 	} else {
-		// No per-frame bounds check (culled earlier).
+		// No per-frame bounds check.
 		clr := color.RGBA{0, 0, 0xff, 0xff}
 		if gs.smoothingDebug && p.Moving {
 			clr = color.RGBA{0xff, 0, 0, 0xff}


### PR DESCRIPTION
## Summary
- retain all picture and mobile objects without view culling
- remove unused culling helpers and references

## Testing
- `go vet ./...` *(fails: Package 'alsa' not found; X11 Xrandr headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a5f0363c832aa700cdba88bc5341