### PR TITLE
Expose input text and stats in plugin API

### DIFF
--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -82,3 +82,19 @@ func Inventory() []InventoryItem { return nil }
 
 // ToggleEquip toggles the equipped state of an item by ID.
 func ToggleEquip(id uint16) {}
+
+// InputText returns the current text in the input bar.
+func InputText() string { return "" }
+
+// SetInputText replaces the text in the input bar.
+func SetInputText(text string) {}
+
+// Stats mirrors the player's HP, SP, and balance values.
+type Stats struct {
+	HP, HPMax           int
+	SP, SPMax           int
+	Balance, BalanceMax int
+}
+
+// PlayerStats returns the player's current stat values.
+func PlayerStats() Stats { return Stats{} }

--- a/plugin.go
+++ b/plugin.go
@@ -36,6 +36,10 @@ var pluginExports = interp.Exports{
 		"InventoryItem":       reflect.ValueOf((*InventoryItem)(nil)),
 		"ToggleEquip":         reflect.ValueOf(pluginToggleEquip),
 		"RegisterChatHandler": reflect.ValueOf(pluginRegisterChatHandler),
+		"InputText":           reflect.ValueOf(pluginInputText),
+		"SetInputText":        reflect.ValueOf(pluginSetInputText),
+		"PlayerStats":         reflect.ValueOf(pluginPlayerStats),
+		"Stats":               reflect.ValueOf((*Stats)(nil)),
 	},
 }
 
@@ -201,6 +205,40 @@ func pluginInventory() []InventoryItem {
 
 func pluginToggleEquip(id uint16) {
 	toggleInventoryEquip(id)
+}
+
+type Stats struct {
+	HP, HPMax           int
+	SP, SPMax           int
+	Balance, BalanceMax int
+}
+
+func pluginPlayerStats() Stats {
+	stateMu.Lock()
+	s := Stats{
+		HP:         state.hp,
+		HPMax:      state.hpMax,
+		SP:         state.sp,
+		SPMax:      state.spMax,
+		Balance:    state.balance,
+		BalanceMax: state.balanceMax,
+	}
+	stateMu.Unlock()
+	return s
+}
+
+func pluginInputText() string {
+	inputMu.Lock()
+	txt := string(inputText)
+	inputMu.Unlock()
+	return txt
+}
+
+func pluginSetInputText(text string) {
+	inputMu.Lock()
+	inputText = []rune(text)
+	inputActive = true
+	inputMu.Unlock()
 }
 
 func pluginRegisterChatHandler(fn func(string)) {


### PR DESCRIPTION
## Summary
- allow plugins to read and set the current input line
- expose player HP/SP/balance stats to plugins

## Testing
- `go vet ./...`
- `go test ./...` *(fails: X11 display missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abecf7fd74832a9839ee37bcb7227e