### PR TITLE
Update Discord presence based on game state

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -7,23 +7,45 @@ import (
 	client "github.com/hugolgst/rich-go/client"
 )
 
+var discordStart time.Time
+var discordReady bool
+
 func initDiscordRPC(ctx context.Context) {
 	if err := client.Login("1406171210240360508"); err != nil {
 		logError("discord rpc login: %v", err)
 		return
 	}
-	now := time.Now()
-	if err := client.SetActivity(client.Activity{
-		State:   "GoThoom",
-		Details: "In game",
-		Timestamps: &client.Timestamps{
-			Start: &now,
-		},
-	}); err != nil {
-		logError("discord rpc activity: %v", err)
-	}
+	discordReady = true
+	discordStart = time.Now()
+	setDiscordStatus("main menu")
 	go func() {
 		<-ctx.Done()
 		client.Logout()
 	}()
+}
+
+func setDiscordStatus(detail string) {
+	if !discordReady {
+		return
+	}
+	if err := client.SetActivity(client.Activity{
+		State:   "GoThoom",
+		Details: detail,
+		Timestamps: &client.Timestamps{
+			Start: &discordStart,
+		},
+	}); err != nil {
+		logError("discord rpc activity: %v", err)
+	}
+}
+
+func updateDiscordMode(mode int) {
+	switch mode {
+	case GAME_MOVIE:
+		setDiscordStatus("watching a visionstone")
+	case GAME_PLAYING, GAME_PCAP:
+		setDiscordStatus("clanning")
+	default:
+		setDiscordStatus("main menu")
+	}
 }

--- a/game_mode.go
+++ b/game_mode.go
@@ -46,6 +46,5 @@ func MODE_NAME() string {
 func CHANGE_MODE(mode int) {
 	gameMode = mode
 	gameModeName = MODE_NAME()
-
-	//Change discord status here
+	updateDiscordMode(mode)
 }


### PR DESCRIPTION
## Summary
- change Discord RPC to update status for main menu, clanning, or watching a visionstone
- update game mode handler to trigger presence updates

## Testing
- `go test ./...` *(fails: login auto update, sound player creation, audio context)*


------
https://chatgpt.com/codex/tasks/task_e_68a5383ad4fc832a9fc198b3a0054ba9