### PR TITLE
Fix pause between repeated tune loops

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -262,6 +262,16 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 			top := &stack[len(stack)-1]
 			if top.remaining > 0 {
 				top.remaining--
+				// If the loop starts with a note and the previous event
+				// was also a note, remove the trailing rest inserted after
+				// the last note of the previous iteration. This prevents an
+				// unintended pause between loop repetitions when no explicit
+				// rest exists at the loop boundary.
+				if prevWasNote && len(pt.events[top.start].keys) > 0 {
+					startMS -= prevRestMS
+					prevWasNote = false
+					prevRestMS = 0
+				}
 				i = top.start
 				// reset tempo to state at loop start
 				tempo = pt.tempo

--- a/tune_test.go
+++ b/tune_test.go
@@ -128,6 +128,22 @@ func TestEventsToNotesLoop(t *testing.T) {
 	}
 }
 
+// TestLoopSeamlessRepeat ensures that looping a sequence starting with a note
+// does not introduce an extra rest between iterations when no explicit rest is
+// present at the loop boundary.
+func TestLoopSeamlessRepeat(t *testing.T) {
+	pt := parseClanLordTune("(c)2")
+	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
+	notes := eventsToNotes(pt, inst, 100)
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 notes, got %d", len(notes))
+	}
+	gap := notes[1].Start - notes[0].Start - notes[0].Duration
+	if gap != 0 {
+		t.Fatalf("gap between loop iterations = %v, want 0", gap)
+	}
+}
+
 func TestNoteDurationsWithTempoChange(t *testing.T) {
 	tune := "c d1 @+60 E g2"
 	pt := parseClanLordTuneWithTempo(tune, 120)


### PR DESCRIPTION
## Summary
- avoid stray rest when looping tunes so repeats start immediately
- add regression test for seamless loop repetition

## Testing
- `go test -run TestLoopSeamlessRepeat -v` *(hangs: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68aa72d94eac832ab137ccd012aa7d49