### PR TITLE
Return parse errors for invalid tunes

### DIFF
--- a/synth_test.go
+++ b/synth_test.go
@@ -117,7 +117,10 @@ func TestPCMBufferDuration(t *testing.T) {
 	sfntCached = &meltysynth.SoundFont{}
 	synthSettings = meltysynth.NewSynthesizerSettings(sampleRate)
 
-	pt := parseClanLordTuneWithTempo("cd", 120)
+	pt, err := parseClanLordTuneWithTempo("cd", 120)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
 	inst := instrument{program: 0, octave: 0, chord: 100, melody: 100}
 	notes := eventsToNotes(pt, inst, 100)
 


### PR DESCRIPTION
## Summary
- return detailed errors from Clan Lord tune parser and note parser
- surface parsing failures via consoleMessage and chatMessage
- test invalid notes, tempo bounds, and unmatched loops

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa444cc98832ab46ace0a71d15364