### PR TITLE
Reorder font fallback to put symbols and emoji last

### DIFF
--- a/font.go
+++ b/font.go
@@ -71,14 +71,14 @@ func initFont() {
 		log.Fatalf("failed to parse font: %v", err)
 	}
 
-	eui.SetFontSources(emoji, symbols, symbols2, regular)
+	eui.SetFontSources(regular, symbols, symbols2, emoji)
 
 	makeFace := func(src *text.GoTextFaceSource, size float64) text.Face {
 		faces := []text.Face{
-			&text.GoTextFace{Source: emoji, Size: size},
+			&text.GoTextFace{Source: src, Size: size},
 			&text.GoTextFace{Source: symbols, Size: size},
 			&text.GoTextFace{Source: symbols2, Size: size},
-			&text.GoTextFace{Source: src, Size: size},
+			&text.GoTextFace{Source: emoji, Size: size},
 		}
 		mf, err := text.NewMultiFace(faces...)
 		if err != nil {


### PR DESCRIPTION
## Summary
- adjust font source setup to make primary fonts precede symbol and emoji fallbacks

## Testing
- `go build ./...`
- `go test ./...` *(fails: GLFW X11 display environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab71a1ccf4832a81daf55fd1583a62