### PR TITLE
Handle bard tune messages

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -168,9 +168,8 @@ func decodeBEPP(data []byte) string {
 			return text
 		}
 	case "ba":
-		// Bard guild messages
-		parseBardText(raw, text)
-		if text != "" {
+		// Bard guild messages or tunes
+		if !parseBardText(raw, text) && text != "" {
 			return text
 		}
 	case "lg":

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -323,7 +323,8 @@ func parsePresenceText(raw []byte, s string) bool {
 }
 
 // parseBardText detects bard guild messages and updates bard status.
-// Returns true if handled.
+// It also handles bard tune messages. Returns true if the message was fully
+// handled and should not be displayed.
 func parseBardText(_ []byte, s string) bool {
 	s = strings.TrimSpace(s)
 	if strings.HasPrefix(s, "* ") {
@@ -332,6 +333,12 @@ func parseBardText(_ []byte, s string) bool {
 	if strings.HasPrefix(s, "¥ ") {
 		s = strings.TrimSpace(s[2:])
 	}
+
+	if strings.HasPrefix(s, "/play ") {
+		go playClanLordTune(strings.TrimSpace(s[len("/play "):]))
+		return true
+	}
+
 	phrases := []struct {
 		suffix string
 		bard   bool
@@ -359,7 +366,7 @@ func parseBardText(_ []byte, s string) bool {
 			playersMu.Unlock()
 			playersDirty = true
 			playersPersistDirty = true
-			return true
+			return false
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary
- redirect bard tune messages to the existing /play handler
- avoid displaying bard tunes in chat

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b62b52d8832ab034b59980bfa950