### PR TITLE
Improve parseNames delimiter handling

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -191,6 +191,7 @@ func parseBackendWho(data []byte) {
 }
 
 // parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.
+// Between segments commas, spaces and the word "and" (case-insensitive) are ignored.
 func parseNames(data []byte) []string {
 	var names []string
 	for len(data) >= 3 {
@@ -205,9 +206,18 @@ func parseNames(data []byte) []string {
 		name := strings.TrimSpace(decodeMacRoman(data[:end]))
 		names = append(names, name)
 		data = data[end+3:]
-		if len(data) > 0 && data[0] == ',' {
-			data = data[1:]
+		for {
+			data = bytes.TrimLeft(data, " ")
+			switch {
+			case len(data) >= 3 && bytes.EqualFold(data[:3], []byte("and")):
+				data = data[3:]
+			case len(data) > 0 && data[0] == ',':
+				data = data[1:]
+			default:
+				goto next
+			}
 		}
+	next:
 	}
 	return names
 }

--- a/parse_names_test.go
+++ b/parse_names_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// helper to wrap a name in -pn tags
+func pn(name string) []byte {
+	b := []byte{0xC2, 'p', 'n'}
+	b = append(b, []byte(name)...)
+	b = append(b, 0xC2, 'p', 'n')
+	return b
+}
+
+func TestParseNamesSkipsDelimiters(t *testing.T) {
+	tests := []struct {
+		data []byte
+		want []string
+	}{
+		{
+			data: func() []byte {
+				d := pn("Alice")
+				d = append(d, []byte(", and ")...)
+				d = append(d, pn("Bob")...)
+				return d
+			}(),
+			want: []string{"Alice", "Bob"},
+		},
+		{
+			data: func() []byte {
+				d := pn("Chad")
+				d = append(d, []byte(" and ")...)
+				d = append(d, pn("Dana")...)
+				return d
+			}(),
+			want: []string{"Chad", "Dana"},
+		},
+		{
+			data: func() []byte {
+				d := pn("Eve")
+				d = append(d, []byte(", ")...)
+				d = append(d, pn("Finn")...)
+				return d
+			}(),
+			want: []string{"Eve", "Finn"},
+		},
+	}
+	for _, tt := range tests {
+		got := parseNames(tt.data)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("parseNames() = %v, want %v", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- allow parseNames to skip spaces and the word "and" between `-pn` segments
- add tests verifying parseNames parses comma and "and" delimiters

## Testing
- `go vet ./...` *(fails: Package 'alsa' not found; X11 headers missing)*
- `go test ./...` *(fails: Package 'alsa' not found; X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a25ed39d9c832a918a1c6a1889d396