### PR TITLE
Expose inventory to plugin API

### DIFF
--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -57,6 +57,10 @@ API
   Returns a slice of known players with basic info (name, race, etc.).
 - gt.RegisterChatHandler(func(msg string))
   Registers a callback invoked for each incoming chat message.
+- gt.Inventory()
+  Returns a slice of inventory items with ID, name, equipped state and quantity.
+- gt.ToggleEquip(id)
+  Toggles the equipped state of the first matching item by ID.
 
 Notes
 -----

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -66,3 +66,19 @@ func Players() []Player { return nil }
 
 // RegisterChatHandler registers a callback for incoming chat messages.
 func RegisterChatHandler(fn func(msg string)) {}
+
+// InventoryItem mirrors the client's inventory item structure.
+type InventoryItem struct {
+	ID       uint16
+	Name     string
+	Equipped bool
+	Index    int
+	IDIndex  int
+	Quantity int
+}
+
+// Inventory returns the player's inventory.
+func Inventory() []InventoryItem { return nil }
+
+// ToggleEquip toggles the equipped state of an item by ID.
+func ToggleEquip(id uint16) {}

--- a/inventory.go
+++ b/inventory.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-type inventoryItem struct {
+type InventoryItem struct {
 	ID       uint16
 	Name     string
 	Equipped bool
@@ -22,7 +22,7 @@ type inventoryKey struct {
 
 var (
 	inventoryMu    sync.RWMutex
-	inventoryItems []inventoryItem
+	inventoryItems []InventoryItem
 	inventoryNames = make(map[inventoryKey]string)
 )
 
@@ -58,7 +58,7 @@ func addInventoryItem(id uint16, idx int, name string, equip bool) {
 			}
 		}
 		// Append as a distinct instance; keep display order by placing at end
-		item := inventoryItem{ID: id, Name: name, Equipped: equip, Index: len(inventoryItems), IDIndex: idx, Quantity: 1}
+		item := InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(inventoryItems), IDIndex: idx, Quantity: 1}
 		inventoryItems = append(inventoryItems, item)
 	} else {
 		// Legacy/non-template: coalesce by ID and bump quantity
@@ -74,7 +74,7 @@ func addInventoryItem(id uint16, idx int, name string, equip bool) {
 			}
 		}
 		if !found {
-			item := inventoryItem{ID: id, Name: name, Equipped: equip, Index: len(inventoryItems), IDIndex: -1, Quantity: 1}
+			item := InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(inventoryItems), IDIndex: -1, Quantity: 1}
 			inventoryItems = append(inventoryItems, item)
 		}
 	}
@@ -246,10 +246,10 @@ func renameInventoryItem(id uint16, idx int, name string) {
 	inventoryDirty = true
 }
 
-func getInventory() []inventoryItem {
+func getInventory() []InventoryItem {
 	inventoryMu.RLock()
 	defer inventoryMu.RUnlock()
-	out := make([]inventoryItem, len(inventoryItems))
+	out := make([]InventoryItem, len(inventoryItems))
 	copy(out, inventoryItems)
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Equipped != out[j].Equipped {
@@ -261,7 +261,7 @@ func getInventory() []inventoryItem {
 }
 
 func setFullInventory(ids []uint16, equipped []bool) {
-	items := make([]inventoryItem, 0, len(ids))
+	items := make([]InventoryItem, 0, len(ids))
 	seen := make(map[uint16]int)
 	inventoryMu.Lock()
 	newNames := make(map[inventoryKey]string)
@@ -290,7 +290,7 @@ func setFullInventory(ids []uint16, equipped []bool) {
 		}
 		// Assign per-ID index sequentially
 		idIdx := seen[id]
-		items = append(items, inventoryItem{ID: id, Name: name, Equipped: equip, Index: len(items), IDIndex: idIdx, Quantity: 1})
+		items = append(items, InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(items), IDIndex: idIdx, Quantity: 1})
 		seen[id] = idIdx + 1
 	}
 	inventoryItems = items

--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -65,7 +65,7 @@ func updateInventoryWindow() {
 	// whether any instance of a given ID is equipped.
 	items := getInventory()
 	counts := make(map[uint16]int)
-	first := make(map[uint16]inventoryItem)
+	first := make(map[uint16]InventoryItem)
 	anyEquipped := make(map[uint16]bool)
 	order := make([]uint16, 0, len(items))
 	for _, it := range items {

--- a/plugin.go
+++ b/plugin.go
@@ -32,6 +32,9 @@ var pluginExports = interp.Exports{
 		"PlayerName":          reflect.ValueOf(pluginPlayerName),
 		"Players":             reflect.ValueOf(pluginPlayers),
 		"Player":              reflect.ValueOf((*Player)(nil)),
+		"Inventory":           reflect.ValueOf(pluginInventory),
+		"InventoryItem":       reflect.ValueOf((*InventoryItem)(nil)),
+		"ToggleEquip":         reflect.ValueOf(pluginToggleEquip),
 		"RegisterChatHandler": reflect.ValueOf(pluginRegisterChatHandler),
 	},
 }
@@ -190,6 +193,14 @@ func pluginPlayers() []Player {
 	out := make([]Player, len(ps))
 	copy(out, ps)
 	return out
+}
+
+func pluginInventory() []InventoryItem {
+	return getInventory()
+}
+
+func pluginToggleEquip(id uint16) {
+	toggleInventoryEquip(id)
 }
 
 func pluginRegisterChatHandler(fn func(string)) {


### PR DESCRIPTION
## Summary
- export inventory data structure as InventoryItem and adjust usage
- add Inventory and ToggleEquip helpers to plugin API with stubs
- document inventory helpers for plugin authors

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68abec298dec832a8e321d31ecfb6976