### PR TITLE
Add option to dump music to WAV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The Go client accepts the following flags:
 - `-pgo` – create `default.pgo` by playing `test.clMov` at 30 fps for 30 seconds
 - `-client-version` – client version number (`kVersionNumber`, default `1445`)
 - `-debug` – enable debug logging (default `true`)
+- `-dumpMusic` – save played music as a WAV file
 
 ## Setup
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	blockSound    bool
 	blockBubbles  bool
 	blockTTS      bool
+	dumpMusic     bool
 	clientVersion int
 )
 
@@ -45,6 +46,7 @@ func main() {
 	clientVer := flag.Int("client-version", 1445, "client version number (for testing)")
 	flag.BoolVar(&doDebug, "debug", false, "verbose/debug logging")
 	flag.BoolVar(&eui.CacheCheck, "cacheCheck", false, "display window and item render counts")
+	flag.BoolVar(&dumpMusic, "dumpMusic", false, "write played music as a .wav file")
 	genPGO := flag.Bool("pgo", false, "create default.pgo using test.clMov at 30 fps for 30s")
 	flag.Parse()
 	clientVersion = *clientVer


### PR DESCRIPTION
## Summary
- add `-dumpMusic` flag to write rendered tunes as WAV files
- generate unique `music_YYYYMMDD_HHMMSS.wav` files when flag enabled
- document the new command line option

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a504019334832aaea428011040537e