### PR TITLE
Prevent window size reset on shutdown

### DIFF
--- a/game.go
+++ b/game.go
@@ -522,6 +522,7 @@ var once sync.Once
 func (g *Game) Update() error {
 	select {
 	case <-gameCtx.Done():
+		syncWindowSettings()
 		return errors.New("shutdown")
 	default:
 	}
@@ -1756,7 +1757,6 @@ func runGame(ctx context.Context) {
 	if err := ebiten.RunGameWithOptions(&Game{}, op); err != nil {
 		log.Printf("ebiten: %v", err)
 	}
-	syncWindowSettings()
 	saveSettings()
 }
 

--- a/settings.go
+++ b/settings.go
@@ -348,10 +348,12 @@ func syncWindowSettings() bool {
 		changed = true
 	}
 	w, h := ebiten.WindowSize()
-	if gs.WindowWidth != w || gs.WindowHeight != h {
-		gs.WindowWidth = w
-		gs.WindowHeight = h
-		changed = true
+	if w > 0 && h > 0 {
+		if gs.WindowWidth != w || gs.WindowHeight != h {
+			gs.WindowWidth = w
+			gs.WindowHeight = h
+			changed = true
+		}
 	}
 	return changed
 }


### PR DESCRIPTION
## Summary
- guard syncWindowSettings against zero-sized window queries
- sync window settings during shutdown rather than after RunGameWithOptions

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5002fb4832a9a9846bd90a581d5