### PR TITLE
Optimize pixel counting using raw CL_Images data

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"container/list"
 	"runtime"
 	"time"
 
@@ -21,11 +20,6 @@ func clearCaches() {
 	pixelCountMu.Lock()
 	pixelCountCache = make(map[uint16]int)
 	pixelCountMu.Unlock()
-
-	pixelDataMu.Lock()
-	pixelDataCache = make(map[uint16]*list.Element)
-	pixelDataList.Init()
-	pixelDataMu.Unlock()
 
 	soundMu.Lock()
 	pcmCache = make(map[uint16][]byte)


### PR DESCRIPTION
## Summary
- cache non-transparent pixel counts derived from `CL_Images` data to avoid GPU readbacks
- clear cached pixel counts alongside other image caches

## Testing
- `gofmt -w draw.go cache.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a231093f58832a9df3777b666946a6