### PR TITLE
Use versioned OS/arch naming for gothoom downloads

### DIFF
--- a/releaseHelper/main.go
+++ b/releaseHelper/main.go
@@ -124,9 +124,9 @@ func main() {
 
 func parseOSArch(name string) (string, string, error) {
 	base := strings.TrimSuffix(filepath.Base(name), ".zip")
-	parts := strings.Split(base, "_")
-	if len(parts) < 3 {
-		return "", "", fmt.Errorf("filename %s does not contain os and arch", name)
+	parts := strings.Split(base, "-")
+	if len(parts) < 4 {
+		return "", "", fmt.Errorf("filename %s does not contain version, os, and arch", name)
 	}
 	osName := parts[len(parts)-2]
 	arch := parts[len(parts)-1]

--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="binaries"
 mkdir -p "$OUTPUT_DIR"
 
+VERSION="${1:-dev}"
+
 platforms=(
   "linux:amd64"
   #"linux:arm64"
@@ -135,7 +137,7 @@ ensure_cmd zip
 
 for platform in "${platforms[@]}"; do
   IFS=":" read -r GOOS GOARCH <<<"$platform"
-  BIN_NAME="gothoom-${GOOS}-${GOARCH}"
+  BIN_NAME="gothoom-${VERSION}-${GOOS}-${GOARCH}"
   ZIP_NAME="${BIN_NAME}.zip"
   TAGS=""
   LDFLAGS="-s -w"

--- a/versions.go
+++ b/versions.go
@@ -34,7 +34,7 @@ var (
 )
 
 const versionsURL = "https://m45sci.xyz/u/dist/goThoom/versions.json"
-const binaryURLFmt = "https://m45sci.xyz/u/dist/goThoom/gothoom-%d.zip"
+const binaryURLFmt = "https://m45sci.xyz/u/dist/goThoom/gothoom-%d-%s-%s.zip"
 
 var uiReady bool
 
@@ -198,7 +198,7 @@ func versionCheckLoop() {
 }
 
 func downloadAndInstall(ver int) error {
-	url := fmt.Sprintf(binaryURLFmt, ver)
+	url := fmt.Sprintf(binaryURLFmt, ver, runtime.GOOS, runtime.GOARCH)
 	exePath, err := os.Executable()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- version build artifacts and zips as `gothoom-<ver>-<os>-<arch>.zip`
- parse new hyphenated filenames in release helper
- fetch updates using OS/arch-specific binary names

## Testing
- `go test ./...` *(fails: Package alsa and GTK/X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b42f6984832a8f0ebbed3f56c359