### PR TITLE
Track dropped frames and show drop rate

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -616,7 +616,12 @@ func parseDrawState(data []byte, buildCache bool) error {
 	ackCmd := data[0]
 	ackFrame = int32(binary.BigEndian.Uint32(data[1:5]))
 	resendFrame = int32(binary.BigEndian.Uint32(data[5:9]))
-	dropped := updateFrameCounters(ackFrame)
+	dropped := 0
+	if movieMode {
+		dropped = movieDropped
+	} else {
+		dropped = updateFrameCounters(ackFrame)
+	}
 	extra := dropped
 	if extra > 2 {
 		extra = 2

--- a/game.go
+++ b/game.go
@@ -652,10 +652,10 @@ func (g *Game) Update() error {
 				changedInput = true
 			}
 		}
-        if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
-            txt := strings.TrimSpace(string(inputText))
-            if txt != "" {
-                if strings.HasPrefix(txt, "/play ") {
+		if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
+			txt := strings.TrimSpace(string(inputText))
+			if txt != "" {
+				if strings.HasPrefix(txt, "/play ") {
 					tune := strings.TrimSpace(txt[len("/play "):])
 					if musicDebug {
 						msg := "/play " + tune
@@ -672,29 +672,29 @@ func (g *Game) Update() error {
 							}
 						}
 					}()
-                } else {
-                    // Try plugin-registered commands first
-                    if strings.HasPrefix(txt, "/") {
-                        parts := strings.SplitN(strings.TrimPrefix(txt, "/"), " ", 2)
-                        name := strings.ToLower(parts[0])
-                        args := ""
-                        if len(parts) > 1 {
-                            args = parts[1]
-                        }
-                        if handler, ok := pluginCommands[name]; ok && handler != nil {
-                            consoleMessage("> " + txt)
-                            go handler(args)
-                        } else {
-                            pendingCommand = txt
-                        }
-                    } else {
-                        pendingCommand = txt
-                    }
-                    //consoleMessage("> " + txt)
-                }
-                inputHistory = append(inputHistory, txt)
-            }
-            inputActive = false
+				} else {
+					// Try plugin-registered commands first
+					if strings.HasPrefix(txt, "/") {
+						parts := strings.SplitN(strings.TrimPrefix(txt, "/"), " ", 2)
+						name := strings.ToLower(parts[0])
+						args := ""
+						if len(parts) > 1 {
+							args = parts[1]
+						}
+						if handler, ok := pluginCommands[name]; ok && handler != nil {
+							consoleMessage("> " + txt)
+							go handler(args)
+						} else {
+							pendingCommand = txt
+						}
+					} else {
+						pendingCommand = txt
+					}
+					//consoleMessage("> " + txt)
+				}
+				inputHistory = append(inputHistory, txt)
+			}
+			inputActive = false
 			inputText = inputText[:0]
 			historyPos = len(inputHistory)
 			changedInput = true
@@ -1788,7 +1788,8 @@ func drawServerFPS(screen *ebiten.Image, ox, oy int, fps float64) {
 
 		lat := netLatency
 		jit := netJitter
-		msg := fmt.Sprintf("FPS: %0.2f Server: %0.2f Ping: %-3v ms Jit: %-3v ms", ebiten.ActualFPS(), fps, lat.Milliseconds(), jit.Milliseconds())
+		drop := droppedPercent()
+		msg := fmt.Sprintf("FPS: %0.2f Server: %0.2f Drop: %0.1f%% Ping: %-3v ms Jit: %-3v ms", ebiten.ActualFPS(), fps, drop, lat.Milliseconds(), jit.Milliseconds())
 		w, h := text.Measure(msg, mainFont, 0)
 
 		if fpsImage == nil || fpsHeight != h {

--- a/main.go
+++ b/main.go
@@ -201,10 +201,10 @@ func main() {
 	<-ctx.Done()
 }
 
-func extractMoviePlayerName(frames [][]byte) string {
+func extractMoviePlayerName(frames []movieFrame) string {
 	for _, m := range frames {
-		if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-			data := append([]byte(nil), m[2:]...)
+		if len(m.data) >= 2 && binary.BigEndian.Uint16(m.data[:2]) == 2 {
+			data := append([]byte(nil), m.data[2:]...)
 			if n := playerFromDrawState(data); n != "" {
 				return n
 			}
@@ -216,8 +216,8 @@ func extractMoviePlayerName(frames [][]byte) string {
 	}
 
 	for _, m := range frames {
-		if len(m) >= 2 && binary.BigEndian.Uint16(m[:2]) == 2 {
-			data := append([]byte(nil), m[2:]...)
+		if len(m.data) >= 2 && binary.BigEndian.Uint16(m.data[:2]) == 2 {
+			data := append([]byte(nil), m.data[2:]...)
 			if n := firstDescriptorName(data); n != "" {
 				return n
 			}

--- a/music_command_test.go
+++ b/music_command_test.go
@@ -33,8 +33,8 @@ func TestParseMusicCommandFromMovie(t *testing.T) {
 	}
 	var msg []byte
 	for _, f := range frames {
-		if idx := bytes.Index(f, []byte("/music/")); idx >= 0 {
-			msg = f[idx:]
+		if idx := bytes.Index(f.data, []byte("/music/")); idx >= 0 {
+			msg = f.data[idx:]
 			if j := bytes.IndexByte(msg, 0); j >= 0 {
 				msg = msg[:j]
 			}

--- a/ui.go
+++ b/ui.go
@@ -275,7 +275,7 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	}
 	row2.AddItem(mixBtn)
 
-    // Removed toolbar volume slider and mute button (use Mixer instead)
+	// Removed toolbar volume slider and mute button (use Mixer instead)
 
 	recordStatus, _ = eui.NewText()
 	recordStatus.Text = ""


### PR DESCRIPTION
## Summary
- parse .clMov frame headers to record frame indices and spot gaps
- update movie playback to use recorded frame numbers for drop tracking
- show 5-second dropped-frame percentage in FPS display

## Testing
- `go test ./...` *(fails: Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abf360bf1c832a938d237515f946ef