### PR TITLE
Implement frequency-domain filtering for image loading

### DIFF
--- a/climg/denoise.go
+++ b/climg/denoise.go
@@ -42,11 +42,18 @@ func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {
 	// Apply low-pass filter in frequency domain.
 	apply := func(ch [][]float64) {
 		freq := fft.FFT2Real(ch)
+		r2 := radius * radius
 		for y := 0; y < h; y++ {
+			dy := float64(y)
+			if y > h/2 {
+				dy = float64(y - h)
+			}
 			for x := 0; x < w; x++ {
-				du := float64(x - w/2)
-				dv := float64(y - h/2)
-				mask := math.Exp(-(du*du + dv*dv) / (2 * radius * radius))
+				dx := float64(x)
+				if x > w/2 {
+					dx = float64(x - w)
+				}
+				mask := math.Exp(-(dx*dx + dy*dy) / (2 * r2))
 				if sharpness != 0 {
 					mask = math.Pow(mask, sharpness)
 				}

--- a/climg/denoise.go
+++ b/climg/denoise.go
@@ -2,93 +2,94 @@ package climg
 
 import (
 	"image"
-	"image/color"
 	"math"
-	"sync"
+
+	"github.com/mjibson/go-dsp/fft"
 )
 
-// denoiseImage softens pixels by blending with neighbours. Pixels that are
-// more similar to their neighbours are blended more strongly while
-// dissimilar pixels are blended less. The sharpness parameter controls how
-// quickly the blend amount falls off as colours become more different. Only
-// the immediate horizontal and vertical neighbours are considered.
+// denoiseImage applies a frequency-domain low-pass filter to soften dithered
+// indexed images. sharpness controls the roll-off of the Gaussian filter while
+// maxPercent sets the cutoff radius as a fraction of the image size.
 func denoiseImage(img *image.RGBA, sharpness, maxPercent float64) {
 	bounds := img.Bounds()
 	w, h := bounds.Dx(), bounds.Dy()
+	if w == 0 || h == 0 {
+		return
+	}
 
-	// Work on a copy so neighbour checks aren't affected by in-place writes.
-	src := getTempRGBA(bounds)
-	copy(src.Pix, img.Pix)
-
-	for y := 1; y < h-1; y++ {
-		yoff := y * src.Stride
-		for x := 1; x < w-1; x++ {
-			off := yoff + x*4
-			c := color.RGBA{src.Pix[off], src.Pix[off+1], src.Pix[off+2], src.Pix[off+3]}
-
-			// Check only direct neighbours.
-			neighbours := []image.Point{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
-			for _, n := range neighbours {
-				nOff := (y+n.Y)*src.Stride + (x+n.X)*4
-				ncol := color.RGBA{src.Pix[nOff], src.Pix[nOff+1], src.Pix[nOff+2], src.Pix[nOff+3]}
-				dist := colourDist(c, ncol)
-				nd := float64(dist) / 195075.0
-				if nd < 1 {
-					blend := maxPercent * math.Pow(1-nd, sharpness)
-					if blend > 0 {
-						c = mixColour(c, ncol, blend)
-					}
-				}
-			}
-			dstOff := y*img.Stride + x*4
-			img.Pix[dstOff] = c.R
-			img.Pix[dstOff+1] = c.G
-			img.Pix[dstOff+2] = c.B
-			img.Pix[dstOff+3] = c.A
+	// Extract colour channels.
+	r := make([][]float64, h)
+	g := make([][]float64, h)
+	b := make([][]float64, h)
+	for y := 0; y < h; y++ {
+		r[y] = make([]float64, w)
+		g[y] = make([]float64, w)
+		b[y] = make([]float64, w)
+		off := y * img.Stride
+		for x := 0; x < w; x++ {
+			r[y][x] = float64(img.Pix[off+0])
+			g[y][x] = float64(img.Pix[off+1])
+			b[y][x] = float64(img.Pix[off+2])
+			off += 4
 		}
 	}
-	putTempRGBA(src)
+
+	radius := maxPercent * float64(max(w, h)) / 2
+	if radius <= 0 {
+		return
+	}
+
+	// Apply low-pass filter in frequency domain.
+	apply := func(ch [][]float64) {
+		freq := fft.FFT2Real(ch)
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				du := float64(x - w/2)
+				dv := float64(y - h/2)
+				mask := math.Exp(-(du*du + dv*dv) / (2 * radius * radius))
+				if sharpness != 0 {
+					mask = math.Pow(mask, sharpness)
+				}
+				freq[y][x] *= complex(mask, 0)
+			}
+		}
+		spatial := fft.IFFT2(freq)
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				ch[y][x] = real(spatial[y][x])
+			}
+		}
+	}
+
+	apply(r)
+	apply(g)
+	apply(b)
+
+	// Write the filtered channels back to the image.
+	for y := 0; y < h; y++ {
+		off := y * img.Stride
+		for x := 0; x < w; x++ {
+			img.Pix[off+0] = clampByte(r[y][x])
+			img.Pix[off+1] = clampByte(g[y][x])
+			img.Pix[off+2] = clampByte(b[y][x])
+			off += 4
+		}
+	}
 }
 
-var rgbaPool = sync.Pool{New: func() any { return &image.RGBA{} }}
-
-func getTempRGBA(bounds image.Rectangle) *image.RGBA {
-	img := rgbaPool.Get().(*image.RGBA)
-	w, h := bounds.Dx(), bounds.Dy()
-	need := w * h * 4
-	if cap(img.Pix) < need {
-		img.Pix = make([]uint8, need)
+func clampByte(v float64) uint8 {
+	if v < 0 {
+		return 0
 	}
-	img.Pix = img.Pix[:need]
-	img.Stride = w * 4
-	img.Rect = bounds
-	return img
+	if v > 255 {
+		return 255
+	}
+	return uint8(v + 0.5)
 }
 
-func putTempRGBA(img *image.RGBA) { rgbaPool.Put(img) }
-
-// colourDist returns the squared Euclidean distance between two colours.
-const dt = 15
-
-func colourDist(a, b color.RGBA) int {
-	dr := int(a.R) - int(b.R)
-	dg := int(a.G) - int(b.G)
-	db := int(a.B) - int(b.B)
-	if a.A < 0xFF || b.A < 0xFF ||
-		(a.R < dt && a.G < dt && a.B < dt) ||
-		(b.R < dt && b.G < dt && b.B < dt) {
-		return 195076
+func max(a, b int) int {
+	if a > b {
+		return a
 	}
-	return dr*dr + dg*dg + db*db
-}
-
-// mixColour blends two colours together by the provided percentage.
-func mixColour(a, b color.RGBA, p float64) color.RGBA {
-	inv := 1 - p
-	return color.RGBA{
-		R: uint8(float64(a.R)*inv + float64(b.R)*p),
-		G: uint8(float64(a.G)*inv + float64(b.G)*p),
-		B: uint8(float64(a.B)*inv + float64(b.B)*p),
-		A: uint8(float64(a.A)*inv + float64(b.A)*p),
-	}
+	return b
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2
+	github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4
 	github.com/sqweek/dialog v0.0.0-20240226140203-065105509627
@@ -30,7 +32,6 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/image v0.30.0 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2 h1:9qOViOQGFIP5ar
 github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2/go.mod h1:nGaW7CGfNZnhtiFxMpc4OZdqIexGXjUlBnlmpZmjEKA=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12 h1:dd7vnTDfjtwCETZDrRe+GPYNLA1jBtbZeyfyE8eZCyk=
+github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12/go.mod h1:i/KKcxEWEO8Yyl11DYafRPKOPVYTrhxiTRigjtEEXZU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
## Summary
- apply Gaussian low-pass filtering via FFT during image loading to reduce dithering
- add go-dsp/fft dependency for frequency-domain operations

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cb12b128832a88df75eb534275b5