### PR TITLE
Fix overlay item click detection

### DIFF
--- a/input_ui.go
+++ b/input_ui.go
@@ -29,5 +29,33 @@ func pointInUI(x, y int) bool {
 		}
 	}
 
+	if gameWin != nil && gameWin.IsOpen() {
+		if pointInItems(gameWin.Contents, fx, fy) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func pointInItems(items []*eui.ItemData, fx, fy float32) bool {
+	for _, it := range items {
+		if it == nil || it.Invisible {
+			continue
+		}
+		if fx >= it.DrawRect.X0 && fx < it.DrawRect.X1 && fy >= it.DrawRect.Y0 && fy < it.DrawRect.Y1 {
+			return true
+		}
+		if len(it.Contents) > 0 && pointInItems(it.Contents, fx, fy) {
+			return true
+		}
+		if len(it.Tabs) > 0 {
+			for _, tab := range it.Tabs {
+				if pointInItems(tab.Contents, fx, fy) {
+					return true
+				}
+			}
+		}
+	}
 	return false
 }

--- a/input_ui_test.go
+++ b/input_ui_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"gothoom/eui"
+	"testing"
+)
+
+func TestPointInUIOverlay(t *testing.T) {
+	gameWin = eui.NewWindow()
+	gameWin.MarkOpen()
+	btn, _ := eui.NewButton()
+	btn.DrawRect.X0 = 10
+	btn.DrawRect.Y0 = 10
+	btn.DrawRect.X1 = 20
+	btn.DrawRect.Y1 = 20
+	gameWin.AddItem(btn)
+	if !pointInUI(15, 15) {
+		t.Fatalf("pointInUI should detect overlay item")
+	}
+}


### PR DESCRIPTION
## Summary
- handle clicks on overlay items by checking game window contents
- add test covering overlay detection

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aac36874832aa6e1115d4a126f23