### PR TITLE
Fix notification alpha to match bubble opacity

### DIFF
--- a/notifications.go
+++ b/notifications.go
@@ -26,7 +26,8 @@ func showNotification(msg string) {
 	btn.FontSize = float32(gs.ChatFontSize)
 	btn.Filled = true
 	btn.Outlined = false
-	btn.Color = eui.NewColor(0, 0, 0, 160)
+	alpha := uint8(gs.BubbleOpacity * 255)
+	btn.Color = eui.NewColor(0, 0, 0, alpha)
 	btn.TextColor = eui.NewColor(255, 255, 255, 255)
 	btn.HoverColor = btn.Color
 	btn.ClickColor = btn.Color


### PR DESCRIPTION
## Summary
- adjust in-game notification background alpha to use the BubbleOpacity setting

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aac0885510832a9941cc772cc02b5c