### PR TITLE
Fix movie player skip speed

### DIFF
--- a/movie_player.go
+++ b/movie_player.go
@@ -35,6 +35,7 @@ const checkpointInterval = 300
 type moviePlayer struct {
 	frames  [][]byte
 	fps     int
+	baseFPS int
 	cur     int // number of frames processed
 	playing bool
 	ticker  *time.Ticker
@@ -58,6 +59,7 @@ func newMoviePlayer(frames [][]byte, fps int, cancel context.CancelFunc) *movieP
 	return &moviePlayer{
 		frames:      frames,
 		fps:         fps,
+		baseFPS:     fps,
 		playing:     true,
 		ticker:      time.NewTicker(time.Second / time.Duration(fps)),
 		cancel:      cancel,
@@ -216,7 +218,7 @@ func (p *moviePlayer) makePlaybackWindow() {
 	reset.Size = eui.Point{X: 140, Y: 24}
 	resetEv.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-			p.setFPS(clMovFPS)
+			p.setFPS(p.baseFPS)
 		}
 	}
 	bFlow.AddItem(reset)
@@ -417,7 +419,8 @@ func (p *moviePlayer) skipBackMilli(milli int) {
 	}
 	seekLock.Lock()
 	go func() {
-		p.seek(p.cur - int(float64(milli)*(float64(p.fps)/1000.0)))
+		skip := int(float64(milli) * (float64(p.baseFPS) / 1000.0))
+		p.seek(p.cur - skip)
 		seekLock.Unlock()
 	}()
 
@@ -429,7 +432,8 @@ func (p *moviePlayer) skipForwardMilli(milli int) {
 	}
 	seekLock.Lock()
 	go func() {
-		p.seek(p.cur + int(float64(milli)*(float64(p.fps)/1000.0)))
+		skip := int(float64(milli) * (float64(p.baseFPS) / 1000.0))
+		p.seek(p.cur + skip)
 		seekLock.Unlock()
 	}()
 


### PR DESCRIPTION
## Summary
- ensure movie player skip timings use original frame rate, unaffected by playback speed

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68aa607c6d04832a927e26128f75638f