### PR TITLE
Add bubble visibility filtering by type and origin

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1132,9 +1132,46 @@ func parseDrawState(data []byte) error {
 			} else if bubbleName == ThinkUnknownName {
 				name = "Someone"
 			}
-			if gs.SpeechBubbles && txt != "" && !blockBubbles {
+			bubbleType := typ & kBubbleTypeMask
+			showBubble := gs.SpeechBubbles && txt != "" && !blockBubbles
+			if showBubble {
+				typeOK := true
+				switch bubbleType {
+				case kBubbleNormal:
+					typeOK = gs.BubbleNormal
+				case kBubbleWhisper:
+					typeOK = gs.BubbleWhisper
+				case kBubbleYell:
+					typeOK = gs.BubbleYell
+				case kBubbleThought:
+					typeOK = gs.BubbleThought
+				case kBubbleRealAction:
+					typeOK = gs.BubbleRealAction
+				case kBubbleMonster:
+					typeOK = gs.BubbleMonster
+				case kBubblePlayerAction:
+					typeOK = gs.BubblePlayerAction
+				case kBubblePonder:
+					typeOK = gs.BubblePonder
+				case kBubbleNarrate:
+					typeOK = gs.BubbleNarrate
+				}
+				originOK := true
+				switch {
+				case idx == playerIndex:
+					originOK = gs.BubbleSelf
+				case bubbleType == kBubbleMonster:
+					originOK = gs.BubbleMonsters
+				case bubbleType == kBubbleNarrate:
+					originOK = gs.BubbleNarration
+				default:
+					originOK = gs.BubbleOtherPlayers
+				}
+				showBubble = typeOK && originOK
+			}
+			if showBubble {
 				b := bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter}
-				switch typ & kBubbleTypeMask {
+				switch bubbleType {
 				case kBubbleRealAction, kBubblePlayerAction, kBubbleNarrate:
 					b.NoArrow = true
 				}

--- a/game.go
+++ b/game.go
@@ -1029,6 +1029,42 @@ func drawScene(screen *ebiten.Image, ox, oy int, snap drawSnapshot, alpha float6
 
 	if gs.SpeechBubbles {
 		for _, b := range snap.bubbles {
+			bubbleType := b.Type & kBubbleTypeMask
+			typeOK := true
+			switch bubbleType {
+			case kBubbleNormal:
+				typeOK = gs.BubbleNormal
+			case kBubbleWhisper:
+				typeOK = gs.BubbleWhisper
+			case kBubbleYell:
+				typeOK = gs.BubbleYell
+			case kBubbleThought:
+				typeOK = gs.BubbleThought
+			case kBubbleRealAction:
+				typeOK = gs.BubbleRealAction
+			case kBubbleMonster:
+				typeOK = gs.BubbleMonster
+			case kBubblePlayerAction:
+				typeOK = gs.BubblePlayerAction
+			case kBubblePonder:
+				typeOK = gs.BubblePonder
+			case kBubbleNarrate:
+				typeOK = gs.BubbleNarrate
+			}
+			originOK := true
+			switch {
+			case b.Index == playerIndex:
+				originOK = gs.BubbleSelf
+			case bubbleType == kBubbleMonster:
+				originOK = gs.BubbleMonsters
+			case bubbleType == kBubbleNarrate:
+				originOK = gs.BubbleNarration
+			default:
+				originOK = gs.BubbleOtherPlayers
+			}
+			if !(typeOK && originOK) {
+				continue
+			}
 			hpos := float64(b.H)
 			vpos := float64(b.V)
 			if !b.Far {


### PR DESCRIPTION
## Summary
- filter incoming bubbles using per-type and per-origin settings
- skip rendering bubbles when disabled flags are toggled at draw time

## Testing
- `go vet ./... && echo go-vet-ok`


------
https://chatgpt.com/codex/tasks/task_e_68a2435349a8832ab1a4f411f8ae9681