### PR TITLE
Add changelog navigation arrows

### DIFF
--- a/text_window.go
+++ b/text_window.go
@@ -152,16 +152,23 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	}
 
 	if win != nil {
-		// Size the flow to the client area, and the list to fill above the input.
+		// Size the flow to the client area, and the list to fill above any bottom items and optional input.
+		var extraH float32
 		if list.Parent != nil {
 			list.Parent.Size.X = clientWAvail
 			list.Parent.Size.Y = clientHAvail
+			for _, c := range list.Parent.Contents {
+				if c != list && c != input {
+					c.Size.X = clientWAvail
+					extraH += c.Size.Y
+				}
+			}
 		}
 		list.Size.X = clientWAvail
 		if input != nil {
-			list.Size.Y = clientHAvail - input.Size.Y
+			list.Size.Y = clientHAvail - input.Size.Y - extraH
 		} else {
-			list.Size.Y = clientHAvail
+			list.Size.Y = clientHAvail - extraH
 		}
 		// Do not refresh here unconditionally; callers decide when to refresh.
 	}


### PR DESCRIPTION
## Summary
- Add previous/next navigation buttons to the changelog window
- Track available changelog versions for browsing
- Adjust text window layout to accommodate navigation controls

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68a543596a3c832ab7ba97d578f85701