### PR TITLE
Replace chat TTS with htgo-tts

### DIFF
--- a/ATTRIBUTE.md
+++ b/ATTRIBUTE.md
@@ -6,7 +6,7 @@ This project uses the following third-party Go libraries.
 | --- | --- | --- | --- |
 | Ebitengine | https://github.com/hajimehoshi/ebiten | Apache-2.0 | Hajime Hoshi |
 | go-humanize | https://github.com/dustin/go-humanize | MIT | Dustin Sallings |
-| go-tts | https://github.com/go-tts/tts | None | go-tts project |
+| htgo-tts | https://github.com/hegedustibor/htgo-tts | MIT | Tibor Hegedus |
 | gopacket | https://github.com/google/gopacket | BSD-3-Clause | Google, Inc.; Andreas Krennmair |
 | durafmt | https://github.com/hako/durafmt | MIT | Wesley Hill |
 | rich-go | https://github.com/hugolgst/rich-go | MIT | Hugo Lageneste |

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require github.com/hajimehoshi/ebiten/v2 v2.8.8
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-tts/tts v1.0.1
 	github.com/google/gopacket v1.1.19
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
+	github.com/hegedustibor/htgo-tts v0.0.0-20240912200108-467b3e535435
 	github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/remeh/sizedwaitgroup v1.0.0
@@ -31,6 +31,7 @@ require (
 	github.com/go-text/typesetting v0.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
+	github.com/hajimehoshi/oto/v2 v2.3.1 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	golang.org/x/image v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/go-text/typesetting v0.3.0 h1:OWCgYpp8njoxSRpwrdd1bQOxdjOXDj9Rqart9ML
 github.com/go-text/typesetting v0.3.0/go.mod h1:qjZLkhRgOEYMhU9eHBr3AR4sfnGJvOXNLt8yRAySFuY=
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
-github.com/go-tts/tts v1.0.1 h1:bYam2djAv/+blgerwyLXl8xxrnUcbZN+JSURTIIvONE=
-github.com/go-tts/tts v1.0.1/go.mod h1:A+ZXJVma+D2lvfrF4ARtI+Fta94S74/xnEy1JiSUry0=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
@@ -27,9 +25,12 @@ github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrx
 github.com/hajimehoshi/ebiten/v2 v2.8.8/go.mod h1:durJ05+OYnio9b8q0sEtOgaNeBEQG7Yr7lRviAciYbs=
 github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=
 github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRSVop0eemFmo=
+github.com/hajimehoshi/oto/v2 v2.3.1 h1:qrLKpNus2UfD674oxckKjNJmesp9hMh7u7QCrStB3Rc=
 github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
 github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
+github.com/hegedustibor/htgo-tts v0.0.0-20240912200108-467b3e535435 h1:XrrY229aKisEKIAoYynbQ7C2VEwdapRVLepQ6RM2+lk=
+github.com/hegedustibor/htgo-tts v0.0.0-20240912200108-467b3e535435/go.mod h1:VBNcur+xWvaQIWCaLH8w7j68zPeqQwVfjREn2S7kYbY=
 github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2 h1:9qOViOQGFIP5ar+2NorfAIsfuADEKXtklySC0zNnYf4=
 github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2/go.mod h1:nGaW7CGfNZnhtiFxMpc4OZdqIexGXjUlBnlmpZmjEKA=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=


### PR DESCRIPTION
## Summary
- switch chat text-to-speech to htgo-tts library
- document htgo-tts in third-party attributions

## Testing
- `go test ./...` *(fails: plugins/healer.go: package pluginapi is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_68abb60737f4832aa2aec45a2b2ef2fa