### PR TITLE
Persist window zones and restore positions

### DIFF
--- a/eui/zone_state.go
+++ b/eui/zone_state.go
@@ -35,6 +35,8 @@ func LoadWindowZones(table map[string]WindowZoneState) {
 			} else {
 				win.ClearZone()
 			}
+		} else {
+			win.ClearZone()
 		}
 	}
 }

--- a/eui/zone_state_test.go
+++ b/eui/zone_state_test.go
@@ -36,3 +36,25 @@ func TestSaveLoadWindowZones(t *testing.T) {
 	}
 	windows = nil
 }
+
+func TestLoadWindowZonesMissingEntry(t *testing.T) {
+	screenWidth = 100
+	screenHeight = 100
+	uiScale = 1
+
+	a := &windowData{Title: "a"}
+	b := &windowData{Title: "b"}
+	windows = []*windowData{a, b}
+
+	a.SetZone(HZoneLeft, VZoneTop)
+	saved := SaveWindowZones()
+	delete(saved, "b")
+
+	b.SetZone(HZoneRight, VZoneBottom)
+	LoadWindowZones(saved)
+
+	if b.zone != nil {
+		t.Fatalf("b zone should be cleared: %+v", b.zone)
+	}
+	windows = nil
+}

--- a/settings.go
+++ b/settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"gothoom/climg"
@@ -160,6 +161,7 @@ type settings struct {
 	PlayersWindow   WindowState
 	MessagesWindow  WindowState
 	ChatWindow      WindowState
+	WindowZones     map[string]eui.WindowZoneState
 
 	imgPlanesDebug      bool
 	smoothingDebug      bool
@@ -340,6 +342,11 @@ func syncWindowSettings() bool {
 		gs.ChatWindow.Open = false
 		changed = true
 	}
+	zones := eui.SaveWindowZones()
+	if !reflect.DeepEqual(zones, gs.WindowZones) {
+		gs.WindowZones = zones
+		changed = true
+	}
 	w, h := ebiten.WindowSize()
 	if gs.WindowWidth != w || gs.WindowHeight != h {
 		gs.WindowWidth = w
@@ -425,6 +432,7 @@ func applyWindowState(win *eui.WindowData, st *WindowState) {
 }
 
 func restoreWindowSettings() {
+	eui.LoadWindowZones(gs.WindowZones)
 	applyWindowState(gameWin, &gs.GameWindow)
 	if gameWin != nil {
 		gameWin.MarkOpen()


### PR DESCRIPTION
## Summary
- Save and load per-window zone assignments so user window locations aren't overridden
- Restore saved zones before applying window size and position
- Track window zone changes in settings and clear zones for windows with no saved state

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a49250992c832a9c6570ab50e1e30a