### PR TITLE
Disable hero think bubbles

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1094,7 +1094,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 				stateMu.Unlock()
 			}
 			bubbleType := typ & kBubbleTypeMask
-			showBubble := gs.SpeechBubbles && txt != "" && !blockBubbles
+			showBubble := gs.SpeechBubbles && txt != "" && !blockBubbles && verb != "thinks"
 			if showBubble {
 				typeOK := true
 				switch bubbleType {


### PR DESCRIPTION
## Summary
- stop think messages from also rendering as character bubbles

## Testing
- `go test ./...` *(fails: undefined: messages; GLFW library not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d408bf24832a875d1e4dc95f5014