### PR TITLE
Prompt for password when character not remembered and add demo mode

### DIFF
--- a/login.go
+++ b/login.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -38,6 +40,149 @@ func handleDisconnect() {
 
 const CL_ImagesFile = "CL_Images"
 const CL_SoundsFile = "CL_Sounds"
+
+// fetchRandomDemoCharacter retrieves the server's demo characters and returns one at random.
+func fetchRandomDemoCharacter(clientVersion int) (string, error) {
+	imagesVersion, err := readKeyFileVersion(filepath.Join(dataDirPath, CL_ImagesFile))
+	imagesMissing := false
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("CL_Images missing; will fetch from server")
+			imagesVersion = 0
+			imagesMissing = true
+		} else {
+			log.Printf("warning: %v", err)
+			imagesVersion = encodeFullVersion(clientVersion)
+		}
+	}
+
+	soundsVersion, err := readKeyFileVersion(filepath.Join(dataDirPath, CL_SoundsFile))
+	soundsMissing := false
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("CL_Sounds missing; will fetch from server")
+			soundsVersion = 0
+			soundsMissing = true
+		} else {
+			log.Printf("warning: %v", err)
+			soundsVersion = encodeFullVersion(clientVersion)
+		}
+	}
+
+	sendVersion := int(imagesVersion >> 8)
+	clientFull := encodeFullVersion(sendVersion)
+	soundsOutdated := soundsVersion != clientFull
+	if soundsOutdated && !soundsMissing {
+		log.Printf("warning: CL_Sounds version %d does not match client version %d", soundsVersion>>8, sendVersion)
+	}
+	if imagesMissing || soundsMissing || soundsOutdated || sendVersion == 0 {
+		sendVersion = baseVersion - 1
+	}
+
+	tcpConn, err := net.Dial("tcp", host)
+	if err != nil {
+		return "", fmt.Errorf("tcp connect: %w", err)
+	}
+	defer tcpConn.Close()
+
+	udpConn, err := net.Dial("udp", host)
+	if err != nil {
+		tcpConn.Close()
+		return "", fmt.Errorf("udp connect: %w", err)
+	}
+	defer udpConn.Close()
+
+	var idBuf [4]byte
+	if _, err := io.ReadFull(tcpConn, idBuf[:]); err != nil {
+		return "", fmt.Errorf("read id: %w", err)
+	}
+	handshake := append([]byte{0xff, 0xff}, idBuf[:]...)
+	if _, err := udpConn.Write(handshake); err != nil {
+		return "", fmt.Errorf("send handshake: %w", err)
+	}
+	var confirm [2]byte
+	if _, err := io.ReadFull(tcpConn, confirm[:]); err != nil {
+		return "", fmt.Errorf("confirm handshake: %w", err)
+	}
+	if err := sendClientIdentifiers(tcpConn, encodeFullVersion(sendVersion), imagesVersion, soundsVersion); err != nil {
+		return "", fmt.Errorf("send identifiers: %w", err)
+	}
+
+	msg, err := readTCPMessage(tcpConn)
+	if err != nil {
+		return "", fmt.Errorf("read challenge: %w", err)
+	}
+	if len(msg) < 16 {
+		return "", fmt.Errorf("short challenge message")
+	}
+	const kMsgChallenge = 18
+	if binary.BigEndian.Uint16(msg[:2]) != kMsgChallenge {
+		return "", fmt.Errorf("unexpected msg tag %d", binary.BigEndian.Uint16(msg[:2]))
+	}
+	challenge := msg[16 : 16+16]
+
+	answer, err := answerChallenge("demo", challenge)
+	if err != nil {
+		return "", fmt.Errorf("hash: %w", err)
+	}
+	const kMsgCharList = 14
+	accountBytes := encodeMacRoman("demo")
+	packet := make([]byte, 16+len(accountBytes)+1+len(answer))
+	binary.BigEndian.PutUint16(packet[0:2], kMsgCharList)
+	binary.BigEndian.PutUint16(packet[2:4], 0)
+	binary.BigEndian.PutUint32(packet[4:8], encodeFullVersion(sendVersion))
+	binary.BigEndian.PutUint32(packet[8:12], imagesVersion)
+	binary.BigEndian.PutUint32(packet[12:16], soundsVersion)
+	copy(packet[16:], accountBytes)
+	packet[16+len(accountBytes)] = 0
+	copy(packet[17+len(accountBytes):], answer)
+	simpleEncrypt(packet[16:])
+	if err := sendTCPMessage(tcpConn, packet); err != nil {
+		return "", fmt.Errorf("send character list: %w", err)
+	}
+
+	resp, err := readTCPMessage(tcpConn)
+	if err != nil {
+		return "", fmt.Errorf("read character list: %w", err)
+	}
+	if len(resp) < 16 {
+		return "", fmt.Errorf("short char list resp")
+	}
+	if binary.BigEndian.Uint16(resp[:2]) != kMsgCharList {
+		return "", fmt.Errorf("unexpected tag %d", binary.BigEndian.Uint16(resp[:2]))
+	}
+	result := int16(binary.BigEndian.Uint16(resp[2:4]))
+	simpleEncrypt(resp[16:])
+	if result != 0 {
+		msg := resp[16:]
+		if i := bytes.IndexByte(msg, 0); i >= 0 {
+			msg = msg[:i]
+		}
+		return "", fmt.Errorf("%s", decodeMacRoman(msg))
+	}
+	if len(resp) < 28 {
+		return "", fmt.Errorf("short char list resp")
+	}
+
+	data := resp[16:]
+	namesData := data[12:]
+	var names []string
+	for len(namesData) > 0 {
+		i := bytes.IndexByte(namesData, 0)
+		if i <= 0 {
+			break
+		}
+		n := strings.TrimSpace(decodeMacRoman(namesData[:i]))
+		if n != "" {
+			names = append(names, n)
+		}
+		namesData = namesData[i+1:]
+	}
+	if len(names) == 0 {
+		return "", fmt.Errorf("no demo characters returned")
+	}
+	return names[rand.Intn(len(names))], nil
+}
 
 // login connects to the server and performs the login handshake.
 // It runs the network loops and blocks until the context is canceled.
