### PR TITLE
Decode MacRoman player names

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"strings"
+
+	"golang.org/x/text/encoding/charmap"
 )
 
 type thinkTarget int
@@ -82,7 +84,13 @@ var languageYellVerb = []string{
 	"yelps",           // Lepori
 }
 
-func decodeMacRoman(b []byte) string { return string(b) }
+func decodeMacRoman(b []byte) string {
+	s, err := charmap.Macintosh.NewDecoder().Bytes(b)
+	if err != nil {
+		return string(b)
+	}
+	return string(s)
+}
 
 /*
 BEPP tag reference (two-letter codes following the 0xC2 prefix):

--- a/macroman_test.go
+++ b/macroman_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestMacRomanEncodeDecode(t *testing.T) {
+	s := "Méme"
+	b := encodeMacRoman(s)
+	got := decodeMacRoman(b)
+	if got != s {
+		t.Fatalf("round-trip = %q, want %q", got, s)
+	}
+}

--- a/parse_names_test.go
+++ b/parse_names_test.go
@@ -53,3 +53,15 @@ func TestParseNamesSkipsDelimiters(t *testing.T) {
 		}
 	}
 }
+
+func TestParseNamesMacRoman(t *testing.T) {
+	nameBytes := []byte{'M', 0x8e, 'm', 'e'}
+	data := []byte{0xC2, 'p', 'n'}
+	data = append(data, nameBytes...)
+	data = append(data, 0xC2, 'p', 'n')
+	got := parseNames(data)
+	want := []string{"Méme"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseNames() = %v, want %v", got, want)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"golang.org/x/crypto/twofish"
+	"golang.org/x/text/encoding/charmap"
 )
 
 func simpleEncrypt(data []byte) {
@@ -24,7 +25,13 @@ func simpleEncrypt(data []byte) {
 	}
 }
 
-func encodeMacRoman(s string) []byte { return []byte(s) }
+func encodeMacRoman(s string) []byte {
+	b, err := charmap.Macintosh.NewEncoder().Bytes([]byte(s))
+	if err != nil {
+		return []byte(s)
+	}
+	return b
+}
 
 func encodeFullVersion(v int) uint32 { return uint32(v) << 8 }
 


### PR DESCRIPTION
## Summary
- decode MacRoman bytes into UTF-8 strings for proper name display
- encode UTF-8 back to MacRoman when sending data
- add tests covering MacRoman name parsing and encode/decode round trip

## Testing
- `go test ./...` *(fails: Package alsa was not found; X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d9b6abbc832a97396b49a5425999