### PR TITLE
Allow hotkeys to specify functions without commands

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -76,6 +76,26 @@ func TestHotkeyCommandInput(t *testing.T) {
 	}
 }
 
+// Test that a hotkey invoking a function can omit the command text.
+func TestHotkeyFunctionWithoutCommand(t *testing.T) {
+	hotkeys = nil
+	openHotkeyEditor(-1)
+	hotkeyComboText.Text = "Ctrl-F"
+	addHotkeyCommand("", "ponder")
+	finishHotkeyEdit(true)
+
+	if len(hotkeys) != 1 {
+		t.Fatalf("hotkey not saved")
+	}
+	cmd := hotkeys[0].Commands[0]
+	if cmd.Command != "" || cmd.Function != "ponder" {
+		t.Fatalf("unexpected hotkey command: %+v", cmd)
+	}
+	if hotkeyEditWin != nil {
+		hotkeyEditWin.Close()
+	}
+}
+
 // Test that editing a hotkey with no name still saves changes.
 func TestHotkeyEditWithoutName(t *testing.T) {
 	hotkeys = []Hotkey{{Combo: "Ctrl-A", Commands: []HotkeyCommand{{Command: "say hi"}}}}

--- a/plugin.go
+++ b/plugin.go
@@ -31,7 +31,7 @@ var pluginExports = interp.Exports{
 		"ClientVersion":       reflect.ValueOf(&clientVersion).Elem(),
 		"PlayerName":          reflect.ValueOf(pluginPlayerName),
 		"Players":             reflect.ValueOf(pluginPlayers),
-		"Player":              reflect.TypeOf(Player{}),
+		"Player":              reflect.ValueOf((*Player)(nil)),
 		"RegisterChatHandler": reflect.ValueOf(pluginRegisterChatHandler),
 	},
 }
@@ -109,7 +109,7 @@ func pluginAddHotkey(combo, command string) {
 // pluginAddHotkeyFunc registers a hotkey that invokes a named plugin function
 // registered via RegisterFunc.
 func pluginAddHotkeyFunc(combo, funcName string) {
-	hk := Hotkey{Name: funcName, Combo: combo, Commands: []HotkeyCommand{{Command: "plugin:" + funcName}}}
+	hk := Hotkey{Name: funcName, Combo: combo, Commands: []HotkeyCommand{{Function: funcName}}}
 	hotkeysMu.Lock()
 	hotkeys = append(hotkeys, hk)
 	hotkeysMu.Unlock()
@@ -148,7 +148,7 @@ func pluginRegisterCommand(name string, handler PluginCommandHandler) {
 }
 
 // pluginRegisterFunc registers a named function that can be called from
-// hotkeys using the special command string "plugin:<name>".
+// hotkeys using AddHotkeyFunc or a command string "plugin:<name>".
 func pluginRegisterFunc(name string, fn PluginFunc) {
 	if name == "" || fn == nil {
 		return


### PR DESCRIPTION
## Summary
- Allow each hotkey action to reference a plugin function while leaving the command blank
- Update the hotkey editor, saving, and runtime execution to handle function-only entries
- Expose the Player type correctly in plugin exports and support AddHotkeyFunc using the new structure

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abe550de44832abe43d523d45c8768