### PR TITLE
Maintain 2:1 ratio for think message bubbles

### DIFF
--- a/think_messages.go
+++ b/think_messages.go
@@ -41,9 +41,10 @@ func showThinkMessage(msg string) {
 	singleWidth, _ := text.Measure(msg, face, 0)
 	metrics := face.Metrics()
 	lineHeight := math.Ceil(metrics.HAscent) + math.Ceil(metrics.HDescent) + math.Ceil(metrics.HLineGap)
-	linesWanted := 1
-	for singleWidth/float64(linesWanted) > 2*lineHeight {
-		linesWanted++
+	ideal := math.Sqrt(singleWidth / (2 * lineHeight))
+	linesWanted := int(math.Round(ideal))
+	if linesWanted < 1 {
+		linesWanted = 1
 	}
 
 	maxWidth := singleWidth / float64(linesWanted)


### PR DESCRIPTION
## Summary
- Adjust think message layout to target a ~2:1 width-to-height ratio

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c1abddf0832abfbbcdd2d6cea705