### PR TITLE
Skip auto placement when settings restored

### DIFF
--- a/game.go
+++ b/game.go
@@ -1778,7 +1778,9 @@ func makeGameWindow() {
 	gameWin.NoCache = true
 	gameWin.NoScale = true
 	gameWin.AlwaysDrawFirst = true
-	gameWin.SetZone(eui.HZoneCenter, eui.VZoneTop)
+	if !settingsLoaded {
+		gameWin.SetZone(eui.HZoneCenter, eui.VZoneTop)
+	}
 	gameWin.Size = eui.Point{X: 8000, Y: 8000}
 	gameWin.MarkOpen()
 	gameWin.OnResize = func() { onGameWindowResize() }

--- a/settings.go
+++ b/settings.go
@@ -25,6 +25,9 @@ const (
 
 var gs settings = gsdef
 
+// settingsLoaded reports whether settings were successfully loaded from disk.
+var settingsLoaded bool
+
 var gsdef settings = settings{
 	Version: SETTINGS_VERSION,
 
@@ -195,6 +198,7 @@ func loadSettings() bool {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		applyQualityPreset("High")
+		settingsLoaded = false
 		return false
 	}
 
@@ -204,17 +208,20 @@ func loadSettings() bool {
 	}
 	tmp.settings = gsdef
 	if err := json.Unmarshal(data, &tmp); err != nil {
+		settingsLoaded = false
 		return false
 	}
 
 	if tmp.Version == SETTINGS_VERSION {
 		gs = tmp.settings
+		settingsLoaded = true
 	} else {
 		applyQualityPreset("High")
+		settingsLoaded = false
 	}
 
 	clampWindowSettings()
-	return true
+	return settingsLoaded
 }
 
 func applySettings() {


### PR DESCRIPTION
## Summary
- track when settings load succeeds and skip default game window zone when restoring

## Testing
- `go test ./...` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b8bc368832ab5721c2db229730f