### PR TITLE
Refactor background tasks into individual goroutines

### DIFF
--- a/game.go
+++ b/game.go
@@ -196,8 +196,6 @@ var (
 	netLatency    time.Duration
 	lastInputSent time.Time
 	latencyMu     sync.Mutex
-	// Throttled refresh for movie controller window
-	lastMovieWinTick time.Time
 )
 
 // drawState tracks information needed by the Ebiten renderer.

--- a/players_persist.go
+++ b/players_persist.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
 )
 
 type persistPlayers struct {
@@ -30,7 +29,6 @@ const PlayersFile = "GT_Players.xml"
 
 var (
 	lastPlayersSave     = lastSettingsSave
-	lastDebugStats      time.Time
 	playersPersistDirty bool
 )
 


### PR DESCRIPTION
## Summary
- Replace monolithic switch-based background loop with dedicated goroutines using `time.Ticker`
- Drop obsolete debug stats ticker state and movie window tick tracking

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a2288d9b24832a96aeb1c70f8076c7