### PR TITLE
Fix hotkey editor text input click area

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -167,6 +167,7 @@ func openHotkeyEditor(idx int) {
 
 	cmdLabel, _ := eui.NewText()
 	cmdLabel.Text = "Command:"
+	cmdLabel.Size = eui.Point{X: 220, Y: 20}
 	cmdLabel.FontSize = 12
 	flow.AddItem(cmdLabel)
 
@@ -186,6 +187,7 @@ func openHotkeyEditor(idx int) {
 
 	textLabel, _ := eui.NewText()
 	textLabel.Text = "Text:"
+	textLabel.Size = eui.Point{X: 220, Y: 20}
 	textLabel.FontSize = 12
 	flow.AddItem(textLabel)
 


### PR DESCRIPTION
## Summary
- specify sizes for command and text labels in hotkey editor so inputs are clickable

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab997370b8832ab78ac86c84af6c00