### PR TITLE
Log reasons for early TTS exits

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -26,6 +26,15 @@ func stopAllTTS() {
 
 func speakChatMessage(msg string) {
 	if audioContext == nil || blockTTS || gs.Mute {
+		if audioContext == nil {
+			logError("chat tts: audio context is nil")
+		}
+		if blockTTS {
+			logDebug("chat tts: tts blocked")
+		}
+		if gs.Mute {
+			logDebug("chat tts: client muted")
+		}
 		return
 	}
 	go func(text string) {


### PR DESCRIPTION
## Summary
- log when chat TTS is skipped due to missing audio context, blocked TTS, or mute

## Testing
- `go test ./...` *(fails: command hung, interrupted)*
- `go build ./...` *(fails: command hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68aad72ccf80832abcace6476cc6b915