### PR TITLE
docs: add third-party attribution

### DIFF
--- a/ATTRIBUTE.md
+++ b/ATTRIBUTE.md
@@ -1,0 +1,34 @@
+# Third-Party Libraries Attribution
+
+This project uses the following third-party Go libraries.
+
+| Library | Repository | License | Author(s) |
+| --- | --- | --- | --- |
+| Ebitengine | https://github.com/hajimehoshi/ebiten | Apache-2.0 | Hajime Hoshi |
+| go-humanize | https://github.com/dustin/go-humanize | MIT | Dustin Sallings |
+| go-tts | https://github.com/go-tts/tts | None | go-tts project |
+| gopacket | https://github.com/google/gopacket | BSD-3-Clause | Google, Inc.; Andreas Krennmair |
+| durafmt | https://github.com/hako/durafmt | MIT | Wesley Hill |
+| rich-go | https://github.com/hugolgst/rich-go | MIT | Hugo Lageneste |
+| sizedwaitgroup | https://github.com/remeh/sizedwaitgroup | MIT | Rémy Mathieu |
+| go-meltysynth | https://github.com/sinshu/go-meltysynth | MIT | Nobuaki Tanaka |
+| dialog | https://github.com/sqweek/dialog | ISC | sqweek and contributors |
+| dark-mode-go | https://github.com/thiagokokada/dark-mode-go | MIT | Thiago Kenji Okada |
+| clipboard | https://github.com/golang-design/clipboard | MIT | Changkun Ou |
+| x/crypto | https://github.com/golang/crypto | BSD-3-Clause | The Go Authors |
+| x/text | https://github.com/golang/text | BSD-3-Clause | The Go Authors |
+| x/time | https://github.com/golang/time | BSD-3-Clause | The Go Authors |
+
+## Fonts
+
+| Font | Repository | License | Author(s) |
+| --- | --- | --- | --- |
+| Noto Sans (Regular, Bold, Italic, BoldItalic) | https://github.com/googlefonts/noto-fonts | SIL Open Font License 1.1 | The Noto Project Authors |
+
+## Delta Tao Software
+
+| Resource | URL | License | Author(s) |
+| --- | --- | --- | --- |
+| Clan Lord | https://www.deltatao.com/clanlord/ | Proprietary | Delta Tao Software |
+| Clan Lord Client | https://github.com/YappyGM/ClanLordClient | Apache-2.0 | Delta Tao Software |
+


### PR DESCRIPTION
## Summary
- document third-party libraries with repo links, license, and authors
- include Noto Sans font license and links
- add Delta Tao Software links for the original game and classic client

## Testing
- `go test ./...` *(fails: Package 'alsa' not found; Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a58d8d49b0832a951a6564281ceb78