### PR TITLE
Enable basic stdlib packages for plugins

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -188,8 +188,8 @@ func loadPlugins() {
 	}
     // Build restricted stdlib symbol map
     allowedPkgs := []string{
-        // "fmt/fmt",
-        // "strings/strings",
+        "fmt/fmt",
+        "strings/strings",
     }
     restricted := interp.Exports{}
     for _, key := range allowedPkgs {


### PR DESCRIPTION
## Summary
- allow plugin scripts to import fmt and strings by default

## Testing
- `go test ./...` *(fails: missing X11 headers; installed required packages but tests still not executed)*
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68abce806f3c832a8197b0d5552bd2c6