### PR TITLE
Check picture visibility before edge detection

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -201,10 +201,11 @@ func nonTransparentPixels(id uint16) int {
 	return count
 }
 
-// pictureOnEdge reports whether the given picture's bounding box touches the
-// edge of the visible game field.
+// pictureOnEdge reports whether the picture overlaps the visible game field and
+// whether its bounding box touches or extends past the field boundaries.
+// Pictures entirely outside the field are not considered to be on the edge.
 func pictureOnEdge(p framePicture) bool {
-	if clImages == nil {
+	if !pictureVisible(p) {
 		return false
 	}
 	w, h := clImages.Size(uint32(p.PictID))


### PR DESCRIPTION
## Summary
- check picture visibility before treating it as on field edge
- clarify `pictureOnEdge` behavior in comment

## Testing
- `go build ./...`
- `go test ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aab6ac4b00832aa932ae461326258b