### PR TITLE
Allow hotkeys to trigger functions without commands

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -328,12 +328,11 @@ func openHotkeyEditor(idx int) {
 	addFnBtn.Disabled = len(fnOpts) == 0
 	addFnEv.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-			opts := pluginFunctionNames()
 			sel := fnDD.Selected
-			if sel <= 0 || sel > len(opts) {
+			if sel <= 0 || sel >= len(fnDD.Options) {
 				return
 			}
-			addHotkeyCommand("", opts[sel-1])
+			addHotkeyCommand("", fnDD.Options[sel])
 		}
 	}
 	fnRow.AddItem(addFnBtn)
@@ -475,8 +474,15 @@ func finishHotkeyEdit(save bool) {
 		combo := strings.ReplaceAll(hotkeyComboText.Text, "\n", " ")
 		name := strings.ReplaceAll(hotkeyNameInput.Text, "\n", " ")
 		cmds := []HotkeyCommand{}
-		for i := range hotkeyCmdInputs {
-			cmd := strings.ReplaceAll(hotkeyCmdInputs[i].Text, "\n", " ")
+		max := len(hotkeyCmdInputs)
+		if len(hotkeyCmdFuncs) > max {
+			max = len(hotkeyCmdFuncs)
+		}
+		for i := 0; i < max; i++ {
+			cmd := ""
+			if i < len(hotkeyCmdInputs) {
+				cmd = strings.ReplaceAll(hotkeyCmdInputs[i].Text, "\n", " ")
+			}
 			fn := ""
 			if i < len(hotkeyCmdFuncs) {
 				fn = hotkeyCmdFuncs[i]

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -96,6 +96,27 @@ func TestHotkeyFunctionWithoutCommand(t *testing.T) {
 	}
 }
 
+// Test that a function-only hotkey persists through save/load cycles.
+func TestHotkeyFunctionPersisted(t *testing.T) {
+	hotkeys = []Hotkey{{Combo: "Ctrl-P", Commands: []HotkeyCommand{{Function: "ponder"}}}}
+	dir := t.TempDir()
+	origDir := dataDirPath
+	dataDirPath = dir
+	defer func() { dataDirPath = origDir }()
+
+	saveHotkeys()
+	hotkeys = nil
+	loadHotkeys()
+
+	if len(hotkeys) != 1 {
+		t.Fatalf("hotkey not loaded")
+	}
+	cmd := hotkeys[0].Commands[0]
+	if cmd.Command != "" || cmd.Function != "ponder" {
+		t.Fatalf("unexpected hotkey after load: %+v", cmd)
+	}
+}
+
 // Test that editing a hotkey with no name still saves changes.
 func TestHotkeyEditWithoutName(t *testing.T) {
 	hotkeys = []Hotkey{{Combo: "Ctrl-A", Commands: []HotkeyCommand{{Command: "say hi"}}}}


### PR DESCRIPTION
## Summary
- ensure hotkeys can be saved with only a plugin function
- keep function selections across save/load cycles

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abeaa29984832a992be421dd423cbe