### PR TITLE
Clear hotkey editor window on close

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -123,6 +123,7 @@ func openHotkeyEditor(idx int) {
 	}
 	editingHotkey = idx
 	hotkeyEditWin = eui.NewWindow()
+	hotkeyEditWin.OnClose = func() { hotkeyEditWin = nil }
 	hotkeyEditWin.Title = "Hotkey"
 	hotkeyEditWin.Size = eui.Point{X: 260, Y: 160}
 	hotkeyEditWin.Closable = true

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+// Test that closing the hotkey editor clears the reference and allows reopening.
+func TestOpenHotkeyEditorReopenAfterClose(t *testing.T) {
+	hotkeyEditWin = nil
+
+	// Open and close with OK
+	openHotkeyEditor(-1)
+	if hotkeyEditWin == nil {
+		t.Fatalf("editor not opened")
+	}
+	finishHotkeyEdit(true)
+	if hotkeyEditWin != nil {
+		t.Fatalf("editor not cleared after OK")
+	}
+
+	// Reopen and close with Cancel
+	openHotkeyEditor(-1)
+	if hotkeyEditWin == nil {
+		t.Fatalf("editor not reopened after OK")
+	}
+	finishHotkeyEdit(false)
+	if hotkeyEditWin != nil {
+		t.Fatalf("editor not cleared after Cancel")
+	}
+
+	// Reopen and close via 'X'
+	openHotkeyEditor(-1)
+	if hotkeyEditWin == nil {
+		t.Fatalf("editor not reopened after Cancel")
+	}
+	hotkeyEditWin.Close()
+	if hotkeyEditWin != nil {
+		t.Fatalf("editor not cleared after Close")
+	}
+
+	// Final reopen to ensure no leftovers
+	openHotkeyEditor(-1)
+	if hotkeyEditWin == nil {
+		t.Fatalf("editor not reopened after Close")
+	}
+	hotkeyEditWin.Close()
+}


### PR DESCRIPTION
## Summary
- ensure hotkey editor clears its window reference when closed
- add tests verifying the editor can reopen after OK, Cancel, or direct window close

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68ab89173274832a998287a8c52dda01