### PR TITLE
Route non-chat messages to console

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1187,7 +1187,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 			return fmt.Errorf("bubble=%d off=%d len=%d", i, off, len(stateData))
 		}
 		bubbleData := stateData[:p+end+1]
-		if verb, txt, bubbleName, lang, code, target := decodeBubble(bubbleData); txt != "" || code != kBubbleCodeKnown {
+		if verb, txt, bubbleName, lang, code, bubbleType, target := decodeBubble(bubbleData); txt != "" || code != kBubbleCodeKnown {
 			name := bubbleName
 			if target == thinkNone {
 				if bubbleName == ThinkUnknownName {
@@ -1221,7 +1221,6 @@ func parseDrawState(data []byte, buildCache bool) error {
 				}
 				stateMu.Unlock()
 			}
-			bubbleType := typ & kBubbleTypeMask
 			showBubble := gs.SpeechBubbles && txt != "" && !blockBubbles && verb != "thinks"
 			if showBubble {
 				typeOK := true
@@ -1344,7 +1343,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 					}
 				}
 			}
-			if gs.MessagesToConsole {
+			if gs.MessagesToConsole || !isChatBubble(bubbleType) {
 				consoleMessage(msg)
 			} else {
 				chatMessage(msg)

--- a/util.go
+++ b/util.go
@@ -216,6 +216,10 @@ const (
 	kBubbleFar       = 0x80
 )
 
+func isChatBubble(t int) bool {
+	return t == kBubbleNormal || t == kBubbleWhisper || t == kBubbleYell
+}
+
 // bubble languages and codes from Public_cl.h
 const (
 	kBubbleHalfling = iota


### PR DESCRIPTION
## Summary
- avoid logging non-chat bubbles to the chat window
- expose bubble type from `decodeBubble` and add helper to detect chat bubbles

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ac281fc25c832a90b2a9e6c5542a44