### PR TITLE
Enforce hotkey names and refresh hotkeys UI

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -76,6 +76,21 @@ func TestHotkeyCommandInput(t *testing.T) {
 	}
 }
 
+// Test that a hotkey without a name is not saved.
+func TestHotkeyRequiresName(t *testing.T) {
+	hotkeys = nil
+	openHotkeyEditor(-1)
+	hotkeyComboText.Text = "Ctrl-C"
+	hotkeyCmdInputs[0].Text = "say hi"
+	finishHotkeyEdit(true)
+	if len(hotkeys) != 0 {
+		t.Fatalf("hotkey saved without name")
+	}
+	if hotkeyEditWin != nil {
+		hotkeyEditWin.Close()
+	}
+}
+
 // Test that loading hotkeys from disk refreshes the hotkeys window list.
 func TestLoadHotkeysShowsEntriesInWindow(t *testing.T) {
 	hotkeys = nil
@@ -111,6 +126,13 @@ func TestLoadHotkeysShowsEntriesInWindow(t *testing.T) {
 
 	if len(hotkeysList.Contents) != 1 {
 		t.Fatalf("hotkeys list not refreshed: %d", len(hotkeysList.Contents))
+	}
+	row := hotkeysList.Contents[0]
+	if row == nil || len(row.Contents) == 0 {
+		t.Fatalf("hotkey row malformed")
+	}
+	if got := row.Contents[0].Text; got != "Bye : Ctrl-B -> say bye" {
+		t.Fatalf("unexpected hotkey text: %q", got)
 	}
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -83,7 +83,7 @@ func pluginLogf(format string, args ...interface{}) {
 }
 
 func pluginAddHotkey(combo, command string) {
-	hk := Hotkey{Combo: combo, Commands: []HotkeyCommand{{Command: command}}}
+	hk := Hotkey{Name: command, Combo: combo, Commands: []HotkeyCommand{{Command: command}}}
 	hotkeysMu.Lock()
 	hotkeys = append(hotkeys, hk)
 	hotkeysMu.Unlock()
@@ -97,7 +97,7 @@ func pluginAddHotkey(combo, command string) {
 // pluginAddHotkeyFunc registers a hotkey that invokes a named plugin function
 // registered via RegisterFunc.
 func pluginAddHotkeyFunc(combo, funcName string) {
-	hk := Hotkey{Combo: combo, Commands: []HotkeyCommand{{Command: "plugin:" + funcName}}}
+	hk := Hotkey{Name: funcName, Combo: combo, Commands: []HotkeyCommand{{Command: "plugin:" + funcName}}}
 	hotkeysMu.Lock()
 	hotkeys = append(hotkeys, hk)
 	hotkeysMu.Unlock()


### PR DESCRIPTION
## Summary
- Default the hotkey editor's function dropdown to `none` and ignore adding when none is selected
- Require a name for saved hotkeys and display entries as `name : combo`
- Ensure plugin-added hotkeys receive names and refresh lists after changes

## Testing
- `go test` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory)*
- `go build` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd6138820832a88400bfa094a1c21