### PR TITLE
Add optional chat and console timestamps

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -1,14 +1,23 @@
 package main
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+	"time"
+)
 
 const (
 	maxChatMessages = 1000
 )
 
+type timedMessage struct {
+	Text string
+	Time time.Time
+}
+
 var (
 	chatMsgMu sync.Mutex
-	chatMsgs  []string
+	chatMsgs  []timedMessage
 )
 
 func chatMessage(msg string) {
@@ -16,7 +25,7 @@ func chatMessage(msg string) {
 		return
 	}
 	chatMsgMu.Lock()
-	chatMsgs = append(chatMsgs, msg)
+	chatMsgs = append(chatMsgs, timedMessage{Text: msg, Time: time.Now()})
 
 	//Remove oldest message if full
 	if len(chatMsgs) > maxChatMessages {
@@ -37,6 +46,12 @@ func getChatMessages() []string {
 	defer chatMsgMu.Unlock()
 
 	out := make([]string, len(chatMsgs))
-	copy(out, chatMsgs)
+	for i, msg := range chatMsgs {
+		if gs.ChatTimestamps {
+			out[i] = fmt.Sprintf("[%s] %s", msg.Time.Format("15:04"), msg.Text)
+		} else {
+			out[i] = msg.Text
+		}
+	}
 	return out
 }

--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -12,8 +12,7 @@ func updateChatWindow() {
 		return
 	}
 
-	msgs := getChatMessages()
-	updateTextWindow(chatWin, chatList, nil, msgs, gs.ChatFontSize, "")
+	updateTextWindow(chatWin, chatList, nil, getChatMessages(), gs.ChatFontSize, "")
 	if chatList != nil {
 		// Auto-scroll list to bottom on new messages
 		chatList.Scroll.Y = 1e9

--- a/console.go
+++ b/console.go
@@ -1,6 +1,10 @@
 package main
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+	"time"
+)
 
 const (
 	maxMessages = 1000
@@ -8,7 +12,7 @@ const (
 
 var (
 	messageMu sync.Mutex
-	messages  []string
+	messages  []timedMessage
 )
 
 func consoleMessage(msg string) {
@@ -17,7 +21,7 @@ func consoleMessage(msg string) {
 	}
 
 	messageMu.Lock()
-	messages = append(messages, msg)
+	messages = append(messages, timedMessage{Text: msg, Time: time.Now()})
 
 	//Remove oldest message if full
 	if len(messages) > maxMessages {
@@ -33,6 +37,12 @@ func getConsoleMessages() []string {
 	defer messageMu.Unlock()
 
 	out := make([]string, len(messages))
-	copy(out, messages)
+	for i, msg := range messages {
+		if gs.ConsoleTimestamps {
+			out[i] = fmt.Sprintf("[%s] %s", msg.Time.Format("15:04"), msg.Text)
+		} else {
+			out[i] = msg.Text
+		}
+	}
 	return out
 }

--- a/console_ui.go
+++ b/console_ui.go
@@ -17,16 +17,16 @@ func updateConsoleWindow() {
 	if inputActive {
 		inputMsg = string(inputText)
 	}
-	msgs := getConsoleMessages()
-	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
-	if messagesFlow != nil && len(msgs) > consolePrevCount {
+	lines := getConsoleMessages()
+	updateTextWindow(consoleWin, messagesFlow, inputFlow, lines, gs.ConsoleFontSize, inputMsg)
+	if messagesFlow != nil && len(lines) > consolePrevCount {
 		// Scroll to bottom on new text; clamp occurs on Refresh.
 		messagesFlow.Scroll.Y = 1e9
 		if consoleWin != nil {
 			consoleWin.Refresh()
 		}
 	}
-	consolePrevCount = len(msgs)
+	consolePrevCount = len(lines)
 }
 
 func makeConsoleWindow() {

--- a/settings.go
+++ b/settings.go
@@ -77,6 +77,8 @@ var gsdef settings = settings{
 	MessagesToConsole: false,
 	ChatTTS:           false,
 	ChatTTSVolume:     1.0,
+	ChatTimestamps:    false,
+	ConsoleTimestamps: false,
 	WindowTiling:      false,
 	WindowSnapping:    false,
 	NoCaching:         false,
@@ -158,6 +160,8 @@ type settings struct {
 	MessagesToConsole bool
 	ChatTTS           bool
 	ChatTTSVolume     float64
+	ChatTimestamps    bool
+	ConsoleTimestamps bool
 	WindowTiling      bool
 	WindowSnapping    bool
 

--- a/ui.go
+++ b/ui.go
@@ -1253,6 +1253,38 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(bubbleMsgCB)
 
+	chatTSCB, chatTSEvents := eui.NewCheckbox()
+	chatTSCB.Text = "Chat timestamps"
+	chatTSCB.Size = eui.Point{X: rightW, Y: 24}
+	chatTSCB.Checked = gs.ChatTimestamps
+	chatTSEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			gs.ChatTimestamps = ev.Checked
+			settingsDirty = true
+			updateChatWindow()
+		}
+	}
+	right.AddItem(chatTSCB)
+
+	consoleTSCB, consoleTSEvents := eui.NewCheckbox()
+	consoleTSCB.Text = "Console timestamps"
+	consoleTSCB.Size = eui.Point{X: rightW, Y: 24}
+	consoleTSCB.Checked = gs.ConsoleTimestamps
+	consoleTSEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			gs.ConsoleTimestamps = ev.Checked
+			settingsDirty = true
+			updateConsoleWindow()
+		}
+	}
+	right.AddItem(consoleTSCB)
+
 	chatTTSRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
 
 	chatTTSCB, chatTTSEvents := eui.NewCheckbox()


### PR DESCRIPTION
## Summary
- track chat and console messages with timestamps
- add settings and UI toggles for showing timestamps
- update windows to render formatted messages

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a3c2c35730832a88168e14116d86cb