### PR TITLE
Initialize client version on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 )
 
 func main() {
+	clientVersion = clVersion
 	flag.StringVar(&clmov, "clmov", "", "play back a .clMov file")
 	flag.StringVar(&pcapPath, "pcap", "", "replay network frames from a .pcap/.pcapng file")
 	flag.BoolVar(&fake, "fake", false, "simulate server messages without connecting")


### PR DESCRIPTION
## Summary
- default clientVersion to clVersion so login displays correct Clan Lord version

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a55093ae4c832a878f49556b26ffa9