### PR TITLE
Compress tune volume scaling and handle low C notes

### DIFF
--- a/tune.go
+++ b/tune.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -226,7 +227,7 @@ func eventsToNotes(pt parsedTune, inst instrument, velocity int) []Note {
 			} else {
 				v = v * inst.melody / 100
 			}
-			v = v * ev.volume / 10
+			v = int(float64(v)*math.Sqrt(float64(ev.volume)/10.0) + 0.5)
 			if v < 1 {
 				v = 1
 			} else if v > 127 {
@@ -320,7 +321,7 @@ func parseClanLordTuneWithTempo(s string, tempo int) parsedTune {
 				}
 				if isNoteLetter(s[i]) {
 					k, _ := parseNoteCL(s, &i, &octave)
-					if k != 0 {
+					if k >= 0 {
 						keys = append(keys, k)
 					}
 					continue
@@ -421,7 +422,7 @@ func parseClanLordTuneWithTempo(s string, tempo int) parsedTune {
 		default:
 			if isNoteLetter(c) {
 				k, beats := parseNoteCL(s, &i, &octave)
-				if k != 0 {
+				if k >= 0 {
 					pt.events = append(pt.events, noteEvent{keys: []int{k}, beats: beats, volume: volume})
 				}
 			} else {
@@ -459,8 +460,8 @@ func parseNoteCL(s string, i *int, octave *int) (int, float64) {
 	isUpper := unicode.IsUpper(rune(c))
 	base := noteOffset(unicode.ToLower(rune(c)))
 	if base < 0 {
-		*i++
-		return 0, 0
+		(*i)++
+		return -1, 0
 	}
 	(*i)++
 	pitch := base + ((*octave)+1)*12

--- a/tune_test.go
+++ b/tune_test.go
@@ -111,8 +111,8 @@ func TestLoopAndTempoAndVolume(t *testing.T) {
 	if notes[4].Duration != 166*time.Millisecond {
 		t.Fatalf("tempo change not applied, got %v", notes[4].Duration)
 	}
-	// volume change should halve velocity for last note (volume set to 5)
-	if notes[5].Velocity != 50 {
+	// volume change should reduce velocity per square-root scaling (volume set to 5)
+	if notes[5].Velocity != 71 {
 		t.Fatalf("volume change not applied, got %d", notes[5].Velocity)
 	}
 }
@@ -183,5 +183,15 @@ func TestNoteDurationsUncommonTempos(t *testing.T) {
 		if notes[0].Duration != c.want {
 			t.Errorf("tempo %d: duration = %v, want %v", c.tempo, notes[0].Duration, c.want)
 		}
+	}
+}
+
+func TestParseNoteLowestCPreserved(t *testing.T) {
+	pt := parseClanLordTune("\\----c")
+	if len(pt.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(pt.events))
+	}
+	if len(pt.events[0].keys) != 1 || pt.events[0].keys[0] != 0 {
+		t.Fatalf("expected low C (0), got %+v", pt.events[0].keys)
 	}
 }


### PR DESCRIPTION
## Summary
- soften volume differences between notes using square-root scaling
- accept MIDI note 0 by returning -1 for invalid notes and checking for >=0
- add regression test for lowest C parsing

## Testing
- `go build ./...`
- `go test ./...` *(fails: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa78ccfa5c832abd5c3e9481823e1d