### PR TITLE
Add tests for scrambleHash blank password handling

### DIFF
--- a/characters_test.go
+++ b/characters_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestScrambleHashBlank(t *testing.T) {
+	if s := scrambleHash("name", ""); s != "" {
+		t.Fatalf("scrambleHash on blank hash = %q, want empty", s)
+	}
+	if s := unscrambleHash("name", ""); s != "" {
+		t.Fatalf("unscrambleHash on blank hash = %q, want empty", s)
+	}
+}
+
+func TestScrambleHashBlankString(t *testing.T) {
+	if s := scrambleHash("", ""); s != "" {
+		t.Fatalf("scrambleHash on blank name and hash = %q, want empty", s)
+	}
+	if s := unscrambleHash("", ""); s != "" {
+		t.Fatalf("unscrambleHash on blank name and hash = %q, want empty", s)
+	}
+}
+
+func TestScrambleHashRoundTrip(t *testing.T) {
+	const name = "char"
+	const hash = "0123456789abcdef0123456789abcdef"
+	enc := scrambleHash(name, hash)
+	if enc == hash {
+		t.Fatalf("scrambleHash(%q, %q) = %q, expected different", name, hash, enc)
+	}
+	dec := unscrambleHash(name, enc)
+	if dec != hash {
+		t.Fatalf("unscrambleHash returned %q, want %q", dec, hash)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests ensuring `scrambleHash` and `unscrambleHash` correctly handle empty password hashes
- validate round-trip scramble/unscramble logic
- verify blank name and hash inputs return empty string

## Testing
- `go test ./...` *(fails: missing ALSA, Xrandr, GTK libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b47daf0832a85dcf3a9cbdb8977