### PR TITLE
fix picture attachment to mobiles

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -887,6 +887,21 @@ func parseDrawState(data []byte, buildCache bool) error {
 				newPics[i].PrevV = best.V
 				best.Owned = true
 			}
+		} else if moving {
+			for j := range prevPics {
+				pp := &prevPics[j]
+				if pp.Owned || pp.PictID != newPics[i].PictID {
+					continue
+				}
+				dh := int(newPics[i].H) - int(pp.H) - state.picShiftX
+				dv := int(newPics[i].V) - int(pp.V) - state.picShiftY
+				if dh*dh+dv*dv <= maxInterpPixels*maxInterpPixels {
+					newPics[i].PrevH = pp.H
+					newPics[i].PrevV = pp.V
+					pp.Owned = true
+					break
+				}
+			}
 		} else if owner != nil {
 			owner.Owned = true
 		}


### PR DESCRIPTION
## Summary
- track previous picture positions even when smooth moving is disabled so that mobile-following logic applies

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*


------
https://chatgpt.com/codex/tasks/task_e_68a7b963fee0832a84c53c14b3711d0f