### PR TITLE
Allow saving nameless hotkeys

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -148,7 +148,10 @@ func refreshHotkeysList() {
 		row := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
 		row.Size = eui.Point{X: 220, Y: 20}
 		btn, events := eui.NewButton()
-		btnText := hk.Name + " : " + hk.Combo
+		btnText := hk.Combo
+		if hk.Name != "" {
+			btnText = hk.Name + " : " + hk.Combo
+		}
 		if len(hk.Commands) > 0 {
 			text := hk.Commands[0].Command
 			if len(hk.Commands) > 1 {
@@ -458,13 +461,11 @@ func finishHotkeyEdit(save bool) {
 				hotkeysMu.Unlock()
 				saveHotkeys()
 				refreshHotkeysList()
-			} else if name != "" {
+			} else {
 				hotkeys = append(hotkeys, hk)
 				hotkeysMu.Unlock()
 				saveHotkeys()
 				refreshHotkeysList()
-			} else {
-				hotkeysMu.Unlock()
 			}
 		}
 	}

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -93,18 +93,49 @@ func TestHotkeyEditWithoutName(t *testing.T) {
 	}
 }
 
-// Test that a hotkey without a name is not saved.
-func TestHotkeyRequiresName(t *testing.T) {
+// Test that a hotkey without a name still saves and refreshes.
+func TestHotkeySavedWithoutName(t *testing.T) {
 	hotkeys = nil
 	openHotkeyEditor(-1)
 	hotkeyComboText.Text = "Ctrl-C"
 	hotkeyCmdInputs[0].Text = "say hi"
 	finishHotkeyEdit(true)
-	if len(hotkeys) != 0 {
-		t.Fatalf("hotkey saved without name")
+	if len(hotkeys) != 1 || hotkeys[0].Name != "" {
+		t.Fatalf("hotkey not saved or name unexpectedly set: %+v", hotkeys)
 	}
 	if hotkeyEditWin != nil {
 		hotkeyEditWin.Close()
+	}
+}
+
+// Test that adding a hotkey without a name updates the window list.
+func TestHotkeyListUpdatesForNamelessHotkey(t *testing.T) {
+	hotkeys = nil
+	hotkeysWin = nil
+	hotkeysList = nil
+
+	makeHotkeysWindow()
+	if hotkeysList == nil {
+		t.Fatalf("hotkeys window not initialized")
+	}
+	if len(hotkeysList.Contents) != 0 {
+		t.Fatalf("expected empty list")
+	}
+
+	openHotkeyEditor(-1)
+	hotkeyComboText.Text = "Ctrl-X"
+	hotkeyCmdInputs[0].Text = "say hi"
+	finishHotkeyEdit(true)
+
+	if len(hotkeysList.Contents) != 1 {
+		t.Fatalf("hotkeys list not refreshed: %d", len(hotkeysList.Contents))
+	}
+	row := hotkeysList.Contents[0]
+	if row == nil || len(row.Contents) == 0 {
+		t.Fatalf("hotkey row malformed")
+	}
+	if got := row.Contents[0].Text; got != "Ctrl-X -> say hi" {
+		t.Fatalf("unexpected hotkey text: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow saving hotkeys without a name and update list display
- add tests covering nameless hotkeys and list refresh

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abdde21854832aa18c3bbda07feb60