### PR TITLE
Add separate game volume control and decouple TTS

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -55,7 +55,7 @@ func speakChatMessage(msg string) {
 		ttsPlayers[p] = struct{}{}
 		ttsPlayersMu.Unlock()
 
-		vol := gs.ChatTTSVolume * gs.Volume
+		vol := gs.ChatTTSVolume
 		if gs.Mute {
 			vol = 0
 		}

--- a/sound.go
+++ b/sound.go
@@ -213,9 +213,13 @@ func initSoundContext() {
 }
 
 func updateSoundVolume() {
-	vol := gs.Volume
+	gameVol := gs.Volume
+	ttsVol := gs.ChatTTSVolume
+	musicVol := gs.MusicVolume
 	if gs.Mute {
-		vol = 0
+		gameVol = 0
+		ttsVol = 0
+		musicVol = 0
 	}
 
 	soundMu.Lock()
@@ -242,7 +246,7 @@ func updateSoundVolume() {
 	stopped := make([]*audio.Player, 0)
 	for _, sp := range players {
 		if sp.IsPlaying() {
-			sp.SetVolume(vol)
+			sp.SetVolume(gameVol)
 		} else {
 			stopped = append(stopped, sp)
 		}
@@ -251,7 +255,7 @@ func updateSoundVolume() {
 	ttsStopped := make([]*audio.Player, 0)
 	for _, p := range tts {
 		if p.IsPlaying() {
-			p.SetVolume(gs.ChatTTSVolume * vol)
+			p.SetVolume(ttsVol)
 		} else {
 			ttsStopped = append(ttsStopped, p)
 		}
@@ -260,7 +264,7 @@ func updateSoundVolume() {
 	musicStopped := make([]*audio.Player, 0)
 	for _, p := range music {
 		if p.IsPlaying() {
-			p.SetVolume(gs.MusicVolume * vol)
+			p.SetVolume(musicVol)
 		} else {
 			musicStopped = append(musicStopped, p)
 		}

--- a/synth.go
+++ b/synth.go
@@ -202,7 +202,7 @@ func Play(ctx *audio.Context, program int, notes []Note) error {
 	}
 	player := ctx.NewPlayerFromBytes(pcm)
 
-	vol := gs.MusicVolume * gs.Volume
+	vol := gs.MusicVolume
 	if gs.Mute {
 		vol = 0
 	}

--- a/tune.go
+++ b/tune.go
@@ -56,7 +56,7 @@ type noteEvent struct {
 // music package. The tune may optionally begin with an instrument index.
 // For example: "3 cde" plays on instrument #3.
 func playClanLordTune(tune string) {
-	if audioContext == nil || gs.Mute || gs.Volume <= 0 || gs.MusicVolume <= 0 {
+	if audioContext == nil || gs.Mute || gs.MusicVolume <= 0 {
 		return
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -1632,6 +1632,25 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(tsFormatInput)
 
+	gameSlider, gameEvents := eui.NewSlider()
+	gameSlider.MinValue = 0
+	gameSlider.MaxValue = 1
+	gameSlider.Value = float32(gs.Volume)
+	gameSlider.Size = eui.Point{X: rightW, Y: 24}
+	gameSlider.FontSize = 9
+	gameSlider.Label = "Game Volume"
+	gameEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			gs.Volume = float64(ev.Value)
+			settingsDirty = true
+			updateSoundVolume()
+		}
+	}
+	right.AddItem(gameSlider)
+
 	musicSlider, musicEvents := eui.NewSlider()
 	musicSlider.MinValue = 0
 	musicSlider.MaxValue = 1


### PR DESCRIPTION
## Summary
- Add settings slider for game volume
- Make chat TTS and music volumes independent of game volume
- Update sound volume handling accordingly

## Testing
- `go test ./...` *(fails: DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e816658832a8c2571cd34d91358