### PR TITLE
Add chat text-to-speech option

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -26,6 +26,10 @@ func chatMessage(msg string) {
 	chatMsgMu.Unlock()
 
 	updateChatWindow()
+
+	if gs.ChatTTS {
+		speakChatMessage(msg)
+	}
 }
 
 func getChatMessages() []string {

--- a/chat_tts.go
+++ b/chat_tts.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"io"
+
+	ttsspeech "github.com/go-tts/tts/pkg/speech"
+	"github.com/hajimehoshi/ebiten/v2/audio/mp3"
+)
+
+func speakChatMessage(msg string) {
+	if audioContext == nil {
+		return
+	}
+	go func(text string) {
+		rc, err := ttsspeech.FromText(text, "en")
+		if err != nil {
+			logDebug("chat tts: %v", err)
+			return
+		}
+		defer rc.Close()
+
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			logDebug("chat tts read: %v", err)
+			return
+		}
+
+		stream, err := mp3.Decode(audioContext, bytes.NewReader(data))
+		if err != nil {
+			logDebug("chat tts decode: %v", err)
+			return
+		}
+
+		p, err := audioContext.NewPlayer(stream)
+		if err != nil {
+			logDebug("chat tts player: %v", err)
+			return
+		}
+		vol := gs.Volume
+		if gs.Mute {
+			vol = 0
+		}
+		p.SetVolume(vol)
+		p.Play()
+	}(msg)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/hajimehoshi/ebiten/v2 v2.8.8
 
 require (
 	github.com/dustin/go-humanize v1.0.1
+	github.com/go-tts/tts v1.0.1
 	github.com/google/gopacket v1.1.19
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2
@@ -26,6 +27,7 @@ require (
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/go-text/typesetting v0.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	golang.org/x/image v0.30.0 // indirect
 	golang.org/x/net v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/go-text/typesetting v0.3.0 h1:OWCgYpp8njoxSRpwrdd1bQOxdjOXDj9Rqart9ML
 github.com/go-text/typesetting v0.3.0/go.mod h1:qjZLkhRgOEYMhU9eHBr3AR4sfnGJvOXNLt8yRAySFuY=
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-tts/tts v1.0.1 h1:bYam2djAv/+blgerwyLXl8xxrnUcbZN+JSURTIIvONE=
+github.com/go-tts/tts v1.0.1/go.mod h1:A+ZXJVma+D2lvfrF4ARtI+Fta94S74/xnEy1JiSUry0=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
@@ -23,6 +25,9 @@ github.com/hajimehoshi/bitmapfont/v3 v3.2.0 h1:0DISQM/rseKIJhdF29AkhvdzIULqNIIlX
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0/go.mod h1:8gLqGatKVu0pwcNCJguW3Igg9WQqVXF0zg/RvrGQWyg=
 github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrxaIbsi8=
 github.com/hajimehoshi/ebiten/v2 v2.8.8/go.mod h1:durJ05+OYnio9b8q0sEtOgaNeBEQG7Yr7lRviAciYbs=
+github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=
+github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRSVop0eemFmo=
+github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2 h1:9qOViOQGFIP5ar+2NorfAIsfuADEKXtklySC0zNnYf4=
@@ -54,6 +59,7 @@ golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/settings.go
+++ b/settings.go
@@ -63,6 +63,7 @@ var gsdef settings = settings{
 	BarPlacement:      BarPlacementBottom,
 	Theme:             "",
 	MessagesToConsole: false,
+	ChatTTS:           false,
 	WindowTiling:      false,
 	WindowSnapping:    false,
 	AnyGameWindowSize: true,
@@ -134,6 +135,7 @@ type settings struct {
 	BarPlacement      BarPlacement
 	Theme             string
 	MessagesToConsole bool
+	ChatTTS           bool
 	WindowTiling      bool
 	WindowSnapping    bool
 	IntegerScaling    bool

--- a/ui.go
+++ b/ui.go
@@ -1207,6 +1207,18 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(bubbleMsgCB)
 
+	chatTTSCB, chatTTSEvents := eui.NewCheckbox()
+	chatTTSCB.Text = "Read chat messages aloud"
+	chatTTSCB.Size = eui.Point{X: rightW, Y: 24}
+	chatTTSCB.Checked = gs.ChatTTS
+	chatTTSEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.ChatTTS = ev.Checked
+			settingsDirty = true
+		}
+	}
+	right.AddItem(chatTTSCB)
+
 	label, _ = eui.NewText()
 	label.Text = "\nStatus Bar Options:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- add pure-Go TTS library to read chat messages aloud
- expose `Read chat messages aloud` setting in options UI
- hook chat messages into the new speech playback

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a23225ce04832abb10655a10954353