### PR TITLE
Expand macro parser to handle include directives

### DIFF
--- a/macro/parser_test.go
+++ b/macro/parser_test.go
@@ -1,6 +1,10 @@
 package macro
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParserExpression(t *testing.T) {
 	p := New()
@@ -67,5 +71,28 @@ func TestSetVariableProducesNoMacro(t *testing.T) {
 	}
 	if len(p.Macros) != 0 {
 		t.Fatalf("expected no macros, got %d", len(p.Macros))
+	}
+}
+
+func TestParserInclude(t *testing.T) {
+	dir := t.TempDir()
+	inc := filepath.Join(dir, "inc.txt")
+	if err := os.WriteFile(inc, []byte("'bar' hello"), 0o644); err != nil {
+		t.Fatalf("write include: %v", err)
+	}
+	main := filepath.Join(dir, "main.txt")
+	content := "include \"inc.txt\""
+	if err := os.WriteFile(main, []byte(content), 0o644); err != nil {
+		t.Fatalf("write main: %v", err)
+	}
+	p := New()
+	if err := p.ParseFile(main); err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(p.Macros) != 1 {
+		t.Fatalf("expected 1 macro from include, got %d", len(p.Macros))
+	}
+	if p.Macros[0].Name != "bar" {
+		t.Fatalf("unexpected macro name: %s", p.Macros[0].Name)
 	}
 }


### PR DESCRIPTION
## Summary
- support `include` directives in macro parser and track parsed files to avoid duplicates
- test parsing of included macro files

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing; pkg-config: alsa, gtk+-3.0 not found)*
- `go test ./macro`


------
https://chatgpt.com/codex/tasks/task_e_68aa90847aac832a85f789552ecc5af5