### PR TITLE
Support multiple hotkey commands and in-app deletion

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -59,19 +59,19 @@ func TestHotkeyCommandInput(t *testing.T) {
 	defer func() { dataDirPath = origDir }()
 
 	openHotkeyEditor(-1)
-	if hotkeyCmdInput == nil {
+	if len(hotkeyCmdInputs) == 0 {
 		t.Fatalf("command input not initialized")
 	}
 
 	hotkeyComboText.Text = "Ctrl-A"
-	hotkeyCmdInput.Text = "say"
-	hotkeyTextInput.Text = "hi"
+	hotkeyCmdInputs[0].Text = "say"
+	hotkeyTextInputs[0].Text = "hi"
 	finishHotkeyEdit(true)
 
 	if len(hotkeys) != 1 {
 		t.Fatalf("hotkey not saved")
 	}
-	if hotkeys[0].Combo != "Ctrl-A" || hotkeys[0].Command != "say" || hotkeys[0].Text != "hi" {
+	if hotkeys[0].Combo != "Ctrl-A" || len(hotkeys[0].Commands) != 1 || hotkeys[0].Commands[0].Command != "say" || hotkeys[0].Commands[0].Text != "hi" {
 		t.Fatalf("unexpected hotkey data: %+v", hotkeys[0])
 	}
 }
@@ -97,7 +97,7 @@ func TestLoadHotkeysShowsEntriesInWindow(t *testing.T) {
 	}
 
 	// Write a hotkey entry to disk and load it.
-	hk := []Hotkey{{Combo: "Ctrl-B", Command: "say bye"}}
+	hk := []Hotkey{{Combo: "Ctrl-B", Commands: []HotkeyCommand{{Command: "say", Text: "bye"}}}}
 	data, err := json.Marshal(hk)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -123,11 +123,11 @@ func TestHotkeyEditorWrapsAndResizes(t *testing.T) {
 	}
 	base := hotkeyEditWin.Size.Y
 	long := "this is a very long command line that should wrap across multiple lines for testing"
-	hotkeyCmdInput.Text = long
-	hotkeyTextInput.Text = long
+	hotkeyCmdInputs[0].Text = long
+	hotkeyTextInputs[0].Text = long
 	wrapHotkeyInputs()
-	if !strings.Contains(hotkeyCmdInput.Text, "\n") || hotkeyCmdInput.Size.Y <= 20 {
-		t.Fatalf("command input did not wrap or grow: %q size %v", hotkeyCmdInput.Text, hotkeyCmdInput.Size.Y)
+	if !strings.Contains(hotkeyCmdInputs[0].Text, "\n") || hotkeyCmdInputs[0].Size.Y <= 20 {
+		t.Fatalf("command input did not wrap or grow: %q size %v", hotkeyCmdInputs[0].Text, hotkeyCmdInputs[0].Size.Y)
 	}
 	if hotkeyEditWin.Size.Y <= base {
 		t.Fatalf("window did not resize: %v <= %v", hotkeyEditWin.Size.Y, base)

--- a/network.go
+++ b/network.go
@@ -132,6 +132,7 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool) 
 		flags = kPIMDownField
 	}
 
+	nextCommand()
 	// Before reading the pending command, give background queues
 	// a chance to schedule maintenance commands.
 	if pendingCommand == "" {
@@ -155,6 +156,7 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool) 
 		// Record last-command frame for who throttling.
 		whoLastCommandFrame = ackFrame
 		pendingCommand = ""
+		nextCommand()
 	}
 	commandNum++
 	logDebug("player input ack=%d resend=%d cmd=%d mouse=%d,%d flags=%#x", ackFrame, resendFrame, commandNum-1, mouseX, mouseY, flags)

--- a/util.go
+++ b/util.go
@@ -134,8 +134,22 @@ var numFrames int
 var lostFrames int
 var commandNum uint32 = 1
 var pendingCommand string
+var commandQueue []string
 var playerName string
 var playerIndex uint8 = 0xff
+
+func enqueueCommand(cmd string) {
+	if cmd != "" {
+		commandQueue = append(commandQueue, cmd)
+	}
+}
+
+func nextCommand() {
+	if pendingCommand == "" && len(commandQueue) > 0 {
+		pendingCommand = commandQueue[0]
+		commandQueue = commandQueue[1:]
+	}
+}
 
 // updateFrameCounters tracks frame statistics and detects dropped frames.
 // It returns the number of frames missing between the previous and


### PR DESCRIPTION
## Summary
- Allow each hotkey to trigger multiple commands
- Add removal buttons with confirmation to hotkey list
- Queue and send chained commands sequentially

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aba62896e4832a96fb371878ab9c21