### PR TITLE
Handle bard music commands with leading parameters

### DIFF
--- a/music_command_test.go
+++ b/music_command_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func TestParseMusicCommandWithWho(t *testing.T) {
+	// Ensure /music commands with a leading /who segment are parsed.
+	if !parseMusicCommand("/music/who123/play/inst2/notesabc") {
+		t.Fatalf("parseMusicCommand failed to parse /music with /who prefix")
+	}
+}

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -380,14 +380,17 @@ func parseMusicCommand(s string) bool {
 		s = s[len("/music/"):]
 	}
 
-	switch {
-	case strings.HasPrefix(s, "/play"):
-		s = s[len("/play"):]
-	case strings.HasPrefix(s, "play"):
+	// Search for the play command anywhere in the string. The server may
+	// prefix it with parameters like "/who" before the actual "/play".
+	if idx := strings.Index(s, "/play"); idx >= 0 {
+		s = s[idx+len("/play"):]
+	} else if idx := strings.Index(s, "/P"); idx >= 0 {
+		s = s[idx+len("/P"):]
+	} else if strings.HasPrefix(s, "play") {
 		s = s[len("play"):]
-	case len(s) > 0 && (s[0] == 'P' || s[0] == 'p'):
+	} else if len(s) > 0 && (s[0] == 'P' || s[0] == 'p') {
 		s = s[1:]
-	default:
+	} else {
 		return false
 	}
 


### PR DESCRIPTION
## Summary
- allow parsing of bard /music commands that include segments before /play
- add regression test for /music with /who prefix

## Testing
- `go test ./...` *(fails: GLFW library requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1bf00a0832aa4b059355bf5e422