### PR TITLE
Add helper to detect semi-transparent sprites

### DIFF
--- a/climg/climg.go
+++ b/climg/climg.go
@@ -707,6 +707,17 @@ func (c *CLImages) Size(id uint32) (int, int) {
 	return int(w), int(h)
 }
 
+// IsSemiTransparent reports whether the sprite with the given ID uses a blend
+// mode that results in a base alpha below full opacity. Missing IDs or sprites
+// without blend flags return false.
+func (c *CLImages) IsSemiTransparent(id uint32) bool {
+	if ref := c.idrefs[id]; ref != nil {
+		alpha, _ := alphaTransparentForFlags(ref.flags)
+		return alpha < 0xFF
+	}
+	return false
+}
+
 // NonTransparentPixels returns the number of pixels with non-zero alpha for
 // the specified image ID. It decodes the image data directly from the archive
 // to avoid GPU readbacks.

--- a/climg/semi_transparent_test.go
+++ b/climg/semi_transparent_test.go
@@ -1,0 +1,28 @@
+package climg
+
+import "testing"
+
+func TestIsSemiTransparent(t *testing.T) {
+	c := &CLImages{idrefs: map[uint32]*dataLocation{
+		1: {flags: pictDefFlagTransparent},
+		2: {flags: 1},
+		3: {flags: pictDefFlagTransparent | 2},
+		4: {flags: 0},
+	}}
+
+	if c.IsSemiTransparent(1) {
+		t.Fatalf("id 1: expected not semi-transparent")
+	}
+	if !c.IsSemiTransparent(2) {
+		t.Fatalf("id 2: expected semi-transparent")
+	}
+	if !c.IsSemiTransparent(3) {
+		t.Fatalf("id 3: expected semi-transparent")
+	}
+	if c.IsSemiTransparent(4) {
+		t.Fatalf("id 4: expected not semi-transparent")
+	}
+	if c.IsSemiTransparent(5) {
+		t.Fatalf("missing id: expected not semi-transparent")
+	}
+}


### PR DESCRIPTION
## Summary
- add `IsSemiTransparent` method to check blend flags for sprite transparency
- cover flag combinations with unit test

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a4ae2fc4832aae0fc4fe24d2e2b2