### PR TITLE
Preserve mobile interpolation history after pictureShift failures

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -821,9 +821,9 @@ func parseDrawState(data []byte, buildCache bool) error {
 		again = 0
 		newPics = append([]framePicture(nil), pics...)
 		state.prevDescs = nil
-		state.prevMobiles = nil
 		state.prevTime = time.Time{}
 		state.curTime = time.Time{}
+		logDebug("pictureShift failed; mobile interpolation may be degraded")
 	}
 	if state.descriptors == nil {
 		state.descriptors = make(map[uint8]frameDescriptor)
@@ -972,6 +972,13 @@ func parseDrawState(data []byte, buildCache bool) error {
 			}
 		}
 		state.mobiles[m.Index] = m
+	}
+	if !ok && state.prevMobiles != nil {
+		for idx := range state.prevMobiles {
+			if _, present := state.mobiles[idx]; !present {
+				delete(state.prevMobiles, idx)
+			}
+		}
 	}
 	// Prepare render caches now that state has been updated when requested.
 	if buildCache {

--- a/game.go
+++ b/game.go
@@ -1058,10 +1058,11 @@ func drawMobile(screen *ebiten.Image, ox, oy int, m frameMobile, descMap map[uin
 		if pm, ok := prevMobiles[m.Index]; ok {
 			dh := int(m.H) - int(pm.H) - shiftX
 			dv := int(m.V) - int(pm.V) - shiftY
-			if dh*dh+dv*dv <= maxMobileInterpPixels*maxMobileInterpPixels {
+			dist := dh*dh + dv*dv
+			if dist <= maxMobileInterpPixels*maxMobileInterpPixels {
 				h = float64(pm.H)*(1-alpha) + float64(m.H)*alpha
 				v = float64(pm.V)*(1-alpha) + float64(m.V)*alpha
-			}
+			} // else skip interpolation for this mobile
 		}
 	}
 	x := roundToInt((h + float64(fieldCenterX)) * gs.GameScale)


### PR DESCRIPTION
## Summary
- Avoid clearing `state.prevMobiles` when `pictureShift` fails and prune only entries for vanished mobiles
- Skip interpolation per mobile when movement exceeds threshold, keeping smoothing for unaffected mobiles
- Log picture shift failures that may degrade mobile interpolation

## Testing
- `go build ./...`
- `go test ./...` *(fails: X11 DISPLAY missing / GLFW not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68a769cea4f0832ab1c4d83cbc3e4b72