### PR TITLE
Use Application Support dir on macOS

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -15,7 +16,17 @@ type assetStats struct {
 }
 
 const statsFile = "stats.json"
-const dataDirPath = "data"
+
+var dataDirPath = "data"
+
+func init() {
+	if runtime.GOOS == "darwin" {
+		if home, err := os.UserHomeDir(); err == nil {
+			dataDirPath = filepath.Join(home, "Library", "Application Support", "goThoom")
+			_ = os.MkdirAll(dataDirPath, 0o755)
+		}
+	}
+}
 
 var (
 	stats      assetStats


### PR DESCRIPTION
## Summary
- On macOS, store client data inside the user's Application Support folder to satisfy quarantine restrictions.

## Testing
- `go build` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a560f56614832a84f5b5a978f05ddc