### PR TITLE
Fix hotkey editor command input registration

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -163,7 +163,8 @@ func openHotkeyEditor(idx int) {
 	cmdLabel.FontSize = 12
 	flow.AddItem(cmdLabel)
 
-	hotkeyCmdInput, cmdEvents := eui.NewInput()
+	var cmdEvents *eui.EventHandler
+	hotkeyCmdInput, cmdEvents = eui.NewInput()
 	hotkeyCmdInput.Size = eui.Point{X: 220, Y: 20}
 	hotkeyCmdInput.FontSize = 12
 	hotkeyCmdInput.Scrollable = true

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -43,3 +43,28 @@ func TestOpenHotkeyEditorReopenAfterClose(t *testing.T) {
 	}
 	hotkeyEditWin.Close()
 }
+
+// Test that entering a command in the hotkey editor saves correctly.
+func TestHotkeyCommandInput(t *testing.T) {
+	hotkeys = nil
+	dir := t.TempDir()
+	origDir := dataDirPath
+	dataDirPath = dir
+	defer func() { dataDirPath = origDir }()
+
+	openHotkeyEditor(-1)
+	if hotkeyCmdInput == nil {
+		t.Fatalf("command input not initialized")
+	}
+
+	hotkeyComboText.Text = "Ctrl-A"
+	hotkeyCmdInput.Text = "say hi"
+	finishHotkeyEdit(true)
+
+	if len(hotkeys) != 1 {
+		t.Fatalf("hotkey not saved")
+	}
+	if hotkeys[0].Combo != "Ctrl-A" || hotkeys[0].Command != "say hi" {
+		t.Fatalf("unexpected hotkey data: %+v", hotkeys[0])
+	}
+}


### PR DESCRIPTION
## Summary
- prevent shadowing of global command input in hotkey editor
- add regression test verifying hotkey command is saved

## Testing
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9055e590832a8a9a69dda86375b7