### PR TITLE
Reset window states when resetting settings

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1824,6 +1824,48 @@ func resetAllSettings() {
 	saveSettings()
 	settingsDirty = false
 
+	// Close existing windows so they can be recreated in their default state.
+	if inventoryWin != nil {
+		inventoryWin.Close()
+		inventoryWin = nil
+	}
+	if playersWin != nil {
+		playersWin.Close()
+		playersWin = nil
+	}
+	if consoleWin != nil {
+		consoleWin.Close()
+		consoleWin = nil
+	}
+	if chatWin != nil {
+		chatWin.Close()
+		chatWin = nil
+	}
+
+	// Recreate windows according to default settings.
+	if gs.InventoryWindow.Open {
+		makeInventoryWindow()
+	}
+	if gs.PlayersWindow.Open {
+		makePlayersWindow()
+	}
+	if gs.MessagesWindow.Open {
+		makeConsoleWindow()
+	}
+	if gs.ChatWindow.Open {
+		_ = makeChatWindow()
+	}
+
+	restoreWindowSettings()
+
+	if inventoryWin != nil {
+		updateInventoryWindow()
+		inventoryWin.Refresh()
+	}
+	if playersWin != nil {
+		updatePlayersWindow()
+		playersWin.Refresh()
+	}
 	if consoleWin != nil {
 		updateConsoleWindow()
 		consoleWin.Refresh()


### PR DESCRIPTION
## Summary
- Reset window-specific state when "Reset All Settings" is used
- Recreate main windows at their default positions and refresh

## Testing
- `go build ./...` *(fails: X11/extensions/Xrandr.h missing; ALSA pkg-config not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a490aa6d3c832a9ad5f4c9f9d5ed2c