### PR TITLE
Add music debug flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	blockBubbles  bool
 	blockTTS      bool
 	dumpMusic     bool
+	musicDebug    bool
 	clientVersion int
 	experimental  bool
 )
@@ -48,6 +49,7 @@ func main() {
 	flag.BoolVar(&doDebug, "debug", false, "verbose/debug logging")
 	flag.BoolVar(&eui.CacheCheck, "cacheCheck", false, "display window and item render counts")
 	flag.BoolVar(&dumpMusic, "dumpMusic", false, "write played music as a .wav file")
+	flag.BoolVar(&musicDebug, "musicDebug", false, "show bard music messages in chat")
 	flag.BoolVar(&experimental, "experimental", false, "enable experimental features like CL_Images/CL_Sounds patching")
 	genPGO := flag.Bool("pgo", false, "create default.pgo using test.clMov at 30 fps for 30s")
 	flag.Parse()

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -417,7 +417,7 @@ func parseMusicCommand(s string) bool {
 			return false
 		}
 		go playClanLordTune(strconv.Itoa(inst) + " " + strings.TrimSpace(notes))
-		return true
+		return !musicDebug
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- add `-musicDebug` flag to show bard music messages in chat
- honor `-musicDebug` by not suppressing /music and /play text

## Testing
- `go test ./...` (fails: GLFW library is not initialized, missing DISPLAY)


------
https://chatgpt.com/codex/tasks/task_e_68a6da73c35c832aa8f875b0239babcf