### PR TITLE
Expose additional plugin APIs for console, players, and chat

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -27,6 +27,13 @@ func chatMessage(msg string) {
 			consoleMessage("Chat TTS is disabled. Enable it in settings to hear messages.")
 		})
 	}
+
+	chatHandlersMu.RLock()
+	handlers := append([]func(string){}, chatHandlers...)
+	chatHandlersMu.RUnlock()
+	for _, h := range handlers {
+		go h(msg)
+	}
 }
 
 func getChatMessages() []string {

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -35,6 +35,8 @@ file or network access.
 
 API
 ---
+- gt.Console(msg)
+  Writes a message to the in-client console.
 - gt.AddHotkey(combo, command)
   Registers a hotkey combo (e.g., "Digit1", "Shift-A", "Mouse Middle") that
   runs a slash-command like "/ponder hello world".
@@ -49,6 +51,12 @@ API
   Echoes to the console and queues a command to send immediately to the server.
 - gt.EnqueueCommand(cmd)
   Queues a command silently for the next tick.
+- gt.PlayerName()
+  Returns the name of the currently logged-in character.
+- gt.Players()
+  Returns a slice of known players with basic info (name, race, etc.).
+- gt.RegisterChatHandler(func(msg string))
+  Registers a callback invoked for each incoming chat message.
 
 Notes
 -----

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -7,11 +7,16 @@
 // runtime; these no-op stubs are never called by the compiled client.
 package gt
 
+import "time"
+
 // ClientVersion mirrors the client version value exported to plugins.
 var ClientVersion int
 
 // Logf is a no-op printf-style logger for editor/linter happiness.
 func Logf(format string, args ...interface{}) {}
+
+// Console writes a message to the in-client console.
+func Console(msg string) {}
 
 // AddHotkey binds a key combo to a slash command.
 func AddHotkey(combo, command string) {}
@@ -30,3 +35,34 @@ func RunCommand(cmd string) {}
 
 // EnqueueCommand queues a command for the next tick without echoing.
 func EnqueueCommand(cmd string) {}
+
+// PlayerName returns the current player's name.
+func PlayerName() string { return "" }
+
+// Player mirrors the player's state exposed to plugins.
+type Player struct {
+	Name       string
+	Race       string
+	Gender     string
+	Class      string
+	Clan       string
+	PictID     uint16
+	Colors     []byte
+	IsNPC      bool
+	Sharee     bool
+	Sharing    bool
+	GMLevel    int
+	Friend     bool
+	Dead       bool
+	FellWhere  string
+	KillerName string
+	Bard       bool
+	LastSeen   time.Time
+	Offline    bool
+}
+
+// Players returns the list of known players.
+func Players() []Player { return nil }
+
+// RegisterChatHandler registers a callback for incoming chat messages.
+func RegisterChatHandler(fn func(msg string)) {}


### PR DESCRIPTION
## Summary
- Allow plugins to write to the in-client console and include console output in `Logf`
- Expose current player name, player list, and player struct to plugins
- Support plugin callbacks for chat messages and document new helpers

## Testing
- `gofmt -w plugin.go chat_messages.go gt/pluginapi.go`
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go vet ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68abdcccee4c832a96b193624176a98c