### PR TITLE
Add pictureOnEdge edge-case tests

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -210,10 +210,16 @@ func pictureOnEdge(p framePicture) bool {
 	w, h := clImages.Size(uint32(p.PictID))
 	halfW := w / 2
 	halfH := h / 2
-	if int(p.H)-halfW <= -fieldCenterX ||
-		int(p.H)+halfW >= fieldCenterX ||
-		int(p.V)-halfH <= -fieldCenterY ||
-		int(p.V)+halfH >= fieldCenterY {
+	left := int(p.H) - halfW
+	right := int(p.H) + halfW
+	top := int(p.V) - halfH
+	bottom := int(p.V) + halfH
+	if right < -fieldCenterX || left > fieldCenterX ||
+		bottom < -fieldCenterY || top > fieldCenterY {
+		return false
+	}
+	if left <= -fieldCenterX || right >= fieldCenterX ||
+		top <= -fieldCenterY || bottom >= fieldCenterY {
 		return true
 	}
 	return false

--- a/draw_test.go
+++ b/draw_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/binary"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"gothoom/climg"
+)
+
+func mockCLImages(w, h int) *climg.CLImages {
+	imgs := &climg.CLImages{}
+	v := reflect.ValueOf(imgs).Elem()
+
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint16(data[:2], uint16(h))
+	binary.BigEndian.PutUint16(data[2:], uint16(w))
+	dataField := v.FieldByName("data")
+	reflect.NewAt(dataField.Type(), unsafe.Pointer(dataField.UnsafeAddr())).Elem().Set(reflect.ValueOf(data))
+
+	idrefsField := v.FieldByName("idrefs")
+	imagesField := v.FieldByName("images")
+	idrefsMap := reflect.MakeMap(idrefsField.Type())
+	imagesMap := reflect.MakeMap(imagesField.Type())
+
+	dlType := idrefsField.Type().Elem().Elem()
+	idref := reflect.New(dlType)
+	imageIDField := idref.Elem().FieldByName("imageID")
+	reflect.NewAt(imageIDField.Type(), unsafe.Pointer(imageIDField.UnsafeAddr())).Elem().SetUint(1)
+	idrefsMap.SetMapIndex(reflect.ValueOf(uint32(1)), idref)
+
+	imgLoc := reflect.New(dlType)
+	imagesMap.SetMapIndex(reflect.ValueOf(uint32(1)), imgLoc)
+
+	reflect.NewAt(idrefsField.Type(), unsafe.Pointer(idrefsField.UnsafeAddr())).Elem().Set(idrefsMap)
+	reflect.NewAt(imagesField.Type(), unsafe.Pointer(imagesField.UnsafeAddr())).Elem().Set(imagesMap)
+
+	return imgs
+}
+
+func TestPictureOnEdge(t *testing.T) {
+	clImages = mockCLImages(10, 10)
+	defer func() { clImages = nil }()
+
+	halfW := 5
+	halfH := 5
+
+	tests := []struct {
+		name string
+		p    framePicture
+		want bool
+	}{
+		{"inside", framePicture{PictID: 1, H: 0, V: 0}, false},
+		{"left edge", framePicture{PictID: 1, H: int16(-fieldCenterX + halfW), V: 0}, true},
+		{"right edge", framePicture{PictID: 1, H: int16(fieldCenterX - halfW), V: 0}, true},
+		{"top edge", framePicture{PictID: 1, H: 0, V: int16(-fieldCenterY + halfH)}, true},
+		{"bottom edge", framePicture{PictID: 1, H: 0, V: int16(fieldCenterY - halfH)}, true},
+		{"outside", framePicture{PictID: 1, H: int16(fieldCenterX + halfW + 1), V: 0}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pictureOnEdge(tt.p); got != tt.want {
+				t.Fatalf("pictureOnEdge(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- refine `pictureOnEdge` to ignore sprites fully outside the field
- add table-driven tests for `pictureOnEdge`

## Testing
- `xvfb-run -a go test ./...` *(fails: TestClassicTimingMatchesReference, TestEventsToNotesChordStart, TestAltEndingsSimple, TestSliderConstrainedWidth)*

------
https://chatgpt.com/codex/tasks/task_e_68aab6b3b90c832aa6706b18387f5c86