### PR TITLE
Close chat TTS stream after playback

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"sync"
 	"time"
 
@@ -52,6 +53,9 @@ func speakChatMessage(msg string) {
 		if err != nil {
 			logError("chat tts decode: %v", err)
 			return
+		}
+		if closer, ok := any(stream).(io.Closer); ok {
+			defer closer.Close()
 		}
 
 		p, err := audioContext.NewPlayer(stream)


### PR DESCRIPTION
## Summary
- Ensure decoded TTS MP3 streams are closed when they implement `io.Closer`

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abb005e4e8832a8093f8d13efd51ca