### PR TITLE
Fix hotkey window layout for add button

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -82,9 +82,11 @@ func makeHotkeysWindow() {
 		}
 	}
 	btnRow.AddItem(addBtn)
+	btnRow.Size = eui.Point{X: hotkeysWin.Size.X, Y: addBtn.Size.Y}
 	flow.AddItem(btnRow)
 
 	hotkeysList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
+	hotkeysList.Size = eui.Point{X: hotkeysWin.Size.X, Y: hotkeysWin.Size.Y - btnRow.Size.Y}
 	flow.AddItem(hotkeysList)
 
 	hotkeysWin.AddWindow(false)


### PR DESCRIPTION
## Summary
- Ensure the hotkey window's button row has a fixed height
- Size the hotkeys list to account for the button row

## Testing
- `go build ./...`
- `go run .` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab86cd68f4832ab4c8f58ec8bf8fde