### PR TITLE
Fade whisper bubble edges

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -194,9 +194,42 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 			tail.Close()
 		}
 	}
+	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true}
+
+	if bubbleType == kBubbleWhisper {
+		maxWidth := float32(12 * gs.GameScale)
+		fadeSteps := 4
+		for i := fadeSteps; i >= 1; i-- {
+			width := maxWidth * float32(i) / float32(fadeSteps)
+			alpha := float32(bgA) / 0xffff * float32(fadeSteps-i+1) / float32(fadeSteps+1)
+
+			vs, is := body.AppendVerticesAndIndicesForStroke(nil, nil, &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound})
+			for j := range vs {
+				vs[j].SrcX = 0
+				vs[j].SrcY = 0
+				vs[j].ColorR = float32(bgR) / 0xffff
+				vs[j].ColorG = float32(bgG) / 0xffff
+				vs[j].ColorB = float32(bgB) / 0xffff
+				vs[j].ColorA = alpha
+			}
+			screen.DrawTriangles(vs, is, whiteImage, op)
+
+			if !far && !noArrow {
+				vs, is = tail.AppendVerticesAndIndicesForStroke(vs[:0], is[:0], &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound})
+				for j := range vs {
+					vs[j].SrcX = 0
+					vs[j].SrcY = 0
+					vs[j].ColorR = float32(bgR) / 0xffff
+					vs[j].ColorG = float32(bgG) / 0xffff
+					vs[j].ColorB = float32(bgB) / 0xffff
+					vs[j].ColorA = alpha
+				}
+				screen.DrawTriangles(vs, is, whiteImage, op)
+			}
+		}
+	}
 
 	vs, is := tail.AppendVerticesAndIndicesForFilling(nil, nil)
-	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true}
 	if !far && !noArrow {
 		for i := range vs {
 			vs[i].SrcX = 0

--- a/bubble.go
+++ b/bubble.go
@@ -196,39 +196,6 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	}
 	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true}
 
-	if bubbleType == kBubbleWhisper {
-		maxWidth := float32(12 * gs.GameScale)
-		fadeSteps := 4
-		for i := fadeSteps; i >= 1; i-- {
-			width := maxWidth * float32(i) / float32(fadeSteps)
-			alpha := float32(bgA) / 0xffff * float32(fadeSteps-i+1) / float32(fadeSteps+1)
-
-			vs, is := body.AppendVerticesAndIndicesForStroke(nil, nil, &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound})
-			for j := range vs {
-				vs[j].SrcX = 0
-				vs[j].SrcY = 0
-				vs[j].ColorR = float32(bgR) / 0xffff
-				vs[j].ColorG = float32(bgG) / 0xffff
-				vs[j].ColorB = float32(bgB) / 0xffff
-				vs[j].ColorA = alpha
-			}
-			screen.DrawTriangles(vs, is, whiteImage, op)
-
-			if !far && !noArrow {
-				vs, is = tail.AppendVerticesAndIndicesForStroke(vs[:0], is[:0], &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound})
-				for j := range vs {
-					vs[j].SrcX = 0
-					vs[j].SrcY = 0
-					vs[j].ColorR = float32(bgR) / 0xffff
-					vs[j].ColorG = float32(bgG) / 0xffff
-					vs[j].ColorB = float32(bgB) / 0xffff
-					vs[j].ColorA = alpha
-				}
-				screen.DrawTriangles(vs, is, whiteImage, op)
-			}
-		}
-	}
-
 	vs, is := tail.AppendVerticesAndIndicesForFilling(nil, nil)
 	if !far && !noArrow {
 		for i := range vs {
@@ -252,6 +219,39 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		vs[i].ColorA = float32(bgA) / 0xffff
 	}
 	screen.DrawTriangles(vs, is, whiteImage, op)
+	if bubbleType == kBubbleWhisper {
+		maxWidth := float32(12 * gs.GameScale)
+		fadeSteps := 4
+		fadeOp := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true, CompositeMode: ebiten.CompositeModeDestinationOut}
+		for i := 1; i <= fadeSteps; i++ {
+			width := maxWidth * float32(i) / float32(fadeSteps)
+			alpha := float32(fadeSteps-i+1) / float32(fadeSteps)
+
+			vsFade, isFade := body.AppendVerticesAndIndicesForStroke(nil, nil, &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound})
+			for j := range vsFade {
+				vsFade[j].SrcX = 0
+				vsFade[j].SrcY = 0
+				vsFade[j].ColorR = 1
+				vsFade[j].ColorG = 1
+				vsFade[j].ColorB = 1
+				vsFade[j].ColorA = alpha
+			}
+			screen.DrawTriangles(vsFade, isFade, whiteImage, fadeOp)
+
+			if !far && !noArrow {
+				vsFade, isFade = tail.AppendVerticesAndIndicesForStroke(vsFade[:0], isFade[:0], &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound})
+				for j := range vsFade {
+					vsFade[j].SrcX = 0
+					vsFade[j].SrcY = 0
+					vsFade[j].ColorR = 1
+					vsFade[j].ColorG = 1
+					vsFade[j].ColorB = 1
+					vsFade[j].ColorA = alpha
+				}
+				screen.DrawTriangles(vsFade, isFade, whiteImage, fadeOp)
+			}
+		}
+	}
 	if bubbleType != kBubblePonder {
 		var outline vector.Path
 		outline.MoveTo(float32(left)+radius, float32(top))


### PR DESCRIPTION
## Summary
- add gradual fade around whisper chat bubbles for subtler edges

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aac02e6c00832ab839999f14c844fb