### PR TITLE
Improve picture matching for motion smoothing

### DIFF
--- a/draw_test.go
+++ b/draw_test.go
@@ -71,3 +71,20 @@ func TestPictureOnEdge(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchPictureGroups(t *testing.T) {
+	prev := []framePicture{{PictID: 1, H: 0, V: 0}, {PictID: 1, H: 20, V: 0}}
+	cur := []framePicture{{PictID: 1, H: 2, V: 0}, {PictID: 1, H: 18, V: 0}}
+	m := matchPictureGroups(prev, cur, 0, 0, 5)
+	if len(m) != 2 || m[0] != 0 || m[1] != 1 {
+		t.Fatalf("unexpected mapping %v", m)
+	}
+
+	// ambiguous layout: two equidistant options, expect no mapping
+	prev = []framePicture{{PictID: 1, H: 0, V: 0}, {PictID: 1, H: 2, V: 0}}
+	cur = []framePicture{{PictID: 1, H: 1, V: -1}, {PictID: 1, H: 1, V: 1}}
+	m = matchPictureGroups(prev, cur, 0, 0, 5)
+	if len(m) != 0 {
+		t.Fatalf("expected ambiguous mapping, got %v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- add `matchPictureGroups` to globally pair previous and current pictures
- use group matching before smoothing to keep layout-consistent interpolation
- test matching with duplicate sprite scenarios

## Testing
- `go test ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path; Package 'alsa', required by 'virtual:world', not found; fatal error: GL/glx.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abec18807c832aa72f3cc7439b2351