### PR TITLE
Avoid copying when decoding messages

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -495,7 +495,9 @@ func maybeDecodeMessage(m []byte) {
 	if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
 		return
 	}
-	if txt := decodeMessage(m); txt != "" {
+	// decodeMessage mutates the message body; use a copy to keep the stored
+	// frame unchanged.
+	if txt := decodeMessage(append([]byte(nil), m...)); txt != "" {
 		_ = txt
 	}
 }


### PR DESCRIPTION
## Summary
- refactor decodeMessage to process the message body in-place and decrypt only when needed
- adjust movie player helper to keep frames intact when decoding

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a22d5ab43c832ab0c49b45324cb1cd