### PR TITLE
Fix denoise strength slider scaling

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -2315,14 +2315,14 @@ func makeQualityWindow() {
 	denoiseAmtSlider.Label = "Denoise strength"
 	denoiseAmtSlider.MinValue = 0
 	denoiseAmtSlider.MaxValue = 100
-	denoiseAmtSlider.Value = float32(gs.DenoiseSharpness * 333.3333)
+	denoiseAmtSlider.Value = float32(gs.DenoiseAmount * 100)
 	denoiseAmtSlider.Size = eui.Point{X: width - 10, Y: 24}
 	denoiseAmtSlider.Tooltip = "How strongly to blend dithered areas"
 	denoiseAmtEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
-			gs.DenoiseSharpness = float64(ev.Value / 333.3333)
+			gs.DenoiseAmount = float64(ev.Value / 100)
 			if clImages != nil {
-				clImages.DenoiseAmount = gs.DenoiseSharpness
+				clImages.DenoiseAmount = gs.DenoiseAmount
 			}
 			clearCaches()
 			settingsDirty = true


### PR DESCRIPTION
## Summary
- use DenoiseAmount for strength slider and scale 0-100
- update runtime to apply new value directly to CL images

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68aac0c741ec832a89d084a527929dfd