### PR TITLE
Handle BEPP share messages

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -111,8 +111,9 @@ func decodeBEPP(data []byte) string {
 			return "info: " + text
 		}
 	case "sh":
+		parseShareText(raw, text)
 		if text != "" {
-			return "share: " + text
+			return text
 		}
 	case "be":
 		// Back-end command: handle internally using raw (unstripped) data.


### PR DESCRIPTION
## Summary
- Parse BEPP `sh` messages to update player sharing state
- Return share text directly so messages display without prefixes

## Testing
- `go fmt decode.go`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a25ecc9208832aa8c788f4bde1b28b