### PR TITLE
Avoid redundant downloads with outdated client version

### DIFF
--- a/login.go
+++ b/login.go
@@ -367,10 +367,14 @@ func login(ctx context.Context, clientVersion int) error {
 
 		if result == -30972 || result == -30973 {
 			logDebug("server requested update, downloading...")
-			if err := autoUpdate(resp, dataDirPath); err != nil {
+			newVer, err := autoUpdate(resp, dataDirPath)
+			if err != nil {
 				tcpConn.Close()
 				udpConn.Close()
 				return fmt.Errorf("auto update: %w", err)
+			}
+			if s, err := checkDataFiles(newVer); err == nil {
+				status = s
 			}
 			logDebug("update complete, reconnecting...")
 			tcpConn.Close()

--- a/ui.go
+++ b/ui.go
@@ -938,6 +938,22 @@ func makePasswordWindow() {
 }
 
 func startLogin() {
+	if status.Version > 0 && clientVersion < status.Version {
+		msg := fmt.Sprintf("goThoom is not tested with client version %d. It may still work with version %d.", clientVersion, status.Version)
+		showPopup(
+			"Untested Version",
+			msg,
+			[]popupButton{
+				{Text: "Cancel"},
+				{Text: "Proceed", Action: func() {
+					clientVersion = status.Version
+					startLogin()
+				}},
+			},
+		)
+		return
+	}
+
 	loginWin.Close()
 	go func() {
 		ctx, cancel := context.WithCancel(gameCtx)

--- a/ui.go
+++ b/ui.go
@@ -638,6 +638,9 @@ func makeDownloadsWindow() {
 				logError("failed to load CL_Sounds: %v", err)
 				return
 			}
+			if s, err := checkDataFiles(clientVersion); err == nil {
+				status = s
+			}
 			// Force reselect from LastCharacter if available
 			name = ""
 			passHash = ""

--- a/update.go
+++ b/update.go
@@ -154,13 +154,13 @@ func (pc *progCounter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func autoUpdate(resp []byte, dataDir string) error {
+func autoUpdate(resp []byte, dataDir string) (int, error) {
 	if len(resp) < 16 {
-		return fmt.Errorf("short response for update")
+		return 0, fmt.Errorf("short response for update")
 	}
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		logError("create %v: %v", dataDir, err)
-		return err
+		return 0, err
 	}
 	base := string(resp[16:])
 	if i := strings.IndexByte(base, 0); i >= 0 {
@@ -176,16 +176,16 @@ func autoUpdate(resp []byte, dataDir string) error {
 	imgPath := filepath.Join(dataDir, CL_ImagesFile)
 	if err := downloadGZ(imgURL, imgPath); err != nil {
 		logError("download %v: %v", imgURL, err)
-		return err
+		return 0, err
 	}
 	sndURL := fmt.Sprintf("%v/data/CL_Sounds.%d.gz", base, sndVer>>8)
 	logDebug("downloading %v", sndURL)
 	sndPath := filepath.Join(dataDir, CL_SoundsFile)
 	if err := downloadGZ(sndURL, sndPath); err != nil {
 		logError("download %v: %v", sndURL, err)
-		return err
+		return 0, err
 	}
-	return nil
+	return int(clientVer >> 8), nil
 }
 
 type dataFilesStatus struct {


### PR DESCRIPTION
## Summary
- Track data file versions and only download when files are outdated
- Warn when client version is older than data files and allow proceed/cancel

## Testing
- `go test ./...` *(fails: Package alsa and Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a53111da4c832ab311a481eed5b0a4