### PR TITLE
Align thought bubble sizing with speech bubbles

### DIFF
--- a/think_messages.go
+++ b/think_messages.go
@@ -38,16 +38,12 @@ func showThinkMessage(msg string) {
 	textSize := (btn.FontSize * eui.UIScale()) + 2
 	face := &text.GoTextFace{Source: eui.FontSource(), Size: float64(textSize)}
 
-	singleWidth, _ := text.Measure(msg, face, 0)
 	metrics := face.Metrics()
 	lineHeight := math.Ceil(metrics.HAscent) + math.Ceil(metrics.HDescent) + math.Ceil(metrics.HLineGap)
-	ideal := math.Sqrt(singleWidth / (2 * lineHeight))
-	linesWanted := int(math.Round(ideal))
-	if linesWanted < 1 {
-		linesWanted = 1
-	}
 
-	maxWidth := singleWidth / float64(linesWanted)
+	winSize := gameWin.GetSize()
+	pad := float64((btn.Padding + btn.BorderPad) * eui.UIScale())
+	maxWidth := float64(winSize.X)/4 - 2*pad
 	usedWidth, lines := wrapText(msg, face, maxWidth)
 	btn.Text = strings.Join(lines, "\n")
 	btn.Size = eui.Point{


### PR DESCRIPTION
## Summary
- Size think message bubbles using a fixed max width similar to speech bubbles, producing consistent aspect ratios.

## Testing
- `go test ./...` *(fails: hangs without output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c4829b38832aa2c0c97f977c3fcd