### PR TITLE
Persist Ebiten window size across sessions

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,11 +53,10 @@ func main() {
 		clMovFPS = 30
 	}
 
-	ebiten.SetWindowSize(1920, 1080)
+	loadSettings()
+	ebiten.SetWindowSize(gs.WindowWidth, gs.WindowHeight)
 
 	var err error
-
-	loadSettings()
 
 	loadCharacters()
 	initSoundContext()

--- a/settings.go
+++ b/settings.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-const SETTINGS_VERSION = 5
+const SETTINGS_VERSION = 6
 
 type BarPlacement int
 
@@ -65,6 +65,8 @@ var gsdef settings = settings{
 	DenoiseAmount:     0.2,
 	ShowFPS:           true,
 	UIScale:           1.0,
+	WindowWidth:       initialWindowW,
+	WindowHeight:      initialWindowH,
 	Volume:            1.0,
 	GameScale:         2,
 	BarPlacement:      BarPlacementBottom,
@@ -126,6 +128,8 @@ type settings struct {
 	UIScale           float64
 	Fullscreen        bool
 	AlwaysOnTop       bool
+	WindowWidth       int
+	WindowHeight      int
 	Volume            float64
 	Mute              bool
 	GameScale         float64
@@ -218,6 +222,10 @@ func loadSettings() bool {
 	} else {
 		applyQualityPreset("High")
 		settingsLoaded = false
+	}
+
+	if gs.WindowWidth > 0 && gs.WindowHeight > 0 {
+		eui.SetScreenSize(gs.WindowWidth, gs.WindowHeight)
 	}
 
 	clampWindowSettings()
@@ -319,6 +327,12 @@ func syncWindowSettings() bool {
 		}
 	} else if gs.ChatWindow.Open {
 		gs.ChatWindow.Open = false
+		changed = true
+	}
+	w, h := ebiten.WindowSize()
+	if gs.WindowWidth != w || gs.WindowHeight != h {
+		gs.WindowWidth = w
+		gs.WindowHeight = h
 		changed = true
 	}
 	return changed


### PR DESCRIPTION
## Summary
- store outer window dimensions in settings and restore on startup
- track window size changes to keep settings up-to-date

## Testing
- `go test ./...` *(fails: build hung or dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a48ae7fd44832ab3c7b6386db41927