### PR TITLE
Split fallen notifications into fallen and not fallen

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -116,7 +116,7 @@ func decodeBEPP(data []byte) string {
 			return text
 		}
 	case "hf", "nf":
-		// Fallen or no-longer-fallen notices
+		// Fallen or not-fallen notices
 		parseFallenText(raw, text)
 		if text != "" {
 			return text

--- a/settings.go
+++ b/settings.go
@@ -72,7 +72,7 @@ var gsdef settings = settings{
 	ChatTTSVolume:        1.0,
 	Notifications:        true,
 	NotifyFallen:         true,
-	NotifyUnfallen:       true,
+	NotifyNotFallen:      true,
 	NotifyShares:         true,
 	NotifyFriendOnline:   true,
 	NotificationDuration: 6,
@@ -143,7 +143,7 @@ type settings struct {
 	ChatTTSVolume        float64
 	Notifications        bool
 	NotifyFallen         bool
-	NotifyUnfallen       bool
+	NotifyNotFallen      bool
 	NotifyShares         bool
 	NotifyFriendOnline   bool
 	NotificationDuration float64

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -228,7 +228,7 @@ func parseShareText(raw []byte, s string) bool {
 	return false
 }
 
-// parseFallenText detects fallen/no-longer-fallen messages and updates state.
+// parseFallenText detects fallen/not-fallen messages and updates state.
 // Returns true if handled.
 func parseFallenText(raw []byte, s string) bool {
 	// Fallen: "<pn name> has fallen" (with optional -mn and -lo tags)
@@ -257,7 +257,7 @@ func parseFallenText(raw []byte, s string) bool {
 		}
 		return true
 	}
-	// No longer fallen: "<pn name> is no longer fallen"
+	// Not fallen: "<pn name> is no longer fallen"
 	if strings.Contains(s, " is no longer fallen") {
 		name := firstTagContent(raw, 'p', 'n')
 		if name == "" {
@@ -276,7 +276,7 @@ func parseFallenText(raw []byte, s string) bool {
 		}
 		playersMu.Unlock()
 		playersDirty = true
-		if gs.NotifyUnfallen {
+		if gs.NotifyNotFallen {
 			showNotification(name + " is no longer fallen")
 		}
 		return true

--- a/ui.go
+++ b/ui.go
@@ -2463,7 +2463,7 @@ func makeNotificationsWindow() {
 	}
 
 	addCB("Fallen", &gs.NotifyFallen)
-	addCB("No longer fallen", &gs.NotifyUnfallen)
+	addCB("Not fallen", &gs.NotifyNotFallen)
 	addCB("Shares", &gs.NotifyShares)
 	addCB("Friend online", &gs.NotifyFriendOnline)
 


### PR DESCRIPTION
## Summary
- rename notification setting to `NotifyNotFallen`
- show "Not fallen" checkbox in notification settings UI
- update fallen parser and comments for new option

## Testing
- `go test ./...` *(fails: package gtk+-3.0 not found / build stalled)*
- `go build ./...` *(terminated: took too long to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b31e31b4832ab9d4d1561b664651