### PR TITLE
Check remote version

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func main() {
 
 	applySettings()
 	setupLogging(doDebug)
+	go checkForNewVersion()
 	defer func() {
 		if r := recover(); r != nil {
 			logPanic(r)

--- a/versions.go
+++ b/versions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 )
 
 //go:embed data/versions.json
@@ -18,6 +19,8 @@ var (
 	clVersion  = baseVersion
 	changelog  string
 )
+
+const versionsURL = "https://m45sci.xyz/downloads/goThoom/versions.jso"
 
 type versionEntry struct {
 	Version   int `json:"version"`
@@ -52,5 +55,35 @@ func init() {
 		log.Printf("read changelog: %v", err)
 	} else {
 		changelog = string(b)
+	}
+}
+
+func checkForNewVersion() {
+	resp, err := http.Get(versionsURL)
+	if err != nil {
+		log.Printf("check new version: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("check new version: %v", resp.Status)
+		return
+	}
+	var vf versionFile
+	if err := json.NewDecoder(resp.Body).Decode(&vf); err != nil {
+		log.Printf("check new version: %v", err)
+		return
+	}
+	if len(vf.Versions) == 0 {
+		return
+	}
+	latest := vf.Versions[0]
+	for _, v := range vf.Versions[1:] {
+		if v.Version > latest.Version {
+			latest = v
+		}
+	}
+	if latest.Version > appVersion {
+		consoleMessage(fmt.Sprintf("New goThoom version %d available", latest.Version))
 	}
 }


### PR DESCRIPTION
## Summary
- check online `versions.jso` file for newer goThoom builds at startup
- teach releaseHelper to load the same remote version file

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a54309a804832abe6d4f40bb3e8341