### PR TITLE
Fold names to ASCII and handle MacRoman conversions

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -203,7 +203,7 @@ func parseNames(data []byte) []string {
 		if end < 0 {
 			break
 		}
-		name := strings.TrimSpace(decodeMacRoman(data[:end]))
+		name := utfFold(strings.TrimSpace(decodeMacRoman(data[:end])))
 		names = append(names, name)
 		data = data[end+3:]
 		for {

--- a/draw.go
+++ b/draw.go
@@ -654,7 +654,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 		d.PictID = binary.BigEndian.Uint16(data[p+2:])
 		p += 4
 		if idx := bytes.IndexByte(data[p:], 0); idx >= 0 {
-			d.Name = string(data[p : p+idx])
+			d.Name = utfFold(decodeMacRoman(data[p : p+idx]))
 			p += idx + 1
 			if d.Name == playerName {
 				playerIndex = d.Index

--- a/login.go
+++ b/login.go
@@ -303,7 +303,7 @@ func login(ctx context.Context, clientVersion int) error {
 			udpConn.Close()
 			return fmt.Errorf("character password required")
 		}
-		playerName = name
+		playerName = utfFold(name)
 
 		var resp []byte
 		var result int16

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func playerFromDrawState(data []byte) string {
 		typ := data[p+1]
 		p += 4
 		if off := bytes.IndexByte(data[p:], 0); off >= 0 {
-			name := string(data[p : p+off])
+			name := utfFold(decodeMacRoman(data[p : p+off]))
 			p += off + 1
 			if p >= len(data) {
 				return ""
@@ -335,7 +335,7 @@ func firstDescriptorName(data []byte) string {
 	}
 	p += 4
 	if idx := bytes.IndexByte(data[p:], 0); idx >= 0 {
-		return string(data[p : p+idx])
+		return utfFold(decodeMacRoman(data[p : p+idx]))
 	}
 	return ""
 }

--- a/parse_names_test.go
+++ b/parse_names_test.go
@@ -60,7 +60,7 @@ func TestParseNamesMacRoman(t *testing.T) {
 	data = append(data, nameBytes...)
 	data = append(data, 0xC2, 'p', 'n')
 	got := parseNames(data)
-	want := []string{"Méme"}
+	want := []string{"Meme"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("parseNames() = %v, want %v", got, want)
 	}

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -171,7 +171,7 @@ func parseShareText(raw []byte, s string) bool {
 		}
 		return true
 	case strings.HasSuffix(s, " is sharing experiences with you."):
-		name := firstTagContent(raw, 'p', 'n')
+		name := utfFold(firstTagContent(raw, 'p', 'n'))
 		if name != "" {
 			p := getPlayer(name)
 			playersMu.Lock()
@@ -186,7 +186,7 @@ func parseShareText(raw []byte, s string) bool {
 		}
 		return true
 	case strings.Contains(s, " is no longer sharing experiences with you"):
-		name := firstTagContent(raw, 'p', 'n')
+		name := utfFold(firstTagContent(raw, 'p', 'n'))
 		if name != "" {
 			playersMu.Lock()
 			changed := false
@@ -234,16 +234,16 @@ func parseFallenText(raw []byte, s string) bool {
 	// Fallen: "<pn name> has fallen" (with optional -mn and -lo tags)
 	if strings.Contains(s, " has fallen") {
 		// Extract main player name
-		name := firstTagContent(raw, 'p', 'n')
+		name := utfFold(firstTagContent(raw, 'p', 'n'))
 		if name == "" {
 			if idx := strings.Index(s, " has fallen"); idx >= 0 {
-				name = strings.TrimSpace(s[:idx])
+				name = utfFold(strings.TrimSpace(s[:idx]))
 			}
 		}
 		if name == "" {
 			return false
 		}
-		killer := firstTagContent(raw, 'm', 'n')
+		killer := utfFold(firstTagContent(raw, 'm', 'n'))
 		where := firstTagContent(raw, 'l', 'o')
 		p := getPlayer(name)
 		playersMu.Lock()
@@ -259,10 +259,10 @@ func parseFallenText(raw []byte, s string) bool {
 	}
 	// Not fallen: "<pn name> is no longer fallen"
 	if strings.Contains(s, " is no longer fallen") {
-		name := firstTagContent(raw, 'p', 'n')
+		name := utfFold(firstTagContent(raw, 'p', 'n'))
 		if name == "" {
 			if idx := strings.Index(s, " is no longer fallen"); idx >= 0 {
-				name = strings.TrimSpace(s[:idx])
+				name = utfFold(strings.TrimSpace(s[:idx]))
 			}
 		}
 		if name == "" {
@@ -289,7 +289,7 @@ func parsePresenceText(raw []byte, s string) bool {
 	// Attempt to detect common phrases. Names are provided in -pn tags.
 	// We treat any recognized login as Online and any recognized logout as Offline.
 	lower := strings.ToLower(s)
-	name := firstTagContent(raw, 'p', 'n')
+	name := utfFold(firstTagContent(raw, 'p', 'n'))
 	if name == "" {
 		return false
 	}

--- a/util.go
+++ b/util.go
@@ -8,9 +8,13 @@ import (
 	"io"
 	"log"
 	"os"
+	"unicode"
 
 	"golang.org/x/crypto/twofish"
 	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 func simpleEncrypt(data []byte) {
@@ -31,6 +35,15 @@ func encodeMacRoman(s string) []byte {
 		return []byte(s)
 	}
 	return b
+}
+
+func utfFold(s string) string {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	out, _, err := transform.String(t, s)
+	if err != nil {
+		return s
+	}
+	return out
 }
 
 func encodeFullVersion(v int) uint32 { return uint32(v) << 8 }

--- a/versions.go
+++ b/versions.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"embed"
+	_ "embed"
 )
 
 //go:embed data/versions.json


### PR DESCRIPTION
## Summary
- add `utfFold` helper to strip diacritics from Unicode strings
- fold player and mobile names after MacRoman decoding
- decode descriptor and login names from MacRoman for consistent display

## Testing
- `go build ./...`
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5395bb36c832aa7c68239b24979be