### PR TITLE
Fix version parsing

### DIFF
--- a/versions.go
+++ b/versions.go
@@ -28,9 +28,12 @@ var (
 
 const versionsURL = "https://m45sci.xyz/u/dist/goThoom/versions.json"
 
+// versionEntry mirrors the structure of the entries in data/versions.json.
+// The JSON file uses capitalized field names, so the tags here must match
+// those exactly in order for decoding to succeed.
 type versionEntry struct {
-	Version   int `json:"version"`
-	CLVersion int `json:"cl_version"`
+	Version   int `json:"Version"`
+	CLVersion int `json:"CLVersion"`
 }
 
 type versionFile struct {


### PR DESCRIPTION
## Summary
- parse version and CLVersion from versions.json instead of defaulting to base version

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68a563cad00c832aae06e2690f58e1af