### PR TITLE
Handle raw music commands when text empty

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -143,7 +143,7 @@ func decodeBEPP(data []byte) string {
 	// For displayable text, strip BEPP tags and non-printables.
 	cleaned := stripBEPPTags(append([]byte(nil), raw...))
 	text := strings.TrimSpace(decodeMacRoman(cleaned))
-	if text == "" && prefix != "be" { // backend commands may have no printable text
+	if text == "" && prefix != "be" && prefix != "mu" { // backend commands or music may have no printable text
 		return ""
 	}
 
@@ -169,7 +169,8 @@ func decodeBEPP(data []byte) string {
 		}
 	case "ba", "mu":
 		// Bard guild messages or tunes
-		if !parseBardText(raw, text) && text != "" {
+		handled := parseBardText(raw, text)
+		if !handled && text != "" {
 			return text
 		}
 	case "lg":

--- a/music_command_test.go
+++ b/music_command_test.go
@@ -4,7 +4,13 @@ import "testing"
 
 func TestParseMusicCommandWithWho(t *testing.T) {
 	// Ensure /music commands with a leading /who segment are parsed.
-	if !parseMusicCommand("/music/who123/play/inst2/notesabc") {
+	if !parseMusicCommand("/music/who123/play/inst2/notesabc", nil) {
 		t.Fatalf("parseMusicCommand failed to parse /music with /who prefix")
+	}
+}
+
+func TestParseMusicCommandRawFallback(t *testing.T) {
+	if !parseMusicCommand("", []byte("/music/play/inst1/notesabc")) {
+		t.Fatalf("parseMusicCommand failed to parse raw payload")
 	}
 }


### PR DESCRIPTION
## Summary
- Process "mu" BEPP messages even with no printable text
- Parse bard music from raw payload when stripped text is empty
- Always log tunes to console and chat when musicDebug is enabled

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a76858040c832abdfd0c3e04fc5575