### PR TITLE
Ensure piper binary is executable

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -179,8 +179,8 @@ func preparePiper(dataDir string) (string, string, string, error) {
 		if err := extractArchive(archivePath, binDir); err != nil {
 			return "", "", "", err
 		}
-		_ = os.Chmod(binPath, 0o755)
 	}
+	_ = os.Chmod(binPath, 0o755)
 
 	voice := "en_US-hfc_female-medium"
 	model := filepath.Join(piperDir, "voices", voice, voice+".onnx")


### PR DESCRIPTION
## Summary
- always chmod piper binary to ensure it is executable

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac38a50e50832aa5e99c0b666da095