### PR TITLE
Add self-signing for macOS and Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ To build release binaries for Linux and Windows, use:
 scripts/build_binaries.sh
 ```
 
+The script optionally self-signs Windows executables and macOS `.app` bundles.
+On Ubuntu, it attempts to install missing tools like `zip` and `osslsigncode` automatically.
+Provide certificate paths via environment variables before running:
+
+```bash
+export WINDOWS_CERT_FILE=certs/fullchain.pem
+export WINDOWS_KEY_FILE=certs/privkey.pem   # optional WINDOWS_KEY_PASS, WINDOWS_CERT_NAME, WINDOWS_TIMESTAMP_URL
+export MAC_SIGN_IDENTITY="-"                # ad-hoc by default; set to your certificate name to sign
+scripts/build_binaries.sh
+```
+
 ## Command-line Flags
 
 The Go client accepts the following flags:


### PR DESCRIPTION
## Summary
- add optional Windows signing using osslsigncode when certificates are available
- add macOS codesign step for built .app bundles
- document signing environment variables in the README
- automatically install `zip` and `osslsigncode` on Ubuntu when missing

## Testing
- `sudo apt-get install -y libasound2-dev libxrandr-dev pkg-config`
- `sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev xorg-dev`
- `sudo apt-get install -y libgtk-3-dev`
- `go test ./...` *(hangs: no output, likely requires a display)*

------
https://chatgpt.com/codex/tasks/task_e_68a5379870b0832a924334f46dbcc5e6