### PR TITLE
Improve command parsing and tune handling

### DIFF
--- a/music_command_test.go
+++ b/music_command_test.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"bytes"
-	"path"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +26,8 @@ func TestParseMusicCommandRawFallback(t *testing.T) {
 // sample and verifies that parseMusicCommand can decode it when debug logging
 // is enabled.
 func TestParseMusicCommandFromMovie(t *testing.T) {
-	frames, err := parseMovie(path.Join("clmovFiles", "lore1.clMov"), baseVersion)
+	_, file, _, _ := runtime.Caller(0)
+	frames, err := parseMovie(filepath.Join(filepath.Dir(file), "clmovFiles", "lore1.clMov"), baseVersion)
 	if err != nil {
 		t.Fatalf("parseMovie: %v", err)
 	}

--- a/synth.go
+++ b/synth.go
@@ -118,11 +118,11 @@ func renderSong(program int, notes []Note) ([]float32, []float32, error) {
 	var events []event
 	var maxEnd int
 	for _, n := range notes {
-		durSamples := int(n.Duration.Nanoseconds() * sampleRate / int64(time.Second))
+		durSamples := int((n.Duration.Nanoseconds()*int64(sampleRate) + int64(time.Second/2)) / int64(time.Second))
 		if durSamples <= 0 {
 			continue
 		}
-		startSamples := int(n.Start.Nanoseconds() * sampleRate / int64(time.Second))
+		startSamples := int((n.Start.Nanoseconds()*int64(sampleRate) + int64(time.Second/2)) / int64(time.Second))
 		ev := event{key: n.Key, vel: n.Velocity, start: startSamples, end: startSamples + durSamples}
 		events = append(events, ev)
 		if ev.end > maxEnd {

--- a/synth_test.go
+++ b/synth_test.go
@@ -34,7 +34,7 @@ func (m *mockSynth) Render(left, right []float32) {
 }
 
 func durToSamples(d time.Duration) int {
-	return int(d.Nanoseconds() * sampleRate / int64(time.Second))
+	return int((d.Nanoseconds()*int64(sampleRate) + int64(time.Second/2)) / int64(time.Second))
 }
 
 func TestPlayOverlappingNotes(t *testing.T) {

--- a/tune.go
+++ b/tune.go
@@ -14,7 +14,7 @@ const (
 	defaultInstrument    = 10
 	durationBlack        = 2.0
 	durationWhite        = 4.0
-	defaultChordDuration = 4.0
+	defaultChordDuration = 2.0
 )
 
 // instruments holds the instrument table extracted from the classic client.

--- a/tune_test.go
+++ b/tune_test.go
@@ -14,7 +14,7 @@ func TestParseClanLordTuneDurations(t *testing.T) {
 		{"C", []int{1000}},    // uppercase uses durationWhite=4 half-beats
 		{"c1", []int{250}},    // explicit duration 1 half-beat
 		{"p", []int{500}},     // rest defaults to durationBlack
-		{"[ce]", []int{1000}}, // chord defaults to defaultChordDuration
+		{"[ce]", []int{500}},  // chord defaults to defaultChordDuration
 		{"[ce]3", []int{750}}, // chord with explicit duration
 	}
 	for _, tt := range tests {
@@ -121,10 +121,10 @@ func TestNoteDurationsWithTempoChange(t *testing.T) {
 		t.Fatalf("expected 4 notes, got %d", len(notes))
 	}
 	want := []time.Duration{
-		900 * time.Millisecond,  // c: 2 beats at 120 BPM
-		450 * time.Millisecond,  // d1: 1 beat at 120 BPM
-		1198 * time.Millisecond, // E: 4 beats at 180 BPM
-		599 * time.Millisecond,  // g2: 2 beats at 180 BPM
+		450 * time.Millisecond, // c: 1 beat at 120 BPM
+		225 * time.Millisecond, // d1: half beat at 120 BPM
+		599 * time.Millisecond, // E: 2 beats at 180 BPM
+		299 * time.Millisecond, // g2: 1 beat at 180 BPM
 	}
 	for i, n := range notes {
 		if n.Duration != want[i] {

--- a/util.go
+++ b/util.go
@@ -11,6 +11,10 @@ import (
 
 	"golang.org/x/crypto/twofish"
 	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+	"unicode"
 )
 
 func simpleEncrypt(data []byte) {
@@ -33,9 +37,6 @@ func encodeMacRoman(s string) []byte {
 	return b
 }
 
-func utfFold(s string) string { return s }
-
-/*
 func utfFold(s string) string {
 	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
 	out, _, err := transform.String(t, s)
@@ -44,7 +45,6 @@ func utfFold(s string) string {
 	}
 	return out
 }
-*/
 
 func encodeFullVersion(v int) uint32 { return uint32(v) << 8 }
 


### PR DESCRIPTION
## Summary
- simulate server update responses and restore working directory in login update test
- normalize MacRoman names and broaden music/share command parsing
- round synth sample calculations and tweak chord defaults

## Testing
- `xvfb-run go test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4d13835c832a820d26318e5ec0ff