### PR TITLE
Scale viewport for HiDPI displays

### DIFF
--- a/eui/glob.go
+++ b/eui/glob.go
@@ -67,6 +67,10 @@ func init() {
 // Pass Ebiten's outside size values to this from your Layout function.
 func Layout(outsideWidth, outsideHeight int) (int, int) {
 	scale := 1.0
+	if AutoHiDPI {
+		scale = ebiten.Monitor().DeviceScaleFactor()
+		lastDeviceScale = scale
+	}
 
 	scaledW := int(float64(outsideWidth) * scale)
 	scaledH := int(float64(outsideHeight) * scale)

--- a/game.go
+++ b/game.go
@@ -1728,7 +1728,7 @@ func equippedItemPicts() (uint16, uint16) {
 
 // drawInputOverlay renders the text entry box when chatting.
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
-	eui.Layout(outsideWidth, outsideHeight)
+	scaledW, scaledH := eui.Layout(outsideWidth, outsideHeight)
 
 	if outsideWidth > 512 && outsideHeight > 384 {
 		if gs.WindowWidth != outsideWidth || gs.WindowHeight != outsideHeight {
@@ -1738,7 +1738,7 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 		}
 	}
 
-	return outsideWidth, outsideHeight
+	return scaledW, scaledH
 }
 
 func runGame(ctx context.Context) {


### PR DESCRIPTION
## Summary
- scale UI layout by monitor device scale factor
- return scaled dimensions from game's Layout for crisp rendering

## Testing
- `go test ./...` *(fails: Package 'alsa' not found; X11 and GTK headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b2c71c38832aaab3e55a7cdd0d32