### PR TITLE
Ensure hotkey editor window opens

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -199,6 +199,7 @@ func openHotkeyEditor(idx int) {
 	}
 
 	hotkeyEditWin.AddWindow(true)
+	hotkeyEditWin.MarkOpen()
 }
 
 func finishHotkeyEdit(save bool) {


### PR DESCRIPTION
## Summary
- Mark hotkey editor window as open after adding it so the UI displays when '+' is pressed

## Testing
- `time go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab89061ddc832a861fd8dd27d4e105