### PR TITLE
Fix yell bubble spikes when no tail

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -326,6 +326,9 @@ func drawSpikes(screen *ebiten.Image, left, top, right, bottom, radius, size flo
 	if bottomGapStart < startX {
 		bottomGapStart = startX
 	}
+	if bottomGapEnd < bottomGapStart {
+		bottomGapEnd = bottomGapStart
+	}
 	if bottomGapEnd > endX {
 		bottomGapEnd = endX
 	}


### PR DESCRIPTION
## Summary
- clamp yell bubble bottom gap parameters when tail is absent so spikes don't span entire screen

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aac97228d0832ab38a4538e5d08418