### PR TITLE
Restore window state from settings

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -377,6 +377,35 @@ func clampWindowState(st *WindowState, sx, sy float64) {
 	}
 }
 
+func applyWindowState(win *eui.WindowData, st *WindowState) {
+	if win == nil || st == nil {
+		return
+	}
+	if st.Size.X >= eui.MinWindowSize && st.Size.Y >= eui.MinWindowSize {
+		_ = win.SetSize(eui.Point{X: float32(st.Size.X), Y: float32(st.Size.Y)})
+	}
+	if st.Position.X != 0 || st.Position.Y != 0 {
+		_ = win.SetPos(eui.Point{X: float32(st.Position.X), Y: float32(st.Position.Y)})
+	}
+	if st.Open {
+		win.MarkOpen()
+	}
+}
+
+func restoreWindowSettings() {
+	applyWindowState(gameWin, &gs.GameWindow)
+	if gameWin != nil {
+		gameWin.MarkOpen()
+	}
+	applyWindowState(inventoryWin, &gs.InventoryWindow)
+	applyWindowState(playersWin, &gs.PlayersWindow)
+	applyWindowState(consoleWin, &gs.MessagesWindow)
+	applyWindowState(chatWin, &gs.ChatWindow)
+	if hudWin != nil {
+		hudWin.MarkOpen()
+	}
+}
+
 type qualityPreset struct {
 	DenoiseImages   bool
 	MotionSmoothing bool

--- a/ui.go
+++ b/ui.go
@@ -155,12 +155,7 @@ func initUI() {
 	// avatars/classes can show up immediately.
 	loadPlayersPersist()
 
-	if !gs.MessagesToConsole {
-		chatWin.MarkOpen()
-	}
-	consoleWin.MarkOpen()
-	inventoryWin.MarkOpen()
-	playersWin.MarkOpen()
+	restoreWindowSettings()
 
 	if status.NeedImages || status.NeedSounds {
 		downloadWin.MarkOpen()


### PR DESCRIPTION
## Summary
- apply saved window positions, sizes, and open states when initializing
- centralize window state restoration logic
- ensure toolbar and game window are always opened

## Testing
- `go test ./...` *(fails: Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a45a4788cc832ab0a5faa3ab07ae99