### PR TITLE
Add music volume slider to settings

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-const SETTINGS_VERSION = 6
+const SETTINGS_VERSION = 7
 
 type BarPlacement int
 
@@ -67,6 +67,7 @@ var gsdef settings = settings{
 	ShowFPS:              true,
 	UIScale:              1.0,
 	Volume:               1.0,
+	MusicVolume:          1.0,
 	GameScale:            2,
 	BarPlacement:         BarPlacementBottom,
 	ChatTTSVolume:        1.0,
@@ -134,6 +135,7 @@ type settings struct {
 	Fullscreen           bool
 	AlwaysOnTop          bool
 	Volume               float64
+	MusicVolume          float64
 	Mute                 bool
 	GameScale            float64
 	BarPlacement         BarPlacement

--- a/sound.go
+++ b/sound.go
@@ -225,6 +225,13 @@ func updateSoundVolume() {
 	}
 	ttsPlayersMu.Unlock()
 
+	musicPlayersMu.Lock()
+	music := make([]*audio.Player, 0, len(musicPlayers))
+	for p := range musicPlayers {
+		music = append(music, p)
+	}
+	musicPlayersMu.Unlock()
+
 	stopped := make([]*audio.Player, 0)
 	for _, sp := range players {
 		if sp.IsPlaying() {
@@ -240,6 +247,15 @@ func updateSoundVolume() {
 			p.SetVolume(gs.ChatTTSVolume * vol)
 		} else {
 			ttsStopped = append(ttsStopped, p)
+		}
+	}
+
+	musicStopped := make([]*audio.Player, 0)
+	for _, p := range music {
+		if p.IsPlaying() {
+			p.SetVolume(gs.MusicVolume * vol)
+		} else {
+			musicStopped = append(musicStopped, p)
 		}
 	}
 
@@ -259,6 +275,15 @@ func updateSoundVolume() {
 			p.Close()
 		}
 		ttsPlayersMu.Unlock()
+	}
+
+	if len(musicStopped) > 0 {
+		musicPlayersMu.Lock()
+		for _, p := range musicStopped {
+			delete(musicPlayers, p)
+			p.Close()
+		}
+		musicPlayersMu.Unlock()
 	}
 }
 

--- a/tune.go
+++ b/tune.go
@@ -56,7 +56,7 @@ type noteEvent struct {
 // music package. The tune may optionally begin with an instrument index.
 // For example: "3 cde" plays on instrument #3.
 func playClanLordTune(tune string) {
-	if audioContext == nil {
+	if audioContext == nil || gs.Mute || gs.Volume <= 0 || gs.MusicVolume <= 0 {
 		return
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -1458,6 +1458,25 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(tsFormatInput)
 
+	musicSlider, musicEvents := eui.NewSlider()
+	musicSlider.MinValue = 0
+	musicSlider.MaxValue = 1
+	musicSlider.Value = float32(gs.MusicVolume)
+	musicSlider.Size = eui.Point{X: rightW, Y: 24}
+	musicSlider.FontSize = 9
+	musicSlider.Label = "Music Volume"
+	musicEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			gs.MusicVolume = float64(ev.Value)
+			settingsDirty = true
+			updateSoundVolume()
+		}
+	}
+	right.AddItem(musicSlider)
+
 	chatTTSRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
 
 	chatTTSCB, chatTTSEvents := eui.NewCheckbox()


### PR DESCRIPTION
## Summary
- add music volume to user settings and bump settings version
- allow adjusting music playback volume with a new slider
- propagate music volume to running players when volume changes

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68a50ee92dd4832a96226ed1ee64734c