### PR TITLE
Add plugin Equip and Unequip helpers

### DIFF
--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -82,3 +82,9 @@ func Inventory() []InventoryItem { return nil }
 
 // ToggleEquip toggles the equipped state of an item by ID.
 func ToggleEquip(id uint16) {}
+
+// Equip equips the specified item by ID if it isn't already equipped.
+func Equip(id uint16) {}
+
+// Unequip removes the specified item by ID if it is currently equipped.
+func Unequip(id uint16) {}

--- a/plugin.go
+++ b/plugin.go
@@ -35,6 +35,8 @@ var pluginExports = interp.Exports{
 		"Inventory":           reflect.ValueOf(pluginInventory),
 		"InventoryItem":       reflect.ValueOf((*InventoryItem)(nil)),
 		"ToggleEquip":         reflect.ValueOf(pluginToggleEquip),
+		"Equip":               reflect.ValueOf(pluginEquip),
+		"Unequip":             reflect.ValueOf(pluginUnequip),
 		"RegisterChatHandler": reflect.ValueOf(pluginRegisterChatHandler),
 	},
 }
@@ -201,6 +203,47 @@ func pluginInventory() []InventoryItem {
 
 func pluginToggleEquip(id uint16) {
 	toggleInventoryEquip(id)
+}
+
+func pluginEquip(id uint16) {
+	items := getInventory()
+	idx := -1
+	for _, it := range items {
+		if it.ID != id {
+			continue
+		}
+		if it.Equipped {
+			return
+		}
+		if idx < 0 {
+			idx = it.IDIndex
+		}
+	}
+	if idx < 0 {
+		return
+	}
+	if idx >= 0 {
+		pendingCommand = fmt.Sprintf("/equip %d %d", id, idx+1)
+	} else {
+		pendingCommand = fmt.Sprintf("/equip %d", id)
+	}
+	equipInventoryItem(id, idx, true)
+}
+
+func pluginUnequip(id uint16) {
+	items := getInventory()
+	equipped := false
+	for _, it := range items {
+		if it.ID == id && it.Equipped {
+			equipped = true
+			break
+		}
+	}
+	if !equipped {
+		return
+	}
+	pendingCommand = fmt.Sprintf("/unequip %d", id)
+	equipInventoryItem(id, -1, false)
 }
 
 func pluginRegisterChatHandler(fn func(string)) {


### PR DESCRIPTION
## Summary
- allow plugins to equip or unequip an item only when necessary
- expose new Equip and Unequip helpers in plugin API and stub package

## Testing
- `go vet ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*
- `go test ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68abed619f54832abad6640a18889884