### PR TITLE
docs: document allowed plugin imports

### DIFF
--- a/embedded_plugins/README.txt
+++ b/embedded_plugins/README.txt
@@ -13,9 +13,21 @@ Getting Started
 
 Imports
 -------
-- Plugins can import only `gt` by default. System packages like `os`,
-  `io`, `net`, etc. are not available from the interpreter to prevent file or
-  network access.
+The interpreter allows only the following packages:
+
+- `gt` (client API)
+- `bytes`
+- `fmt`
+- `math`
+- `math/rand`
+- `sort`
+- `strconv`
+- `strings`
+- `time`
+- `unicode/utf8`
+
+Other system packages like `os`, `io`, `net`, etc. are not available to prevent
+file or network access.
 
 API
 ---


### PR DESCRIPTION
## Summary
- clarify which stdlib packages plugins may import

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abd3e7f3a4832ab245c41bb76a9c64