### PR TITLE
Add bard message parsing and persistence

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -159,6 +159,12 @@ func decodeBEPP(data []byte) string {
 		if text != "" {
 			return text
 		}
+	case "ba":
+		// Bard guild messages
+		parseBardText(raw, text)
+		if text != "" {
+			return text
+		}
 	case "lg":
 		// Login/logout presence notices
 		parsePresenceText(raw, text)
@@ -407,6 +413,9 @@ func handleInfoText(data []byte) {
 			continue
 		}
 		if parseFallenText(line, s) {
+			continue
+		}
+		if parseBardText(line, s) {
 			continue
 		}
 		if parsePresenceText(line, s) {

--- a/player.go
+++ b/player.go
@@ -22,6 +22,7 @@ type Player struct {
 	Dead       bool // parsed from obit messages (future)
 	FellWhere  string
 	KillerName string
+	Bard       bool // true if player is in the Bards' Guild
 	// Presence tracking
 	LastSeen time.Time // last time we observed any activity/info for this player
 	Offline  bool      // explicitly observed as offline/logged off

--- a/players_persist.go
+++ b/players_persist.go
@@ -20,6 +20,7 @@ type persistPlayer struct {
 	Dead       bool   `json:"dead"`
 	GMLevel    int    `json:"gm,omitempty"`
 	Friend     bool   `json:"friend,omitempty"`
+	Bard       bool   `json:"bard,omitempty"`
 	ColorsHex  string `json:"colors,omitempty"` // hex of [count][colors...]
 	FellWhere  string `json:"fell_where,omitempty"`
 	KillerName string `json:"killer,omitempty"`
@@ -70,6 +71,7 @@ func loadPlayersPersist() {
 		pr.Dead = p.Dead
 		pr.GMLevel = p.GMLevel
 		pr.Friend = p.Friend
+		pr.Bard = p.Bard
 		pr.FellWhere = p.FellWhere
 		pr.KillerName = p.KillerName
 		playersMu.Unlock()
@@ -117,6 +119,7 @@ func savePlayersPersist() {
 			Dead:       p.Dead,
 			GMLevel:    p.GMLevel,
 			Friend:     p.Friend,
+			Bard:       p.Bard,
 			ColorsHex:  hex,
 			FellWhere:  p.FellWhere,
 			KillerName: p.KillerName,


### PR DESCRIPTION
## Summary
- parse bard guild text to track membership
- persist bard status and handle bard BEPP messages

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d5c9465c832a819a2896c46c21ef