### PR TITLE
Handle additional BEPP prefixes

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-    "bytes"
-    "log"
-    "strings"
+	"bytes"
+	"log"
+	"strings"
 
 	"golang.org/x/text/encoding/charmap"
 )
@@ -132,25 +132,27 @@ BEPP tag reference (two-letter codes following the 0xC2 prefix):
 | yk  | you killed          |
 */
 func decodeBEPP(data []byte) string {
-    if len(data) < 3 || data[0] != 0xC2 {
-        return ""
-    }
-    prefix := string(data[1:3])
-    // Keep a raw copy (without NUL terminator) for backend parsing.
-    raw := data[3:]
-    if i := bytes.IndexByte(raw, 0); i >= 0 {
-        raw = raw[:i]
-    }
-    // For displayable text, strip BEPP tags and non-printables.
-    cleaned := stripBEPPTags(append([]byte(nil), raw...))
-    text := strings.TrimSpace(decodeMacRoman(cleaned))
+	if len(data) < 3 || data[0] != 0xC2 {
+		return ""
+	}
+	prefix := string(data[1:3])
+	// Keep a raw copy (without NUL terminator) for backend parsing.
+	raw := data[3:]
+	if i := bytes.IndexByte(raw, 0); i >= 0 {
+		raw = raw[:i]
+	}
+	// For displayable text, strip BEPP tags and non-printables.
+	cleaned := stripBEPPTags(append([]byte(nil), raw...))
+	text := strings.TrimSpace(decodeMacRoman(cleaned))
 
-    if dumpBEPPTags {
-        // Log the tag and a truncated form of the text for empirical analysis.
-        t := text
-        if len(t) > 120 { t = t[:120] + "..." }
-        log.Printf("BEPP %s: %q", prefix, t)
-    }
+	if dumpBEPPTags {
+		// Log the tag and a truncated form of the text for empirical analysis.
+		t := text
+		if len(t) > 120 {
+			t = t[:120] + "..."
+		}
+		log.Printf("BEPP %s: %q", prefix, t)
+	}
 	if text == "" && prefix != "be" && prefix != "mu" { // backend commands or music may have no printable text
 		return ""
 	}
@@ -181,8 +183,9 @@ func decodeBEPP(data []byte) string {
 		if !handled && text != "" {
 			return text
 		}
-	case "lg":
-		// Login/logout presence notices
+	case "lg", "lf", "er":
+		// Login/logout presence notices and error messages like
+		// "<name> is not in the lands." which imply logoff
 		parsePresenceText(raw, text)
 		if text != "" {
 			return text
@@ -191,8 +194,9 @@ func decodeBEPP(data []byte) string {
 		// Back-end command: handle internally using raw (unstripped) data.
 		parseBackend(raw)
 		return ""
-	case "yk", "iv", "hp", "cf", "pn":
-		// Known simple pass-through prefixes (e.g., iv: item/verb)
+	case "yk", "iv", "hp", "cf", "pn", "ka", "tl":
+		// Known simple pass-through prefixes (e.g., iv: item/verb,
+		// ka: karma, tl: text log only)
 		if text != "" {
 			return text
 		}
@@ -396,40 +400,40 @@ func decodeMessage(m []byte) string {
 }
 
 func handleInfoText(data []byte) {
-    for _, line := range bytes.Split(data, []byte{'\r'}) {
-        if len(line) == 0 {
-            continue
-        }
-        if line[0] == 0xC2 {
-            if txt := decodeBEPP(line); txt != "" {
-                consoleMessage(txt)
-            }
-            continue
-        }
-        if _, txt, _, _, _, _ := decodeBubble(line); txt != "" {
-            if gs.MessagesToConsole {
-                consoleMessage(txt)
-            } else {
-                chatMessage(txt)
-            }
-            continue
-        }
-        s := strings.TrimSpace(decodeMacRoman(stripBEPPTags(line)))
-        if s == "" {
-            continue
-        }
-        // Empirical: classic client handles server-sent info-text music commands
-        // like "/music/..." here. Accept only this canonical prefix from
-        // info-text (not bubbles), and otherwise avoid parsing plain text.
-        if strings.HasPrefix(s, "/music/") {
-            if parseMusicCommand(s, line) {
-                continue
-            }
-        }
-        // Ignore other command-like lines.
-        if strings.HasPrefix(s, "/") {
-            continue
-        }
-        consoleMessage(s)
-    }
+	for _, line := range bytes.Split(data, []byte{'\r'}) {
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == 0xC2 {
+			if txt := decodeBEPP(line); txt != "" {
+				consoleMessage(txt)
+			}
+			continue
+		}
+		if _, txt, _, _, _, _ := decodeBubble(line); txt != "" {
+			if gs.MessagesToConsole {
+				consoleMessage(txt)
+			} else {
+				chatMessage(txt)
+			}
+			continue
+		}
+		s := strings.TrimSpace(decodeMacRoman(stripBEPPTags(line)))
+		if s == "" {
+			continue
+		}
+		// Empirical: classic client handles server-sent info-text music commands
+		// like "/music/..." here. Accept only this canonical prefix from
+		// info-text (not bubbles), and otherwise avoid parsing plain text.
+		if strings.HasPrefix(s, "/music/") {
+			if parseMusicCommand(s, line) {
+				continue
+			}
+		}
+		// Ignore other command-like lines.
+		if strings.HasPrefix(s, "/") {
+			continue
+		}
+		consoleMessage(s)
+	}
 }

--- a/presence_bepp_test.go
+++ b/presence_bepp_test.go
@@ -2,9 +2,10 @@ package main
 
 import "testing"
 
-// helper to build BEPP line with lg prefix
-func presenceLine(msg []byte) []byte {
-	b := []byte{0xC2, 'l', 'g'}
+// helper to build BEPP line with specified prefix
+func presenceLine(prefix string, msg []byte) []byte {
+	b := []byte{0xC2}
+	b = append(b, prefix[0], prefix[1])
 	b = append(b, msg...)
 	b = append(b, 0)
 	return b
@@ -14,7 +15,7 @@ func TestDecodeLoginBEPP(t *testing.T) {
 	players = make(map[string]*Player)
 	players["Bob"] = &Player{Name: "Bob", Offline: true}
 	msg := append(pnTag("Bob"), []byte(" has logged on")...)
-	raw := presenceLine(msg)
+	raw := presenceLine("lg", msg)
 	if got := decodeBEPP(raw); got != "Bob has logged on" {
 		t.Fatalf("decodeBEPP returned %q", got)
 	}
@@ -30,7 +31,7 @@ func TestDecodeLogoutBEPP(t *testing.T) {
 	players = make(map[string]*Player)
 	players["Bob"] = &Player{Name: "Bob", Offline: false}
 	msg := append(pnTag("Bob"), []byte(" has left the lands")...)
-	raw := presenceLine(msg)
+	raw := presenceLine("lf", msg)
 	if got := decodeBEPP(raw); got != "Bob has left the lands" {
 		t.Fatalf("decodeBEPP returned %q", got)
 	}


### PR DESCRIPTION
## Summary
- parse BEPP messages for `lf` and `er` as presence or errors
- treat `ka` and `tl` as simple pass-through BEPP prefixes
- fix presence tests to use `lg` for logon and `lf` for logoff

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2846d85c832abfb917d71bf09ecf