### PR TITLE
Improve share state parsing to mirror classic client

### DIFF
--- a/player.go
+++ b/player.go
@@ -15,8 +15,8 @@ type Player struct {
 	PictID     uint16
 	Colors     []byte
 	IsNPC      bool // entry represents an NPC
-	Sharee     bool // player is sharing to us
-	Sharing    bool // we are sharing to player
+	Sharee     bool // we are sharing to this player
+	Sharing    bool // player is sharing to us
 	GMLevel    int  // parsed from be-who; not rendered
 	Dead       bool // parsed from obit messages (future)
 	FellWhere  string


### PR DESCRIPTION
## Summary
- Reset sharee list when updating share targets and handle "no longer sharing" variant
- Track individual sharer start/stop messages
- Clarify Player.Sharee/Sharing field comments

## Testing
- `gofmt -w player.go text_parsers.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a210f003ac832ab12bcbb9acb5b8ff