### PR TITLE
Show default avatar in login window

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -816,12 +816,25 @@ func updateCharacterButtons() {
 			avItem.Margin = 4
 			avItem.Border = 0
 			avItem.Filled = false
+			var img *ebiten.Image
 			if c.PictID != 0 {
 				if m := loadMobileFrame(c.PictID, 0, c.Colors); m != nil {
-					avItem.Image = m
+					img = m
 				} else if im := loadImage(c.PictID); im != nil {
-					avItem.Image = im
+					img = im
 				}
+			}
+			if img == nil {
+				if gid := defaultMobilePictID(genderUnknown); gid != 0 {
+					if m := loadMobileFrame(gid, 0, nil); m != nil {
+						img = m
+					} else if im := loadImage(gid); im != nil {
+						img = im
+					}
+				}
+			}
+			if img != nil {
+				avItem.Image = img
 			}
 			row.AddItem(avItem)
 


### PR DESCRIPTION
## Summary
- show generic avatar on login when character has no avatar

## Testing
- `go test ./...` *(fails: GLFW missing DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7bacc020832abbec63edc2aa5343