### PR TITLE
Ensure hotkey function selection persists

### DIFF
--- a/data/plugins/README.txt
+++ b/data/plugins/README.txt
@@ -10,6 +10,8 @@ Getting Started
 - Copy or edit the example_ponder.go file to customize hotkeys.
 - Each plugin must define an `Init()` function. The client discovers and calls
   this function after loading the script.
+- Each plugin must define a unique `PluginName` string. Plugins with duplicate
+  names will be ignored.
 
 Imports
 -------

--- a/data/plugins/example_ponder.go
+++ b/data/plugins/example_ponder.go
@@ -4,6 +4,8 @@ import (
 	"gt"
 )
 
+var PluginName = "Example"
+
 // Highly recommend vscodium or vscode with the official golang plugin!
 func Wave() {
 	gt.RunCommand("/ponder hello world")

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -10,6 +10,8 @@ Getting Started
 - Copy or edit the example_ponder.go file to customize hotkeys.
 - Each plugin must define an `Init()` function. The client discovers and calls
   this function after loading the script.
+- Each plugin must define a unique `PluginName` string. Plugins with duplicate
+  names will be ignored.
 
 Imports
 -------

--- a/example_plugins/example_ponder.go
+++ b/example_plugins/example_ponder.go
@@ -4,6 +4,8 @@ import (
 	"gt"
 )
 
+var PluginName = "Example"
+
 // Highly recommend vscodium or vscode with the official golang plugin!
 func Wave() {
 	gt.RunCommand("/ponder hello world")

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -28,6 +28,7 @@ func AddHotkeyFunc(combo, funcName string) {}
 type HotkeyCommand struct {
 	Command  string
 	Function string
+	Plugin   string
 }
 
 // Hotkey represents a single key binding and its metadata.
@@ -90,6 +91,7 @@ func RegisterChatHandler(fn func(msg string)) {}
 
 // RegisterPlayerHandler registers a callback for player info updates.
 func RegisterPlayerHandler(fn func(Player)) {}
+
 // InventoryItem mirrors the client's inventory item structure.
 type InventoryItem struct {
 	ID       uint16
@@ -121,6 +123,7 @@ type Stats struct {
 
 // PlayerStats returns the player's current stat values.
 func PlayerStats() Stats { return Stats{} }
+
 // Equip equips the specified item by ID if it isn't already equipped.
 func Equip(id uint16) {}
 

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -81,7 +81,7 @@ func TestHotkeyFunctionWithoutCommand(t *testing.T) {
 	hotkeys = nil
 	openHotkeyEditor(-1)
 	hotkeyComboText.Text = "Ctrl-F"
-	addHotkeyCommand("", "ponder")
+	addHotkeyCommand("", "ponder", "")
 	finishHotkeyEdit(true)
 
 	if len(hotkeys) != 1 {


### PR DESCRIPTION
## Summary
- require plugins to declare a unique `PluginName` and skip duplicates on load
- track each hotkey's plugin owner to disambiguate function lookups
- document plugin naming in examples and README

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abf1346bd0832aa2d22671ff386b45