### PR TITLE
Skip stationary images in pictureShift

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -344,6 +344,11 @@ func pictureShift(prev, cur []framePicture, max int) (int, int, []int, bool) {
 			}
 		}
 		if matched {
+			if bestDx == 0 && bestDy == 0 {
+				// Ignore pictures that didn't move between frames to avoid static
+				// images dominating the shift calculation (e.g., a giant background).
+				continue
+			}
 			pixels, ok := pixelCache[p.PictID]
 			if !ok {
 				pixels = nonTransparentPixels(p.PictID)


### PR DESCRIPTION
## Summary
- Ignore images that stay in the same position between frames when computing pictureShift, preventing static sprites from skewing motion detection.

## Testing
- `go vet .`
- `go test .` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac087de600832abed49df3ecad7dbf