### PR TITLE
Log TTS errors to error logger

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -34,20 +34,20 @@ func speakChatMessage(msg string) {
 
 		rc, err := ttsspeech.FromText(text, "en")
 		if err != nil {
-			logDebug("chat tts: %v", err)
+			logError("chat tts: %v", err)
 			return
 		}
 		defer rc.Close()
 
 		stream, err := mp3.DecodeWithSampleRate(44100, rc)
 		if err != nil {
-			logDebug("chat tts decode: %v", err)
+			logError("chat tts decode: %v", err)
 			return
 		}
 
 		p, err := audioContext.NewPlayer(stream)
 		if err != nil {
-			logDebug("chat tts player: %v", err)
+			logError("chat tts player: %v", err)
 			return
 		}
 


### PR DESCRIPTION
## Summary
- log TTS creation, decode, and player initialization failures as errors

## Testing
- `go build ./...` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory; Package alsa/gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aad730d29c832ab490cafcb711ba1b