### PR TITLE
Extend playback duration for reverb tail

### DIFF
--- a/music/player.go
+++ b/music/player.go
@@ -14,6 +14,9 @@ import (
 const (
 	sampleRate = 44100
 	block      = 512
+
+	// tailMultiplier extends the rendered length to allow reverb to decay.
+	tailMultiplier = 4
 )
 
 // Note represents a single MIDI note with a duration.
@@ -61,7 +64,7 @@ func Play(ctx *audio.Context, sf io.ReadSeeker, program int, notes []Note) error
 		events = append(events, ev)
 		cursor += durSamples
 	}
-	totalSamples := cursor
+	totalSamples := cursor * tailMultiplier
 
 	leftAll := make([]float32, 0, totalSamples)
 	rightAll := make([]float32, 0, totalSamples)


### PR DESCRIPTION
## Summary
- allow synthesized notes to decay by rendering 4x more samples in Play

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f12d59c0832a8ac524ce72b6a015