### PR TITLE
Persist character appearance and profession

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -72,6 +72,18 @@ func parseBackendInfo(data []byte) {
 	playersMu.Unlock()
 	playersDirty = true
 	playersPersistDirty = true
+
+	if playerName != "" && strings.EqualFold(name, playerName) {
+		for i := range characters {
+			if strings.EqualFold(characters[i].Name, name) {
+				if characters[i].Profession != class {
+					characters[i].Profession = class
+					saveCharacters()
+				}
+				break
+			}
+		}
+	}
 }
 
 // parseBackendShare parses "be-sh" messages describing sharing relationships.

--- a/characters_test.go
+++ b/characters_test.go
@@ -32,3 +32,29 @@ func TestScrambleHashRoundTrip(t *testing.T) {
 		t.Fatalf("unscrambleHash returned %q, want %q", dec, hash)
 	}
 }
+
+func TestSaveLoadCharactersAppearanceProfession(t *testing.T) {
+	dir := t.TempDir()
+	orig := dataDirPath
+	dataDirPath = dir
+	defer func() { dataDirPath = orig }()
+
+	characters = []Character{{Name: "Hero", PictID: 123, Colors: []byte{1, 2, 3}, Profession: "fighter"}}
+	saveCharacters()
+
+	characters = nil
+	loadCharacters()
+	if len(characters) != 1 {
+		t.Fatalf("expected 1 character, got %d", len(characters))
+	}
+	c := characters[0]
+	if c.PictID != 123 {
+		t.Fatalf("expected pict 123, got %d", c.PictID)
+	}
+	if c.Profession != "fighter" {
+		t.Fatalf("expected profession fighter, got %q", c.Profession)
+	}
+	if len(c.Colors) != 3 || c.Colors[0] != 1 || c.Colors[1] != 2 || c.Colors[2] != 3 {
+		t.Fatalf("unexpected colors: %v", c.Colors)
+	}
+}

--- a/player.go
+++ b/player.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"sync"
 	"time"
 )
@@ -71,6 +73,26 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte, isNPC boo
 	p.Offline = false
 	playersMu.Unlock()
 	playersDirty = true
+
+	if playerName != "" && strings.EqualFold(name, playerName) {
+		changed := false
+		for i := range characters {
+			if strings.EqualFold(characters[i].Name, name) {
+				if characters[i].PictID != pictID {
+					characters[i].PictID = pictID
+					changed = true
+				}
+				if len(colors) > 0 && !bytes.Equal(characters[i].Colors, colors) {
+					characters[i].Colors = append(characters[i].Colors[:0], colors...)
+					changed = true
+				}
+				if changed {
+					saveCharacters()
+				}
+				break
+			}
+		}
+	}
 }
 
 func getPlayers() []Player {

--- a/ui.go
+++ b/ui.go
@@ -795,6 +795,32 @@ func updateCharacterButtons() {
 	} else {
 		for _, c := range characters {
 			row := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
+
+			avItem, _ := eui.NewImageItem(24, 24)
+			avItem.Margin = 4
+			avItem.Border = 0
+			avItem.Filled = false
+			if c.PictID != 0 {
+				if m := loadMobileFrame(c.PictID, 0, c.Colors); m != nil {
+					avItem.Image = m
+				} else if im := loadImage(c.PictID); im != nil {
+					avItem.Image = im
+				}
+			}
+			row.AddItem(avItem)
+
+			profItem, _ := eui.NewImageItem(24, 24)
+			profItem.Margin = 4
+			profItem.Border = 0
+			profItem.Filled = false
+			if pid := professionPictID(c.Profession); pid != 0 {
+				if img := loadImage(pid); img != nil {
+					profItem.Image = img
+					profItem.ImageName = "prof:cl:" + fmt.Sprint(pid)
+				}
+			}
+			row.AddItem(profItem)
+
 			radio, radioEvents := eui.NewRadio()
 			radio.Text = c.Name
 			radio.RadioGroup = "characters"


### PR DESCRIPTION
## Summary
- store character appearance (sprite+colors) and profession in characters.json
- update player info hooks to persist appearance and class when seen
- show avatar and profession icons alongside saved characters on login screen

## Testing
- `go test -run TestSaveLoadCharactersAppearanceProfession -count=1` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aadbf26f08832a80ef428b48223c9b