### PR TITLE
Throttle update checks and switch to notifications in-game

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 
 	applySettings()
 	setupLogging(doDebug)
-	go checkForNewVersion()
+	go versionCheckLoop()
 	defer func() {
 		if r := recover(); r != nil {
 			logPanic(r)

--- a/settings.go
+++ b/settings.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-const SETTINGS_VERSION = 8
+const SETTINGS_VERSION = 9
 
 type BarPlacement int
 
@@ -79,6 +79,8 @@ var gsdef settings = settings{
 	NotifyFriendOnline:   true,
 	NotificationDuration: 6,
 	TimestampFormat:      "3:04PM",
+	LastUpdateCheck:      time.Time{},
+	NotifiedVersion:      0,
 
 	GameWindow:      WindowState{Open: true},
 	InventoryWindow: WindowState{Open: true},
@@ -154,6 +156,8 @@ type settings struct {
 	ChatTimestamps       bool
 	ConsoleTimestamps    bool
 	TimestampFormat      string
+	LastUpdateCheck      time.Time
+	NotifiedVersion      int
 	WindowTiling         bool
 	WindowSnapping       bool
 


### PR DESCRIPTION
## Summary
- store last update check time and last notified version in settings
- check for updates at most every 3 hours and while running
- notify players in-game via notifications instead of dialog

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a57036d600832a954fbb1341177645