### PR TITLE
Sync bubble visibility with settings flags

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -198,6 +198,15 @@ type settings struct {
 var (
 	settingsDirty    bool
 	lastSettingsSave = time.Now()
+	bubbleTypeMask   uint32
+	bubbleSourceMask uint32
+)
+
+const (
+	bubbleSourceSelf = 1 << iota
+	bubbleSourceOtherPlayers
+	bubbleSourceMonsters
+	bubbleSourceNarration
 )
 
 type WindowPoint struct {
@@ -239,6 +248,7 @@ func loadSettings() bool {
 func applySettings() {
 	// Fixed-size mode is deprecated; force any-size mode on.
 	gs.AnyGameWindowSize = true
+	updateBubbleVisibility()
 	eui.SetWindowTiling(gs.WindowTiling)
 	eui.SetWindowSnapping(gs.WindowSnapping)
 	eui.SetPotatoMode(gs.PotatoComputer)
@@ -253,6 +263,51 @@ func applySettings() {
 	ebiten.SetWindowFloating(gs.Fullscreen)
 	initFont()
 	updateSoundVolume()
+}
+
+func updateBubbleVisibility() {
+	bubbleTypeMask = 0
+	if gs.BubbleNormal {
+		bubbleTypeMask |= 1 << kBubbleNormal
+	}
+	if gs.BubbleWhisper {
+		bubbleTypeMask |= 1 << kBubbleWhisper
+	}
+	if gs.BubbleYell {
+		bubbleTypeMask |= 1 << kBubbleYell
+	}
+	if gs.BubbleThought {
+		bubbleTypeMask |= 1 << kBubbleThought
+	}
+	if gs.BubbleRealAction {
+		bubbleTypeMask |= 1 << kBubbleRealAction
+	}
+	if gs.BubbleMonster {
+		bubbleTypeMask |= 1 << kBubbleMonster
+	}
+	if gs.BubblePlayerAction {
+		bubbleTypeMask |= 1 << kBubblePlayerAction
+	}
+	if gs.BubblePonder {
+		bubbleTypeMask |= 1 << kBubblePonder
+	}
+	if gs.BubbleNarrate {
+		bubbleTypeMask |= 1 << kBubbleNarrate
+	}
+
+	bubbleSourceMask = 0
+	if gs.BubbleSelf {
+		bubbleSourceMask |= bubbleSourceSelf
+	}
+	if gs.BubbleOtherPlayers {
+		bubbleSourceMask |= bubbleSourceOtherPlayers
+	}
+	if gs.BubbleMonsters {
+		bubbleSourceMask |= bubbleSourceMonsters
+	}
+	if gs.BubbleNarration {
+		bubbleSourceMask |= bubbleSourceNarration
+	}
 }
 
 func saveSettings() {

--- a/ui.go
+++ b/ui.go
@@ -2227,6 +2227,7 @@ func makeBubbleWindow() {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.SpeechBubbles = ev.Checked
 			settingsDirty = true
+			updateBubbleVisibility()
 		}
 	}
 	flow.AddItem(bubbleCB)
@@ -2240,6 +2241,7 @@ func makeBubbleWindow() {
 			if ev.Type == eui.EventCheckboxChanged {
 				*val = ev.Checked
 				settingsDirty = true
+				updateBubbleVisibility()
 			}
 		}
 		flow.AddItem(cb)


### PR DESCRIPTION
## Summary
- track bubble-type and speaker preferences via global masks and update when settings change
- propagate bubble visibility changes through UI checkbox handlers

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a24358b794832abbb735471b9752d7