### PR TITLE
Add player update callbacks for plugins

### DIFF
--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -57,6 +57,8 @@ API
   Returns a slice of known players with basic info (name, race, etc.).
 - gt.RegisterChatHandler(func(msg string))
   Registers a callback invoked for each incoming chat message.
+- gt.RegisterPlayerHandler(func(p gt.Player))
+  Registers a callback invoked whenever player info changes.
 
 Notes
 -----

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -66,3 +66,6 @@ func Players() []Player { return nil }
 
 // RegisterChatHandler registers a callback for incoming chat messages.
 func RegisterChatHandler(fn func(msg string)) {}
+
+// RegisterPlayerHandler registers a callback for player info updates.
+func RegisterPlayerHandler(fn func(Player)) {}

--- a/plugin.go
+++ b/plugin.go
@@ -20,19 +20,20 @@ var pluginExports = interp.Exports{
 	// Short path used by simple plugin scripts: import "gt"
 	// Yaegi expects keys as "importPath/pkgName".
 	"gt/gt": {
-		"Logf":                reflect.ValueOf(pluginLogf),
-		"Console":             reflect.ValueOf(pluginConsole),
-		"AddHotkey":           reflect.ValueOf(pluginAddHotkey),
-		"AddHotkeyFunc":       reflect.ValueOf(pluginAddHotkeyFunc),
-		"RegisterCommand":     reflect.ValueOf(pluginRegisterCommand),
-		"RegisterFunc":        reflect.ValueOf(pluginRegisterFunc),
-		"RunCommand":          reflect.ValueOf(pluginRunCommand),
-		"EnqueueCommand":      reflect.ValueOf(pluginEnqueueCommand),
-		"ClientVersion":       reflect.ValueOf(&clientVersion).Elem(),
-		"PlayerName":          reflect.ValueOf(pluginPlayerName),
-		"Players":             reflect.ValueOf(pluginPlayers),
-		"Player":              reflect.ValueOf((*Player)(nil)),
-		"RegisterChatHandler": reflect.ValueOf(pluginRegisterChatHandler),
+		"Logf":                  reflect.ValueOf(pluginLogf),
+		"Console":               reflect.ValueOf(pluginConsole),
+		"AddHotkey":             reflect.ValueOf(pluginAddHotkey),
+		"AddHotkeyFunc":         reflect.ValueOf(pluginAddHotkeyFunc),
+		"RegisterCommand":       reflect.ValueOf(pluginRegisterCommand),
+		"RegisterFunc":          reflect.ValueOf(pluginRegisterFunc),
+		"RunCommand":            reflect.ValueOf(pluginRunCommand),
+		"EnqueueCommand":        reflect.ValueOf(pluginEnqueueCommand),
+		"ClientVersion":         reflect.ValueOf(&clientVersion).Elem(),
+		"PlayerName":            reflect.ValueOf(pluginPlayerName),
+		"Players":               reflect.ValueOf(pluginPlayers),
+		"Player":                reflect.ValueOf((*Player)(nil)),
+		"RegisterChatHandler":   reflect.ValueOf(pluginRegisterChatHandler),
+		"RegisterPlayerHandler": reflect.ValueOf(pluginRegisterPlayerHandler),
 	},
 }
 
@@ -199,6 +200,15 @@ func pluginRegisterChatHandler(fn func(string)) {
 	chatHandlersMu.Lock()
 	chatHandlers = append(chatHandlers, fn)
 	chatHandlersMu.Unlock()
+}
+
+func pluginRegisterPlayerHandler(fn func(Player)) {
+	if fn == nil {
+		return
+	}
+	playerHandlersMu.Lock()
+	playerHandlers = append(playerHandlers, fn)
+	playerHandlersMu.Unlock()
 }
 
 func loadPlugins() {


### PR DESCRIPTION
## Summary
- notify registered player handlers on appearance, who, share, and backend updates
- allow plugins to register player callbacks
- document player handler API for plugins

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68abec33cc34832a8cc9daeb856823a5