### PR TITLE
Add spacing between login action buttons

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1224,6 +1224,11 @@ func makeLoginWindow() {
 	}
 	loginFlow.AddItem(openBtn)
 
+	spacer, _ := eui.NewText()
+	spacer.Text = ""
+	spacer.Size = eui.Point{X: 1, Y: 8}
+	loginFlow.AddItem(spacer)
+
 	demoBtn, demoEvents := eui.NewButton()
 	demoBtn.Text = "Try the demo"
 	demoBtn.Size = eui.Point{X: charWinWidth, Y: 24}
@@ -1245,6 +1250,11 @@ func makeLoginWindow() {
 		}
 	}
 	loginFlow.AddItem(demoBtn)
+
+	spacer, _ = eui.NewText()
+	spacer.Text = ""
+	spacer.Size = eui.Point{X: 1, Y: 8}
+	loginFlow.AddItem(spacer)
 
 	quitBttn, quitEvn := eui.NewButton()
 	quitBttn.Text = "Quit"


### PR DESCRIPTION
## Summary
- add vertical spacers between movie, demo, and quit buttons in the login window for better layout

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7bdc58e4832a8b392f4902a95148