### PR TITLE
Fix changelog resizing and word wrap

### DIFF
--- a/text_window.go
+++ b/text_window.go
@@ -77,8 +77,8 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 
 	// Prepare wrapping parameters: use the same face for measurement.
 	var face text.Face = goFace
-	// list.Size.X is in item units; convert to pixels for measurement.
-	wrapWidthPx := float64(list.Size.X - (3*pad)*ui)
+	// Use the current client width in pixels for wrapping.
+	wrapWidthPx := float64(clientWAvail - 3*pad)
 
 	for i, msg := range msgs {
 		// Word-wrap the message to the available width.

--- a/ui.go
+++ b/ui.go
@@ -1166,6 +1166,7 @@ func makeLoginWindow() {
 func makeChangelogWindow() {
 	if changelogWin == nil {
 		changelogWin, changelogList, _ = makeTextWindow("Changelog", eui.HZoneCenter, eui.VZoneMiddleTop, false)
+		changelogWin.OnResize = updateChangelogWindow
 		flow := changelogWin.Contents[0]
 
 		navFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true, Alignment: eui.ALIGN_RIGHT}


### PR DESCRIPTION
## Summary
- Rewrap text window content based on available client width
- Refresh changelog text when the window is resized

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68a54656e29c832a8f348ee8dfc2472b