### PR TITLE
Stop audio playback when muted

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -36,6 +36,13 @@ func stopAllSounds() {
 	}
 }
 
+// stopAllAudioPlayers stops and disposes every active audio player type.
+func stopAllAudioPlayers() {
+	stopAllSounds()
+	stopAllTTS()
+	stopAllMusic()
+}
+
 // playSound mixes the provided sound IDs and plays the result asynchronously.
 // Each ID is loaded, mixed with simple clipping and then played at the current
 // global volume. The function returns immediately after scheduling playback.

--- a/sound_test.go
+++ b/sound_test.go
@@ -142,3 +142,43 @@ func TestMuteDoesNotOverrideVolume(t *testing.T) {
 
 	p.Close()
 }
+
+func TestStopAllAudioPlayers(t *testing.T) {
+	initSoundContext()
+
+	sp := audioContext.NewPlayerFromBytes(make([]byte, 44100))
+	tp := audioContext.NewPlayerFromBytes(make([]byte, 44100))
+	mp := audioContext.NewPlayerFromBytes(make([]byte, 44100))
+
+	soundMu.Lock()
+	soundPlayers = map[*audio.Player]struct{}{sp: {}}
+	soundMu.Unlock()
+
+	ttsPlayersMu.Lock()
+	ttsPlayers = map[*audio.Player]struct{}{tp: {}}
+	ttsPlayersMu.Unlock()
+
+	musicPlayersMu.Lock()
+	musicPlayers = map[*audio.Player]struct{}{mp: {}}
+	musicPlayersMu.Unlock()
+
+	stopAllAudioPlayers()
+
+	soundMu.Lock()
+	if len(soundPlayers) != 0 {
+		t.Fatalf("sound players not cleared: %d", len(soundPlayers))
+	}
+	soundMu.Unlock()
+
+	ttsPlayersMu.Lock()
+	if len(ttsPlayers) != 0 {
+		t.Fatalf("tts players not cleared: %d", len(ttsPlayers))
+	}
+	ttsPlayersMu.Unlock()
+
+	musicPlayersMu.Lock()
+	if len(musicPlayers) != 0 {
+		t.Fatalf("music players not cleared: %d", len(musicPlayers))
+	}
+	musicPlayersMu.Unlock()
+}

--- a/synth.go
+++ b/synth.go
@@ -51,6 +51,15 @@ var (
 	musicPlayersMu sync.Mutex
 )
 
+func stopAllMusic() {
+	musicPlayersMu.Lock()
+	defer musicPlayersMu.Unlock()
+	for p := range musicPlayers {
+		_ = p.Close()
+		delete(musicPlayers, p)
+	}
+}
+
 func setupSynth() {
 	var err error
 

--- a/ui.go
+++ b/ui.go
@@ -266,6 +266,7 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 			if gs.Mute {
 				muteBtn.Text = "Unmute"
 				volumeSlider.Value = 0
+				stopAllAudioPlayers()
 			} else {
 				muteBtn.Text = "Mute"
 				volumeSlider.Value = float32(gs.Volume)


### PR DESCRIPTION
## Summary
- stop all types of Ebiten audio players when the mute button is toggled
- add stopAllMusic and stopAllAudioPlayers helpers
- test stopping of all audio players

## Testing
- `go test -run TestStopAllAudioPlayers -count=1` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68a52ec4e5d4832a9f6ecec0d73bb3f5