### PR TITLE
Add audio toggles and spacing to mixer window

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -70,6 +70,8 @@ var gsdef settings = settings{
 	MasterVolume:         0.25,
 	Volume:               1.0,
 	MusicVolume:          1.0,
+	Music:                true,
+	GameSound:            true,
 	GameScale:            2,
 	BarPlacement:         BarPlacementBottom,
 	MaxNightLevel:        100,
@@ -145,6 +147,8 @@ type settings struct {
 	MasterVolume         float64
 	Volume               float64
 	MusicVolume          float64
+	Music                bool
+	GameSound            bool
 	Mute                 bool
 	GameScale            float64
 	BarPlacement         BarPlacement

--- a/sound.go
+++ b/sound.go
@@ -57,11 +57,11 @@ func stopAllAudioPlayers() {
 // Each ID is loaded, mixed with simple clipping and then played at the current
 // global volume. The function returns immediately after scheduling playback.
 func playSound(ids []uint16) {
-	if len(ids) == 0 || gs.Mute {
+	if len(ids) == 0 || gs.Mute || !gs.GameSound {
 		return
 	}
 	go func(ids []uint16) {
-		if gs.Mute {
+		if gs.Mute || !gs.GameSound {
 			return
 		}
 		//logDebug("playSound %v called", ids)
@@ -226,6 +226,15 @@ func updateSoundVolume() {
 	gameVol := gs.MasterVolume * gs.Volume
 	ttsVol := gs.MasterVolume * gs.ChatTTSVolume
 	musicVol := gs.MasterVolume * gs.MusicVolume
+	if !gs.GameSound {
+		gameVol = 0
+	}
+	if !gs.ChatTTS {
+		ttsVol = 0
+	}
+	if !gs.Music {
+		musicVol = 0
+	}
 	if gs.Mute {
 		gameVol = 0
 		ttsVol = 0

--- a/tune.go
+++ b/tune.go
@@ -152,7 +152,7 @@ func playClanLordTune(tune string) error {
 	if audioContext == nil {
 		return fmt.Errorf("audio disabled")
 	}
-	if gs.Mute || gs.MasterVolume <= 0 || gs.MusicVolume <= 0 {
+	if gs.Mute || !gs.Music || gs.MasterVolume <= 0 || gs.MusicVolume <= 0 {
 		return fmt.Errorf("music muted")
 	}
 
@@ -725,7 +725,7 @@ func handleMusicParams(mp MusicParams) {
 	}
 	// Ignore play requests while muted, matching classic behavior when sound
 	// is off. Still handled /stop above regardless of mute state.
-	if gs.Mute || gs.MasterVolume <= 0 || gs.MusicVolume <= 0 {
+	if gs.Mute || !gs.Music || gs.MasterVolume <= 0 || gs.MusicVolume <= 0 {
 		return
 	}
 	// Validate basics


### PR DESCRIPTION
## Summary
- Expand settings with booleans for music and game sound
- Space out mixer sliders and add per-channel enable/disable checkboxes with a mute button
- Respect audio toggles when playing sounds or music

## Testing
- `go build ./...` *(fails: Xrandr.h: No such file or directory; missing alsa and gtk+-3.0)*
- `go test ./...` *(fails: Package gtk+-3.0, alsa, and Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abae4ebbe4832aad25bcb39dea2d5b