### PR TITLE
Stop TTS when disabled or seeking

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -27,7 +27,7 @@ func chatMessage(msg string) {
 
 	updateChatWindow()
 
-	if gs.ChatTTS {
+	if gs.ChatTTS && !blockTTS {
 		speakChatMessage(msg)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	pcapPath      string
 	blockSound    bool
 	blockBubbles  bool
+	blockTTS      bool
 	clientVersion int
 )
 

--- a/movie_player.go
+++ b/movie_player.go
@@ -288,6 +288,7 @@ func (p *moviePlayer) makePlaybackWindow() {
 		}
 		// Stop any active sounds
 		stopAllSounds()
+		stopAllTTS()
 		// Cancel playback loop
 		if p.cancel != nil {
 			p.cancel()
@@ -435,11 +436,14 @@ func (p *moviePlayer) seek(idx int) {
 
 	// Stop any currently playing sounds so scrubbing is silent.
 	stopAllSounds()
+	stopAllTTS()
 	blockSound = true
 	blockBubbles = true
+	blockTTS = true
 	defer func() {
 		blockSound = false
 		blockBubbles = false
+		blockTTS = false
 	}()
 
 	if idx < 0 {
@@ -473,7 +477,7 @@ func (p *moviePlayer) seek(idx int) {
 			// without draw-state are encountered.
 			frameCounter++
 		}
-    maybeDecodeMessage(m)
+		maybeDecodeMessage(m)
 		if frameCounter%checkpointInterval == 0 {
 			last := p.checkpoints[len(p.checkpoints)-1]
 			if last.idx != frameCounter {

--- a/ui.go
+++ b/ui.go
@@ -1229,6 +1229,9 @@ func makeSettingsWindow() {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.ChatTTS = ev.Checked
 			settingsDirty = true
+			if !ev.Checked {
+				stopAllTTS()
+			}
 		}
 	}
 	chatTTSRow.AddItem(chatTTSCB)


### PR DESCRIPTION
## Summary
- halt any ongoing text-to-speech when setting is toggled off
- mute and block TTS playback while seeking through clMov movies

## Testing
- `gofmt -w main.go chat_messages.go chat_tts.go movie_player.go ui.go`
- `go vet ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h: No such file; gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d2e8258832abcc4a5216a7b0ef5