### PR TITLE
Fix yell bubble spikes when arrow omitted

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -252,6 +252,8 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		if !far && !noArrow {
 			gapStart = float32(baseX - tailHalf)
 			gapEnd = float32(baseX + tailHalf)
+		} else {
+			gapStart, gapEnd = -1, -1
 		}
 		drawSpikes(screen, float32(left), float32(top), float32(right), float32(bottom), radius, float32(gs.GameScale*3), borderCol, gapStart, gapEnd)
 	} else if bubbleType == kBubbleMonster {


### PR DESCRIPTION
## Summary
- avoid stray bottom gap when yell bubble arrow is hidden

## Testing
- `go test ./...` *(fails: X11 extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aab805c31c832a8ad7c686cd1d2805