### PR TITLE
Use source-over blending for ponder bubble edges

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -853,6 +853,6 @@ func drawBubbleCircle(screen *ebiten.Image, cx, cy, radius float32, col color.Co
 		vs[i].ColorB = float32(b) / 0xffff
 		vs[i].ColorA = float32(a) / 0xffff
 	}
-	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true, CompositeMode: ebiten.CompositeModeCopy}
+	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true}
 	screen.DrawTriangles(vs, is, whiteImage, op)
 }


### PR DESCRIPTION
## Summary
- Ensure ponder bubble wave circles blend using the bubble body's color and opacity

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aabaa81474832a9ed6b99e5f034ffa