### PR TITLE
Handle disappearing edge pictures during camera shift

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -900,6 +900,34 @@ func parseDrawState(data []byte, buildCache bool) error {
 		}
 	}
 
+	// Carry over pictures that were visible in the previous frame but are
+	// absent this frame. If such a picture was touching the screen edge,
+	// keep it for one more frame using its previous position shifted by the
+	// detected picture movement. This prevents edge pictures from abruptly
+	// disappearing during camera pans.
+	if (state.picShiftX != 0 || state.picShiftY != 0) && len(prevPics) > 0 {
+		for _, pp := range prevPics {
+			if pp.Owned {
+				continue
+			}
+			if _, skip := skipPictShift[pp.PictID]; skip {
+				continue
+			}
+			if !pictureOnEdge(pp) {
+				continue
+			}
+			oldH, oldV := pp.H, pp.V
+			pp.H = int16(int(pp.H) + state.picShiftX)
+			pp.V = int16(int(pp.V) + state.picShiftY)
+			pp.PrevH = oldH
+			pp.PrevV = oldV
+			pp.Moving = true
+			pp.Background = false
+			pp.Again = true
+			newPics = append(newPics, pp)
+		}
+	}
+
 	state.pictures = newPics
 
 	needPrev := (gs.MotionSmoothing || gs.BlendMobiles) && ok && !seekingMov


### PR DESCRIPTION
## Summary
- retain previous-frame pictures on the screen edge by applying current frame's picture shift

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a781724bf4832aab8ffd38e73b26a1