### PR TITLE
Avoid double-scaling name tags

### DIFF
--- a/game.go
+++ b/game.go
@@ -1377,14 +1377,9 @@ func drawMobileNameTag(screen *ebiten.Image, snap drawSnapshot, m frameMobile, a
 			}
 			playersMu.RUnlock()
 			if m.nameTag != nil && m.nameTagKey.FontGen == fontGen && m.nameTagKey.Opacity == nameAlpha && m.nameTagKey.Text == d.Name && m.nameTagKey.Colors == m.Colors && m.nameTagKey.Style == style {
-				scale := 1.0
-				if !gs.nameTagsNative {
-					scale = gs.GameScale
-				}
 				top := y + int(20*gs.GameScale)
-				left := x - int(float64(m.nameTagW)/2*scale)
+				left := x - int(float64(m.nameTagW)/2)
 				op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
-				op.GeoM.Scale(scale, scale)
 				op.GeoM.Translate(float64(left), float64(top))
 				screen.DrawImage(m.nameTag, op)
 			} else {
@@ -1403,21 +1398,16 @@ func drawMobileNameTag(screen *ebiten.Image, snap drawSnapshot, m frameMobile, a
 				w, h := text.Measure(d.Name, face, 0)
 				iw := int(math.Ceil(w))
 				ih := int(math.Ceil(h))
-				scale := 1.0
-				if !gs.nameTagsNative {
-					scale = gs.GameScale
-				}
 				top := y + int(20*gs.GameScale)
-				left := x - int(float64(iw)/2*scale)
+				left := x - int(float64(iw)/2)
 				op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
-				op.GeoM.Scale(float64(iw+5)*scale, float64(ih)*scale)
+				op.GeoM.Scale(float64(iw+5), float64(ih))
 				op.GeoM.Translate(float64(left), float64(top))
 				op.ColorScale.ScaleWithColor(bgClr)
 				screen.DrawImage(whiteImage, op)
-				vector.StrokeRect(screen, float32(left), float32(top), float32(iw+5)*float32(scale), float32(ih)*float32(scale), 1, frameClr, false)
+				vector.StrokeRect(screen, float32(left), float32(top), float32(iw+5), float32(ih), 1, frameClr, false)
 				opTxt := &text.DrawOptions{}
-				opTxt.GeoM.Scale(scale, scale)
-				opTxt.GeoM.Translate(float64(left)+2*scale, float64(top)+2*scale)
+				opTxt.GeoM.Translate(float64(left)+2, float64(top)+2)
 				opTxt.ColorScale.ScaleWithColor(textClr)
 				text.Draw(screen, d.Name, face, opTxt)
 			}


### PR DESCRIPTION
## Summary
- remove extra scaling when drawing name tags so they render at native resolution

## Testing
- `xvfb-run -a go test ./...` *(fails: CL_Images missing; will fetch from server)*

------
https://chatgpt.com/codex/tasks/task_e_68a6afb2de7c832abe758240eff37933