### PR TITLE
Fix transparency mapping to avoid unintended alpha

### DIFF
--- a/climg/alpha_test.go
+++ b/climg/alpha_test.go
@@ -1,0 +1,42 @@
+package climg
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestNonTransparentPixelsIgnoresPaletteIndex verifies that transparency
+// is determined solely by the original pixel index and not by the mapped
+// palette color. A non-zero pixel mapped to palette index 0 should still
+// be counted as non-transparent.
+func TestNonTransparentPixelsIgnoresPaletteIndex(t *testing.T) {
+	// Build minimal image data: 1x1 pixel with value 1.
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.BigEndian, uint16(1)) // height
+	binary.Write(&buf, binary.BigEndian, uint16(1)) // width
+	binary.Write(&buf, binary.BigEndian, uint32(0)) // pad
+	buf.WriteByte(1)                                // value bits per pixel
+	buf.WriteByte(0)                                // block length bits
+	buf.Write([]byte{0x40})                         // encoded pixel: t=0, value=1
+
+	imgData := buf.Bytes()
+
+	c := &CLImages{
+		data: imgData,
+		idrefs: map[uint32]*dataLocation{
+			1: {imageID: 1, colorID: 1, flags: pictDefFlagTransparent},
+		},
+		images: map[uint32]*dataLocation{
+			1: {offset: 0},
+		},
+		colors: map[uint32]*dataLocation{
+			// Map color index 1 to palette index 0 to replicate bug case.
+			1: {colorBytes: []uint16{0, 0}},
+		},
+	}
+
+	if n := c.NonTransparentPixels(1); n != 1 {
+		t.Fatalf("NonTransparentPixels = %d, want 1", n)
+	}
+}

--- a/climg/climg.go
+++ b/climg/climg.go
@@ -612,12 +612,13 @@ func (c *CLImages) Get(id uint32, custom []byte, forceTransparent bool) *ebiten.
 	pix := img.Pix
 	stride := img.Stride
 	for i := 0; i < pixelCount; i++ {
-		idx := col[data[i]]
+		src := data[i]
+		idx := col[src]
 		r := uint8(pal[idx*3])
 		g := uint8(pal[idx*3+1])
 		b := uint8(pal[idx*3+2])
 		a := alpha
-		if idx == 0 && transparent {
+		if src == 0 && transparent {
 			a = 0
 		}
 		// Ebiten expects premultiplied alpha values.
@@ -812,10 +813,9 @@ func (c *CLImages) NonTransparentPixels(id uint32) int {
 		return len(data)
 	}
 
-	col := colLoc.colorBytes
 	count := 0
 	for _, idx := range data {
-		if col[idx] != 0 {
+		if idx != 0 {
 			count++
 		}
 	}


### PR DESCRIPTION
## Summary
- use original color index when deciding transparency, preventing non-zero palette entries from becoming transparent
- add regression test to ensure palette mappings don't drop alpha

## Testing
- `xvfb-run go test ./...` *(fails: TestClassicTimingMatchesReference, TestEventsToNotesChordStart, TestAltEndingsSimple, TestSliderConstrainedWidth)*

------
https://chatgpt.com/codex/tasks/task_e_68aabb3dc514832a8a50ea59b0b00bbd