### PR TITLE
Avoid persisting images that span screen

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -67,6 +67,7 @@ const (
 const poseDead = 32
 const maxInterpPixels = 64
 const maxMobileInterpPixels = 64
+const maxPersistImageSize = 256
 
 // sanity limits for parsed counts to avoid excessive allocations or
 // obviously corrupt packets.
@@ -209,6 +210,9 @@ func pictureOnEdge(p framePicture) bool {
 		return false
 	}
 	w, h := clImages.Size(uint32(p.PictID))
+	if w > maxPersistImageSize || h > maxPersistImageSize {
+		return false
+	}
 	halfW := w / 2
 	halfH := h / 2
 	left := int(p.H) - halfW
@@ -219,8 +223,12 @@ func pictureOnEdge(p framePicture) bool {
 		bottom < -fieldCenterY || top > fieldCenterY {
 		return false
 	}
-	if left <= -fieldCenterX || right >= fieldCenterX ||
-		top <= -fieldCenterY || bottom >= fieldCenterY {
+	edgeLeft := left <= -fieldCenterX
+	edgeRight := right >= fieldCenterX
+	edgeTop := top <= -fieldCenterY
+	edgeBottom := bottom >= fieldCenterY
+	if (edgeLeft || edgeRight || edgeTop || edgeBottom) &&
+		!(edgeLeft && edgeRight) && !(edgeTop && edgeBottom) {
 		return true
 	}
 	return false

--- a/draw_test.go
+++ b/draw_test.go
@@ -40,27 +40,31 @@ func mockCLImages(w, h int) *climg.CLImages {
 }
 
 func TestPictureOnEdge(t *testing.T) {
-	clImages = mockCLImages(10, 10)
-	defer func() { clImages = nil }()
-
 	halfW := 5
 	halfH := 5
 
 	tests := []struct {
 		name string
 		p    framePicture
+		w    int
+		h    int
 		want bool
 	}{
-		{"inside", framePicture{PictID: 1, H: 0, V: 0}, false},
-		{"left edge", framePicture{PictID: 1, H: int16(-fieldCenterX + halfW), V: 0}, true},
-		{"right edge", framePicture{PictID: 1, H: int16(fieldCenterX - halfW), V: 0}, true},
-		{"top edge", framePicture{PictID: 1, H: 0, V: int16(-fieldCenterY + halfH)}, true},
-		{"bottom edge", framePicture{PictID: 1, H: 0, V: int16(fieldCenterY - halfH)}, true},
-		{"outside", framePicture{PictID: 1, H: int16(fieldCenterX + halfW + 1), V: 0}, false},
+		{"inside", framePicture{PictID: 1, H: 0, V: 0}, 10, 10, false},
+		{"left edge", framePicture{PictID: 1, H: int16(-fieldCenterX + halfW), V: 0}, 10, 10, true},
+		{"right edge", framePicture{PictID: 1, H: int16(fieldCenterX - halfW), V: 0}, 10, 10, true},
+		{"top edge", framePicture{PictID: 1, H: 0, V: int16(-fieldCenterY + halfH)}, 10, 10, true},
+		{"bottom edge", framePicture{PictID: 1, H: 0, V: int16(fieldCenterY - halfH)}, 10, 10, true},
+		{"outside", framePicture{PictID: 1, H: int16(fieldCenterX + halfW + 1), V: 0}, 10, 10, false},
+		{"spanning middle", framePicture{PictID: 1, H: 0, V: 0}, gameAreaSizeX * 2, gameAreaSizeY * 2, false},
+		{"wide edge big", framePicture{PictID: 1, H: int16(-fieldCenterX + 150), V: 0}, 300, 10, false},
+		{"tall edge big", framePicture{PictID: 1, H: 0, V: int16(-fieldCenterY + 150)}, 10, 300, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			clImages = mockCLImages(tt.w, tt.h)
+			defer func() { clImages = nil }()
 			if got := pictureOnEdge(tt.p); got != tt.want {
 				t.Fatalf("pictureOnEdge(%s) = %v, want %v", tt.name, got, tt.want)
 			}


### PR DESCRIPTION
## Summary
- refine edge detection to skip persisting images touching opposite screen edges
- add size guard so only images <=256x256 persist
- extend edge tests for oversized sprites

## Testing
- `go test ./...` *(fails: fatal error: GL/glx.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aacc387608832ab2208273bd09bbde