### PR TITLE
Handle sentinel IDs in image and movie loading

### DIFF
--- a/images.go
+++ b/images.go
@@ -107,6 +107,9 @@ func makeMobileKey(id uint16, state uint8, colors []byte) mobileKey {
 // regardless of the pictDef flags. Mobile sprites require this behavior
 // since the original client always treats index 0 as transparent for them.
 func loadSheet(id uint16, colors []byte, forceTransparent bool) *ebiten.Image {
+	if id == 0xffff {
+		return nil
+	}
 	key := makeSheetKey(id, colors, forceTransparent)
 	if !gs.NoCaching {
 		imageMu.Lock()

--- a/movie.go
+++ b/movie.go
@@ -257,7 +257,11 @@ func parseMobileTable(data []byte, pos int, version, revision uint16) int {
 		d := frameDescriptor{Index: uint8(idx)}
 		d.Type = uint8(binary.BigEndian.Uint32(buf[16:20]))
 		pict := binary.BigEndian.Uint32(buf[0:4])
-		d.PictID = uint16(pict & 0xffff)
+		if pict == 0xffffffff || uint16(pict) == 0xffff {
+			d.PictID = 0
+		} else {
+			d.PictID = uint16(pict)
+		}
 
 		numColors := int(binary.BigEndian.Uint32(buf[l.numColorsOffset : l.numColorsOffset+4]))
 		if numColors < 0 || numColors > 30 {


### PR DESCRIPTION
## Summary
- Avoid fetching sprites when `loadSheet` receives the sentinel ID `0xffff`
- Normalize descriptor picture IDs in movies by setting `PictID` to 0 when the pict value is `0xffffffff` or ends with `0xffff`

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4a3814250832a9190a0d4d70e5c1b