### PR TITLE
Add versioning to characters file

### DIFF
--- a/characters.go
+++ b/characters.go
@@ -16,18 +16,33 @@ type Character struct {
 var characters []Character
 
 const (
-	charsFilePath = "characters.json"
+	charsFilePath    = "characters.json"
+	charsFileVersion = 1
 )
+
+type charactersFile struct {
+	Version    int         `json:"version"`
+	Characters []Character `json:"characters"`
+}
 
 func loadCharacters() {
 	data, err := os.ReadFile(filepath.Join(dataDirPath, charsFilePath))
-	if err == nil {
-		_ = json.Unmarshal(data, &characters)
+	if err != nil {
+		return
 	}
+	var cf charactersFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		return
+	}
+	if cf.Version != charsFileVersion {
+		return
+	}
+	characters = cf.Characters
 }
 
 func saveCharacters() {
-	data, err := json.MarshalIndent(characters, "", "  ")
+	cf := charactersFile{Version: charsFileVersion, Characters: characters}
+	data, err := json.MarshalIndent(cf, "", "  ")
 	if err != nil {
 		log.Printf("save characters: %v", err)
 		return

--- a/characters_test.go
+++ b/characters_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCharactersRequiresVersion(t *testing.T) {
+	dir := t.TempDir()
+	oldDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	if err := os.Mkdir("data", 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := []byte(`[{"name":"foo","passHash":"bar"}]`)
+	if err := os.WriteFile(filepath.Join("data", charsFilePath), data, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	characters = nil
+	loadCharacters()
+	if len(characters) != 0 {
+		t.Fatalf("expected 0 characters, got %d", len(characters))
+	}
+}
+
+func TestLoadCharactersWithVersion(t *testing.T) {
+	dir := t.TempDir()
+	oldDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	if err := os.Mkdir("data", 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cf := charactersFile{
+		Version:    charsFileVersion,
+		Characters: []Character{{Name: "foo", PassHash: "bar"}},
+	}
+	data, err := json.Marshal(cf)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("data", charsFilePath), data, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	characters = nil
+	loadCharacters()
+	if len(characters) != 1 || characters[0].Name != "foo" {
+		t.Fatalf("characters not loaded: %+v", characters)
+	}
+}


### PR DESCRIPTION
## Summary
- track characters.json version and skip loading files with missing or wrong version
- add tests for characters.json version handling

## Testing
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: GLFW missing DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68a454ae65c0832ab9677b64343135c5