### PR TITLE
Skip arrows for off-screen yell bubbles

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -120,6 +120,9 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 
 	sw := int(float64(gameAreaSizeX) * gs.GameScale)
 	sh := int(float64(gameAreaSizeY) * gs.GameScale)
+	if tailX < 0 || tailX >= sw || tailY < 0 || tailY >= sh {
+		noArrow = true
+	}
 	pad := int((4 + 2) * gs.GameScale)
 	tailHeight := int(10 * gs.GameScale)
 	tailHalf := int(6 * gs.GameScale)


### PR DESCRIPTION
## Summary
- prevent drawing yell bubble tails when the bubble's anchor point is off-screen

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aab6a0ef24832a8c966326df90f4d0