### PR TITLE
Use hfc voices in piper download script

### DIFF
--- a/scripts/download_piper.sh
+++ b/scripts/download_piper.sh
@@ -28,8 +28,8 @@ done
 # Download voices
 VOICE_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main"
 declare -A VOICES=(
-  [en_GB-jenny_dioco-medium]="en/en_GB/jenny_dioco/medium"
-  [en_GB-alan-medium]="en/en_GB/alan/medium"
+  [en_US-hfc_female-medium]="en/en_US/hfc_female/medium"
+  [en_US-hfc_male-medium]="en/en_US/hfc_male/medium"
 )
 
 for name in "${!VOICES[@]}"; do


### PR DESCRIPTION
## Summary
- Update Piper download script to fetch en_US hfc male and female medium voices from Hugging Face

## Testing
- `shellcheck scripts/download_piper.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac31d28258832aa2195dcacd5ccdb9