### PR TITLE
Refresh hotkeys list after loading from disk

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -43,6 +43,7 @@ func loadHotkeys() {
 		return
 	}
 	_ = json.Unmarshal(data, &hotkeys)
+	refreshHotkeysList()
 }
 
 func saveHotkeys() {


### PR DESCRIPTION
## Summary
- refresh hotkeys list whenever global-hotkeys.json is loaded so newly created entries display
- test that loadHotkeys repopulates the hotkeys window

## Testing
- `go test -tags ebitenginepurego -run TestLoadHotkeysShowsEntriesInWindow -count=1 -v` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9533118c832a8eeddc77c76cc65b