### PR TITLE
Add script to download Piper binaries and voices

### DIFF
--- a/data/piper/.gitignore
+++ b/data/piper/.gitignore
@@ -1,0 +1,3 @@
+# Piper binaries and voices are downloaded here
+*
+!.gitignore

--- a/scripts/download_piper.sh
+++ b/scripts/download_piper.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PIPER_DIR="$ROOT_DIR/data/piper"
+
+mkdir -p "$PIPER_DIR"
+
+# Download piper binaries
+PIPER_RELEASE="https://github.com/rhasspy/piper/releases/latest/download"
+BINS=(
+  "piper_linux_x86_64.tar.gz"
+  "piper_macos_x64.tar.gz"
+  "piper_macos_aarch64.tar.gz"
+  "piper_windows_amd64.zip"
+)
+
+for f in "${BINS[@]}"; do
+  echo "Downloading $f..."
+  curl -L "$PIPER_RELEASE/$f" -o "$PIPER_DIR/$f"
+done
+
+# Download voices
+VOICE_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main"
+declare -A VOICES=(
+  [en_GB-jenny_dioco-medium]="en/en_GB/jenny_dioco/medium"
+  [en_GB-alan-medium]="en/en_GB/alan/medium"
+)
+
+for name in "${!VOICES[@]}"; do
+  path="${VOICES[$name]}"
+  vdir="$PIPER_DIR/$name"
+  mkdir -p "$vdir"
+  echo "Downloading voice $name..."
+  curl -L "$VOICE_BASE/$path/$name.onnx" -o "$vdir/$name.onnx"
+  curl -L "$VOICE_BASE/$path/$name.onnx.json" -o "$vdir/$name.onnx.json"
+  curl -L "$VOICE_BASE/$path/MODEL_CARD" -o "$vdir/MODEL_CARD"
+done
+
+echo "Piper binaries and voices downloaded to $PIPER_DIR"


### PR DESCRIPTION
## Summary
- add script to fetch Piper binaries for Linux, macOS, and Windows along with Jenny and Alan voices
- ignore downloaded Piper assets in `data/piper`

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package alsa not found; Package gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac29955a4c832aab25c84183e0ede3