### PR TITLE
Add slider to cap night darkness with server override

### DIFF
--- a/night.go
+++ b/night.go
@@ -175,7 +175,16 @@ func init() {
 func drawNightOverlay(screen *ebiten.Image, ox, oy int) {
 	gNight.mu.Lock()
 	lvl := gNight.Level
+	flags := gNight.Flags
 	gNight.mu.Unlock()
+
+	limit := gs.MaxNightLevel
+	if flags&kLightForce100Pct != 0 {
+		limit = 100
+	}
+	if lvl > limit {
+		lvl = limit
+	}
 	if lvl <= 0 {
 		return
 	}

--- a/settings.go
+++ b/settings.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-const SETTINGS_VERSION = 7
+const SETTINGS_VERSION = 8
 
 type BarPlacement int
 
@@ -70,6 +70,7 @@ var gsdef settings = settings{
 	MusicVolume:          1.0,
 	GameScale:            2,
 	BarPlacement:         BarPlacementBottom,
+	MaxNightLevel:        100,
 	ChatTTSVolume:        1.0,
 	Notifications:        true,
 	NotifyFallen:         true,
@@ -139,6 +140,7 @@ type settings struct {
 	Mute                 bool
 	GameScale            float64
 	BarPlacement         BarPlacement
+	MaxNightLevel        int
 	Theme                string
 	MessagesToConsole    bool
 	ChatTTS              bool

--- a/ui.go
+++ b/ui.go
@@ -2591,6 +2591,21 @@ func makeDebugWindow() {
 	}
 	debugFlow.AddItem(nightCB)
 
+	maxNightSlider, maxNightEvents := eui.NewSlider()
+	maxNightSlider.Label = "Max Night Level"
+	maxNightSlider.MinValue = 0
+	maxNightSlider.MaxValue = 100
+	maxNightSlider.IntOnly = true
+	maxNightSlider.Value = float32(gs.MaxNightLevel)
+	maxNightSlider.Size = eui.Point{X: width - 10, Y: 24}
+	maxNightEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.MaxNightLevel = int(ev.Value)
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(maxNightSlider)
+
 	lateInputCB, lateInputEvents := eui.NewCheckbox()
 	lateInputCB.Text = "Late Input Updates (experimental)"
 	lateInputCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- add configurable maximum night level setting and debug slider
- clamp night overlay by setting; server `kLightForce100Pct` flag forces full darkness
- bump settings version to persist new preference

## Testing
- `go test ./...` *(fails: Package 'alsa' not found, Xrandr.h missing)*
- `go build ./...` *(fails: Xrandr.h missing, Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a52ff83ca4832a9fe3e0f6a8e6c4c6