### PR TITLE
Clamp growl bubbles without arrow

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -30,10 +30,11 @@ func init() {
 
 // adjustBubbleRect calculates the on-screen rectangle for a bubble and clamps
 // it to the visible area. The tail tip coordinates remain unchanged and must
-// be handled by the caller if needed.
-func adjustBubbleRect(x, y, width, height, tailHeight, sw, sh int, far bool) (left, top, right, bottom int) {
+// be handled by the caller if needed. Set noTail when the bubble has no arrow
+// pointing to a character so the rectangle is based directly on (x, y).
+func adjustBubbleRect(x, y, width, height, tailHeight, sw, sh int, noTail bool) (left, top, right, bottom int) {
 	bottom = y
-	if !far {
+	if !noTail {
 		bottom = y - tailHeight
 	}
 	left = x - width/2
@@ -139,7 +140,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 	width += 2 * pad
 	height := lineHeight*len(lines) + 2*pad
 
-	left, top, right, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far)
+	left, top, right, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, far || noArrow)
 	baseX := left + width/2
 
 	bgR, bgG, bgB, bgA := bgCol.RGBA()

--- a/bubble_test.go
+++ b/bubble_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "testing"
+
+func TestAdjustBubbleRectNoTail(t *testing.T) {
+	sw, sh := 100, 100
+	width, height := 20, 20
+	tailHeight := 10
+	x, y := 50, 90
+	_, _, _, bottom := adjustBubbleRect(x, y, width, height, tailHeight, sw, sh, true)
+	if bottom != y {
+		t.Fatalf("expected bottom %d, got %d", y, bottom)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid mispositioning by treating bubbles without arrows as tail-less when clamping
- add regression test for adjustBubbleRect without tail

## Testing
- `go test -v -run TestAdjustBubbleRectNoTail ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68aad72430d0832aaa8d7a15883b317c