### PR TITLE
Add toolbar screenshot button

### DIFF
--- a/screenshot.go
+++ b/screenshot.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"image/png"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func takeScreenshot() {
+	if worldRT == nil {
+		return
+	}
+	dir := filepath.Join(dataDirPath, "Screenshots")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		logError("screenshot: create %v: %v", dir, err)
+		return
+	}
+	ts := time.Now().Format("2006-01-02-15-04-05")
+	fn := filepath.Join(dir, fmt.Sprintf("clan-lord-%s.png", ts))
+	f, err := os.Create(fn)
+	if err != nil {
+		logError("screenshot: create %v: %v", fn, err)
+		return
+	}
+	defer f.Close()
+	if err := png.Encode(f, worldRT); err != nil {
+		logError("screenshot: encode %v: %v", fn, err)
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -207,6 +207,17 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	}
 	row1.AddItem(helpBtn)
 
+	shotBtn, shotEvents := eui.NewButton()
+	shotBtn.Text = "Screenshot"
+	shotBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	shotBtn.FontSize = toolFontSize
+	shotEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			takeScreenshot()
+		}
+	}
+	row1.AddItem(shotBtn)
+
 	exitSessBtn, exitSessEv := eui.NewButton()
 	exitSessBtn.Text = "Exit"
 	exitSessBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}


### PR DESCRIPTION
## Summary
- add Screenshot button to the HUD toolbar
- implement screenshot routine saving the off-screen buffer to `data/Screenshots/clan-lord-(date-time).png`

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a232d09114832ab98a1c5525154084