### PR TITLE
Allow editing nameless hotkeys

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -450,17 +450,22 @@ func finishHotkeyEdit(save bool) {
 				cmds = append(cmds, HotkeyCommand{Command: cmd})
 			}
 		}
-		if combo != "" && name != "" && len(cmds) > 0 {
+		if combo != "" && len(cmds) > 0 {
 			hk := Hotkey{Name: name, Combo: combo, Commands: cmds}
 			hotkeysMu.Lock()
 			if editingHotkey >= 0 && editingHotkey < len(hotkeys) {
 				hotkeys[editingHotkey] = hk
-			} else {
+				hotkeysMu.Unlock()
+				saveHotkeys()
+				refreshHotkeysList()
+			} else if name != "" {
 				hotkeys = append(hotkeys, hk)
+				hotkeysMu.Unlock()
+				saveHotkeys()
+				refreshHotkeysList()
+			} else {
+				hotkeysMu.Unlock()
 			}
-			hotkeysMu.Unlock()
-			saveHotkeys()
-			refreshHotkeysList()
 		}
 	}
 	if hotkeyEditWin != nil {

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -76,6 +76,23 @@ func TestHotkeyCommandInput(t *testing.T) {
 	}
 }
 
+// Test that editing a hotkey with no name still saves changes.
+func TestHotkeyEditWithoutName(t *testing.T) {
+	hotkeys = []Hotkey{{Combo: "Ctrl-A", Commands: []HotkeyCommand{{Command: "say hi"}}}}
+	dir := t.TempDir()
+	origDir := dataDirPath
+	dataDirPath = dir
+	defer func() { dataDirPath = origDir }()
+
+	openHotkeyEditor(0)
+	hotkeyCmdInputs[0].Text = "say bye"
+	finishHotkeyEdit(true)
+
+	if len(hotkeys) != 1 || hotkeys[0].Commands[0].Command != "say bye" {
+		t.Fatalf("hotkey not updated without name: %+v", hotkeys)
+	}
+}
+
 // Test that a hotkey without a name is not saved.
 func TestHotkeyRequiresName(t *testing.T) {
 	hotkeys = nil


### PR DESCRIPTION
## Summary
- Permit updates to hotkeys that lack a name
- Add regression test ensuring nameless hotkeys can be edited

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abda741de8832ab8fd71a8dc73b275