### PR TITLE
Log music commands when musicDebug is enabled

### DIFF
--- a/text_parsers.go
+++ b/text_parsers.go
@@ -379,47 +379,65 @@ func parseMusicCommand(s string) bool {
 	if strings.HasPrefix(s, "/music/") {
 		s = s[len("/music/"):]
 	}
-	if strings.HasPrefix(s, "/play") {
+
+	switch {
+	case strings.HasPrefix(s, "/play"):
 		s = s[len("/play"):]
-		s = strings.TrimPrefix(s, "/")
-		inst := defaultInstrument
-		if idx := strings.Index(s, "/inst"); idx >= 0 {
-			v := s[idx+len("/inst"):]
-			v = strings.TrimPrefix(v, "/")
-			if j := strings.IndexByte(v, '/'); j >= 0 {
-				v = v[:j]
-			}
-			if n, err := strconv.Atoi(v); err == nil {
-				inst = n
-			}
-		} else if idx := strings.Index(s, "/I"); idx >= 0 {
-			v := s[idx+len("/I"):]
-			if len(v) > 0 && v[0] == '/' {
-				v = v[1:]
-			}
-			if j := strings.IndexByte(v, '/'); j >= 0 {
-				v = v[:j]
-			}
-			if n, err := strconv.Atoi(v); err == nil {
-				inst = n
-			}
-		}
-		notes := ""
-		if idx := strings.Index(s, "/notes"); idx >= 0 {
-			notes = s[idx+len("/notes"):]
-		} else if idx := strings.Index(s, "/N"); idx >= 0 {
-			notes = s[idx+len("/N"):]
-		} else {
-			notes = s
-		}
-		notes = strings.Trim(notes, "/")
-		if notes == "" {
-			return false
-		}
-		go playClanLordTune(strconv.Itoa(inst) + " " + strings.TrimSpace(notes))
-		return !musicDebug
+	case strings.HasPrefix(s, "play"):
+		s = s[len("play"):]
+	case len(s) > 0 && (s[0] == 'P' || s[0] == 'p'):
+		s = s[1:]
+	default:
+		return false
 	}
-	return false
+
+	s = strings.TrimSpace(s)
+
+	inst := defaultInstrument
+	if idx := strings.Index(s, "/inst"); idx >= 0 {
+		v := s[idx+len("/inst"):]
+		v = strings.TrimPrefix(v, "/")
+		if j := strings.IndexByte(v, '/'); j >= 0 {
+			v = v[:j]
+		}
+		if n, err := strconv.Atoi(v); err == nil {
+			inst = n
+		}
+	} else if idx := strings.Index(s, "/I"); idx >= 0 {
+		v := s[idx+len("/I"):]
+		if len(v) > 0 && v[0] == '/' {
+			v = v[1:]
+		}
+		if j := strings.IndexByte(v, '/'); j >= 0 {
+			v = v[:j]
+		}
+		if n, err := strconv.Atoi(v); err == nil {
+			inst = n
+		}
+	}
+
+	notes := ""
+	if idx := strings.Index(s, "/notes"); idx >= 0 {
+		notes = s[idx+len("/notes"):]
+	} else if idx := strings.Index(s, "/N"); idx >= 0 {
+		notes = s[idx+len("/N"):]
+	} else {
+		notes = s
+	}
+	notes = strings.Trim(notes, "/")
+	if notes == "" {
+		return false
+	}
+	go playClanLordTune(strconv.Itoa(inst) + " " + strings.TrimSpace(notes))
+
+	if musicDebug {
+		msg := "/play " + strconv.Itoa(inst) + " " + strings.TrimSpace(notes)
+		consoleMessage(msg)
+		if !gs.MessagesToConsole {
+			chatMessage(msg)
+		}
+	}
+	return true
 }
 
 // firstTagContent extracts the first bracketed content for a given 2-letter BEPP tag.


### PR DESCRIPTION
## Summary
- Always log `/play` command to the console when `-musicDebug` is set
- Also mirror the message to chat when chat isn't redirected to the console
- Handle shorthand `/music/P/...` bard music messages so logging works for all tune formats

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dc2dadb8832ab1fd653b1e52c9bf