@@ -138,69 +283,10 @@ func login(ctx context.Context, clientVersion int) error {
 		}
 		challenge := msg[16 : 16+16]
 
-		if account != "" || demo {
-			acct := account
-			acctPass := accountPass
-			if demo {
-				acct = "demo"
-				acctPass = "demo"
-			}
-			names, err := requestCharList(tcpConn, acct, acctPass, challenge, encodeFullVersion(sendVersion), imagesVersion, soundsVersion)
-			if err != nil {
-				tcpConn.Close()
-				udpConn.Close()
-				return fmt.Errorf("list characters: %w", err)
-			}
-			if len(names) == 0 {
-				tcpConn.Close()
-				udpConn.Close()
-				return fmt.Errorf("no characters available for account %v", acct)
-			}
-			if demo {
-				name = names[rand.Intn(len(names))]
-				logDebug("selected demo character: %v", name)
-				pass = "demo"
-			} else {
-				selected := false
-				if name != "" {
-					for _, n := range names {
-						if n == name {
-							logDebug("selected character: %v", name)
-							selected = true
-							break
-						}
-					}
-					if !selected {
-						logError("character %v not found in account %v", name, account)
-					}
-				}
-				if !selected {
-					if len(names) == 1 {
-						name = names[0]
-						logDebug("selected character: %v", name)
-					} else {
-						logDebug("available characters:")
-						for i, n := range names {
-							logDebug("%d) %v", i+1, n)
-						}
-						logDebug("select character: ")
-						var choice int
-						for {
-							if _, err := fmt.Scanln(&choice); err != nil || choice < 1 || choice > len(names) {
-								logDebug("enter a number between 1 and %d: ", len(names))
-								continue
-							}
-							break
-						}
-						name = names[choice-1]
-						logDebug("selected character: %v", name)
-					}
-				}
-			}
-		}
-		if pass == "" && passHash == "" && !demo {
-			logDebug("enter character password: ")
-			fmt.Scanln(&pass)
+		if pass == "" && passHash == "" {
+			tcpConn.Close()
+			udpConn.Close()
+			return fmt.Errorf("character password required")
 		}
 		playerName = name
 

--- a/main.go
+++ b/main.go
@@ -23,14 +23,11 @@ import (
 var (
 	clMovFPS int = 5
 
-	host        string = "server.deltatao.com:5010"
-	account     string
-	accountPass string
-	name        string
-	pass        string
-	passHash    string
+	host     string = "server.deltatao.com:5010"
+	name     string
+	pass     string
+	passHash string
 
-	demo          bool
 	clmov         string
 	pcapPath      string
 	fake          bool


### PR DESCRIPTION
## Summary
- Store blank hash when adding a character without remembering the password
- Prompt for password entry if a character has no stored password
- Remove obsolete terminal-based login code and account variables
- Add "Try the demo" button that logs in with a random demo character

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*


------
https://chatgpt.com/codex/tasks/task_e_68a46052b4d8832a8d366364e1cda644