### PR TITLE
Search certs in script directory

### DIFF
--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 OUTPUT_DIR="binaries"
 mkdir -p "$OUTPUT_DIR"
 
@@ -195,8 +197,8 @@ for platform in "${platforms[@]}"; do
       -o "${OUTPUT_DIR}/${BIN_NAME}" .
 
   if [ "$GOOS" = "windows" ]; then
-    cert_file="${WINDOWS_CERT_FILE:-certs/fullchain.pem}"
-    key_file="${WINDOWS_KEY_FILE:-certs/privkey.pem}"
+    cert_file="${WINDOWS_CERT_FILE:-${SCRIPT_DIR}/fullchain.pem}"
+    key_file="${WINDOWS_KEY_FILE:-${SCRIPT_DIR}/privkey.pem}"
     ensure_cmd osslsigncode osslsigncode
     if command -v osslsigncode >/dev/null 2>&1 && [ -f "$cert_file" ] && [ -f "$key_file" ]; then
       echo "Signing ${BIN_NAME}..."


### PR DESCRIPTION
## Summary
- Resolve certificates relative to the scripts folder when signing Windows binaries

## Testing
- `bash -n scripts/build_binaries.sh`
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a558a3b16c832a9d452451c6beba3f