### PR TITLE
Clear unremembered passwords on disconnect

### DIFF
--- a/login.go
+++ b/login.go
@@ -34,8 +34,19 @@ func handleDisconnect() {
 	// Reset session sources so we return to splash state
 	clmov = ""
 	pcapPath = ""
+	pass = ""
+	if passHash == "" && name != "" {
+		for i := range characters {
+			if characters[i].Name == name && characters[i].passHash != "" {
+				characters[i].passHash = ""
+				saveCharacters()
+				break
+			}
+		}
+	}
 	consoleMessage("Disconnected from server.")
 	loginWin.MarkOpen()
+	updateCharacterButtons()
 }
 
 const CL_ImagesFile = "CL_Images"


### PR DESCRIPTION
## Summary
- clear plaintext password when disconnecting
- drop persisted password hash when "Remember Password" is off
- refresh login UI to honor "Remember Password" setting

## Testing
- `go test ./...` *(fails: Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c674d80832a9e773566aaa14a5c