### PR TITLE
Fix name tag scaling with game scale

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -91,7 +91,7 @@ var gsdef settings = settings{
 	vsync:          true,
 	nightEffect:    true,
 	throttleSounds: true,
-	nameTagsNative: true,
+	nameTagsNative: false,
 }
 
 type settings struct {

--- a/ui.go
+++ b/ui.go
@@ -2385,6 +2385,7 @@ func makeQualityWindow() {
 			gs.GameScale = v
 			renderScale.Value = float32(v)
 			settingsDirty = true
+			initFont()
 			if gameWin != nil {
 				gameWin.Refresh()
 			}


### PR DESCRIPTION
## Summary
- Reinitialize fonts when changing game scale so name tag images regenerate at the new resolution
- Disable native-resolution name tags by default

## Testing
- `go test ./...` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aca05cd4832ab6f8d5bac384e327