### PR TITLE
Update plugin API stubs and example hotkey plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ func Init() {
 Currently exposed symbols:
 
 - `pluginapi.Logf(format, ...any)` – write to the client log
-- `pluginapi.AddHotkey(combo, command)` – register a global hotkey
+- `pluginapi.AddHotkey(combo, command)` – bind a hotkey to a slash command
+- `pluginapi.AddHotkeyFunc(combo, funcName)` – bind a hotkey to a plugin function
+- `pluginapi.RegisterCommand(name, func(args string))` – handle a local slash command
+- `pluginapi.RegisterFunc(name, func())` – register a callable plugin function
+- `pluginapi.RunCommand(cmd)` – echo and send a command immediately
+- `pluginapi.EnqueueCommand(cmd)` – queue a command silently for the next tick
 - `pluginapi.ClientVersion` – current client version (read/write)
 
 All plugin code runs in the same process but is sandboxed to this approved list of

--- a/embedded_plugins/example_ponder.go
+++ b/embedded_plugins/example_ponder.go
@@ -5,14 +5,20 @@ import (
 	"strings"
 )
 
-// Init registers a simple hotkey example. Pressing the '1' key
-// (aka Ebiten's "Digit1") will run an exported plugin function.
+// Wave demonstrates an exported plugin function that sends a command.
+func Wave() {
+	pluginapi.RunCommand("/ponder hello world")
+}
+
+// Init sets up example hotkeys and commands. Pressing the '1' key
+// (aka Ebiten's "Digit1") will call the Wave function above.
 func Init() {
-	// Example 1: Bind a hotkey directly to a plugin function
-	// (this uses the special command format "plugin:<name>" under the hood).
+	// Bind a hotkey to the Wave function. This uses the special
+	// "plugin:<name>" command format under the hood.
+	pluginapi.RegisterFunc("wave", Wave)
 	pluginapi.AddHotkeyFunc("Digit1", "wave")
 
-	// Example 2: Slash command `/example` handled locally
+	// Slash command `/example` handled locally
 	pluginapi.RegisterCommand("example", func(args string) {
 		if args == "" {
 			args = "hello world"
@@ -26,10 +32,6 @@ func Init() {
 		}
 	})
 
-	// Example 3: Register a function callable from hotkeys
-	pluginapi.RegisterFunc("wave", func() {
-		pluginapi.RunCommand("/ponder hello world")
-	})
 	// Another binding example:
-	// pluginapi.AddHotkeyFunc("Digit2", "wave")
+	// pluginapi.AddHotkey("Digit2", "/ponder hello world")
 }

--- a/pluginapi/pluginapi.go
+++ b/pluginapi/pluginapi.go
@@ -13,8 +13,20 @@ var ClientVersion int
 // Logf is a no-op printf-style logger for editor/linter happiness.
 func Logf(format string, args ...interface{}) {}
 
-// AddHotkey is a no-op stub matching the runtime API signature.
+// AddHotkey binds a key combo to a slash command.
 func AddHotkey(combo, command string) {}
 
+// AddHotkeyFunc binds a key combo to a registered plugin function.
+func AddHotkeyFunc(combo, funcName string) {}
+
+// RegisterCommand handles a local slash command like "/example".
 func RegisterCommand(command string, handler func(args string)) {}
-func RegisterFunc(command string, handler func())               {}
+
+// RegisterFunc registers a callable function invokable via AddHotkeyFunc.
+func RegisterFunc(command string, handler func()) {}
+
+// RunCommand queues a command to send immediately to the server.
+func RunCommand(cmd string) {}
+
+// EnqueueCommand queues a command for the next tick without echoing.
+func EnqueueCommand(cmd string) {}


### PR DESCRIPTION
## Summary
- expand pluginapi stubs with hotkey and command helpers
- expose a callable function in example_ponder plugin and bind a hotkey to it
- document available plugin API functions in README

## Testing
- `go test ./...` *(fails: non-constant format string and missing X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc0b1c8c832a802986fe237c89ec