### PR TITLE
Ensure temporary TTS audio files are cleaned up

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -30,10 +32,19 @@ func stopAllTTS() {
 
 func fetchTTS(text string) (io.ReadCloser, error) {
 	fileName := fmt.Sprintf("chat_%d", time.Now().UnixNano())
+
+	if err := os.MkdirAll(chatSpeech.Folder, 0o755); err != nil {
+		return nil, fmt.Errorf("create audio dir: %w", err)
+	}
+
 	r, err := chatSpeech.CreateSpeechBuff(text, fileName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create speech: %w", err)
 	}
+
+	// Remove the temporary file written by CreateSpeechBuff.
+	_ = os.Remove(filepath.Join(chatSpeech.Folder, fileName+".mp3"))
+
 	return io.NopCloser(r), nil
 }
 


### PR DESCRIPTION
## Summary
- Create the TTS audio directory on demand and remove generated mp3 files after buffering
- Import filesystem helpers to manage TTS temporary files

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; Package 'gtk+-3.0' not found; Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abd419ae8c832a95e16d66a96885a8