### PR TITLE
Add hotkeys window with recording and persistence

### DIFF
--- a/game.go
+++ b/game.go
@@ -539,6 +539,8 @@ func (g *Game) Update() error {
 	eui.Update() //We really need this to return eaten clicks
 	updateNotifications()
 	updateThinkMessages()
+	updateHotkeyRecording()
+	checkHotkeys()
 
 	once.Do(func() {
 		initGame()

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+	"gothoom/eui"
+)
+
+const hotkeysFile = "global-hotkeys.json"
+
+type Hotkey struct {
+	Combo   string `json:"combo"`
+	Command string `json:"command"`
+}
+
+var (
+	hotkeys         []Hotkey
+	hotkeysWin      *eui.WindowData
+	hotkeysList     *eui.ItemData
+	hotkeyEditWin   *eui.WindowData
+	hotkeyComboText *eui.ItemData
+	hotkeyCmdInput  *eui.ItemData
+	editingHotkey   int = -1
+
+	recording     bool
+	recordStart   time.Time
+	recordTarget  *eui.ItemData
+	recordedCombo string
+)
+
+func loadHotkeys() {
+	path := filepath.Join(dataDirPath, hotkeysFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(data, &hotkeys)
+}
+
+func saveHotkeys() {
+	path := filepath.Join(dataDirPath, hotkeysFile)
+	_ = os.MkdirAll(dataDirPath, 0o755)
+	data, err := json.MarshalIndent(hotkeys, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
+}
+
+func makeHotkeysWindow() {
+	if hotkeysWin != nil {
+		return
+	}
+	hotkeysWin = eui.NewWindow()
+	hotkeysWin.Title = "Hotkeys"
+	hotkeysWin.Size = eui.Point{X: 260, Y: 300}
+	hotkeysWin.Closable = true
+	hotkeysWin.Movable = true
+	hotkeysWin.Resizable = true
+	hotkeysWin.NoScroll = true
+	hotkeysWin.SetZone(eui.HZoneCenter, eui.VZoneMiddleTop)
+
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	hotkeysWin.AddItem(flow)
+
+	btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
+	addBtn, addEvents := eui.NewButton()
+	addBtn.Text = "+"
+	addBtn.Size = eui.Point{X: 20, Y: 20}
+	addBtn.FontSize = 14
+	addEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			openHotkeyEditor(-1)
+		}
+	}
+	btnRow.AddItem(addBtn)
+	flow.AddItem(btnRow)
+
+	hotkeysList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
+	flow.AddItem(hotkeysList)
+
+	hotkeysWin.AddWindow(false)
+	refreshHotkeysList()
+}
+
+func refreshHotkeysList() {
+	if hotkeysList == nil {
+		return
+	}
+	hotkeysList.Contents = hotkeysList.Contents[:0]
+	for i, hk := range hotkeys {
+		idx := i
+		btn, events := eui.NewButton()
+		btn.Text = hk.Combo + " -> " + hk.Command
+		btn.Size = eui.Point{X: 220, Y: 20}
+		btn.FontSize = 10
+		events.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventClick {
+				openHotkeyEditor(idx)
+			}
+		}
+		hotkeysList.AddItem(btn)
+	}
+	hotkeysList.Dirty = true
+	if hotkeysWin != nil {
+		hotkeysWin.Refresh()
+	}
+}
+
+func openHotkeyEditor(idx int) {
+	if hotkeyEditWin != nil {
+		return
+	}
+	editingHotkey = idx
+	hotkeyEditWin = eui.NewWindow()
+	hotkeyEditWin.Title = "Hotkey"
+	hotkeyEditWin.Size = eui.Point{X: 260, Y: 160}
+	hotkeyEditWin.Closable = true
+	hotkeyEditWin.Movable = true
+	hotkeyEditWin.Resizable = false
+	hotkeyEditWin.NoScroll = true
+	hotkeyEditWin.SetZone(eui.HZoneCenter, eui.VZoneMiddleTop)
+
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	hotkeyEditWin.AddItem(flow)
+
+	row := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
+	label, _ := eui.NewText()
+	label.Text = "Keys:"
+	label.Size = eui.Point{X: 40, Y: 20}
+	label.FontSize = 12
+	row.AddItem(label)
+	hotkeyComboText, _ = eui.NewText()
+	hotkeyComboText.Text = ""
+	hotkeyComboText.Size = eui.Point{X: 120, Y: 20}
+	hotkeyComboText.FontSize = 12
+	row.AddItem(hotkeyComboText)
+	recordBtn, recordEvents := eui.NewButton()
+	recordBtn.Text = "Record"
+	recordBtn.Size = eui.Point{X: 60, Y: 20}
+	recordBtn.FontSize = 12
+	recordEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			startRecording(hotkeyComboText)
+		}
+	}
+	row.AddItem(recordBtn)
+	flow.AddItem(row)
+
+	cmdLabel, _ := eui.NewText()
+	cmdLabel.Text = "Command:"
+	cmdLabel.FontSize = 12
+	flow.AddItem(cmdLabel)
+
+	hotkeyCmdInput, _ = eui.NewInput()
+	hotkeyCmdInput.Size = eui.Point{X: 220, Y: 20}
+	hotkeyCmdInput.FontSize = 12
+	hotkeyCmdInput.Scrollable = true
+	flow.AddItem(hotkeyCmdInput)
+
+	btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
+	okBtn, okEvents := eui.NewButton()
+	okBtn.Text = "OK"
+	okBtn.Size = eui.Point{X: 80, Y: 20}
+	okBtn.FontSize = 12
+	okEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			finishHotkeyEdit(true)
+		}
+	}
+	btnRow.AddItem(okBtn)
+
+	cancelBtn, cancelEvents := eui.NewButton()
+	cancelBtn.Text = "Cancel"
+	cancelBtn.Size = eui.Point{X: 80, Y: 20}
+	cancelBtn.FontSize = 12
+	cancelEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			finishHotkeyEdit(false)
+		}
+	}
+	btnRow.AddItem(cancelBtn)
+
+	flow.AddItem(btnRow)
+
+	if idx >= 0 && idx < len(hotkeys) {
+		hotkeyComboText.Text = hotkeys[idx].Combo
+		hotkeyCmdInput.Text = hotkeys[idx].Command
+	}
+
+	hotkeyEditWin.AddWindow(true)
+}
+
+func finishHotkeyEdit(save bool) {
+	if save {
+		combo := hotkeyComboText.Text
+		cmd := hotkeyCmdInput.Text
+		if combo != "" && cmd != "" {
+			hk := Hotkey{Combo: combo, Command: cmd}
+			if editingHotkey >= 0 && editingHotkey < len(hotkeys) {
+				hotkeys[editingHotkey] = hk
+			} else {
+				hotkeys = append(hotkeys, hk)
+			}
+			saveHotkeys()
+			refreshHotkeysList()
+		}
+	}
+	if hotkeyEditWin != nil {
+		hotkeyEditWin.Close()
+		hotkeyEditWin = nil
+	}
+}
+
+func startRecording(target *eui.ItemData) {
+	recording = true
+	recordStart = time.Now()
+	recordTarget = target
+	recordedCombo = ""
+	if recordTarget != nil {
+		recordTarget.Text = "Recording..."
+		recordTarget.Dirty = true
+	}
+}
+
+func finishRecording() {
+	recording = false
+	if recordTarget != nil {
+		if recordedCombo == "" {
+			recordTarget.Text = ""
+		} else {
+			recordTarget.Text = recordedCombo
+		}
+		recordTarget.Dirty = true
+	}
+}
+
+func detectCombo() string {
+	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight) {
+		return comboFromMouse(ebiten.MouseButtonRight)
+	}
+	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonMiddle) {
+		return comboFromMouse(ebiten.MouseButtonMiddle)
+	}
+	for _, k := range inpututil.AppendJustPressedKeys(nil) {
+		if isModifier(k) {
+			continue
+		}
+		return comboFromKey(k)
+	}
+	return ""
+}
+
+func comboFromKey(k ebiten.Key) string {
+	mods := currentMods()
+	mods = append(mods, k.String())
+	return strings.Join(mods, "-")
+}
+
+func comboFromMouse(b ebiten.MouseButton) string {
+	mods := currentMods()
+	name := mouseButtonName(b)
+	mods = append(mods, name)
+	return strings.Join(mods, "-")
+}
+
+func currentMods() []string {
+	mods := []string{}
+	if ebiten.IsKeyPressed(ebiten.KeyControl) || ebiten.IsKeyPressed(ebiten.KeyControlLeft) || ebiten.IsKeyPressed(ebiten.KeyControlRight) {
+		mods = append(mods, "Ctrl")
+	}
+	if ebiten.IsKeyPressed(ebiten.KeyAlt) || ebiten.IsKeyPressed(ebiten.KeyAltLeft) || ebiten.IsKeyPressed(ebiten.KeyAltRight) {
+		mods = append(mods, "Alt")
+	}
+	if ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight) {
+		mods = append(mods, "Shift")
+	}
+	return mods
+}
+
+func mouseButtonName(b ebiten.MouseButton) string {
+	switch b {
+	case ebiten.MouseButtonRight:
+		return "RightClick"
+	case ebiten.MouseButtonMiddle:
+		return "MiddleClick"
+	default:
+		return "Mouse" + b.String()
+	}
+}
+
+func isModifier(k ebiten.Key) bool {
+	switch k {
+	case ebiten.KeyShift, ebiten.KeyShiftLeft, ebiten.KeyShiftRight,
+		ebiten.KeyControl, ebiten.KeyControlLeft, ebiten.KeyControlRight,
+		ebiten.KeyAlt, ebiten.KeyAltLeft, ebiten.KeyAltRight:
+		return true
+	}
+	return false
+}
+
+func updateHotkeyRecording() {
+	if !recording {
+		return
+	}
+	if time.Since(recordStart) > 5*time.Second {
+		finishRecording()
+		return
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
+		finishRecording()
+		return
+	}
+	if c := detectCombo(); c != "" {
+		recordedCombo = c
+		finishRecording()
+	}
+}
+
+func checkHotkeys() {
+	if recording || inputActive {
+		return
+	}
+	if combo := detectCombo(); combo != "" {
+		for _, hk := range hotkeys {
+			if hk.Combo == combo {
+				pendingCommand = hk.Command
+				break
+			}
+		}
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -143,6 +143,8 @@ func initUI() {
 		logError("check data files: %v", err)
 	}
 
+	loadHotkeys()
+
 	makeGameWindow()
 	makeDownloadsWindow()
 	makeLoginWindow()
@@ -158,6 +160,7 @@ func initUI() {
 	makeWindowsWindow()
 	makeInventoryWindow()
 	makePlayersWindow()
+	makeHotkeysWindow()
 	makeToolbar()
 
 	// Load any persisted players data (e.g., from prior sessions) so
@@ -214,6 +217,17 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 		}
 	}
 	row1.AddItem(helpBtn)
+
+	hotBtn, hotEvents := eui.NewButton()
+	hotBtn.Text = "Hotkeys"
+	hotBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	hotBtn.FontSize = toolFontSize
+	hotEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			hotkeysWin.ToggleNear(ev.Item)
+		}
+	}
+	row1.AddItem(hotBtn)
 
 	shotBtn, shotEvents := eui.NewButton()
 	shotBtn.Text = "Snapshot"


### PR DESCRIPTION
## Summary
- Add Hotkeys toolbar button and window with + to add hotkey entries
- Record key/mouse combinations and associate commands
- Persist hotkeys to `data/global-hotkeys.json` and trigger commands on press

## Testing
- `go test ./...` *(fails: Xrandr, ALSA, gtk+-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ae965ec832aaacf4703591741f5