### PR TITLE
Add optional Piper TTS downloads

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -182,9 +182,18 @@ func preparePiper(dataDir string) (string, string, string, error) {
 	}
 	_ = os.Chmod(binPath, 0o755)
 
+	voicesDir := filepath.Join(piperDir, "voices")
+	voices := []string{"en_US-hfc_female-medium", "en_US-hfc_male-medium"}
+	for _, v := range voices {
+		modelPath := filepath.Join(voicesDir, v, v+".onnx")
+		if _, err := os.Stat(modelPath); err != nil {
+			archive := filepath.Join(piperDir, v+".tar.gz")
+			_ = extractArchive(archive, voicesDir)
+		}
+	}
 	voice := "en_US-hfc_female-medium"
-	model := filepath.Join(piperDir, "voices", voice, voice+".onnx")
-	cfg := filepath.Join(piperDir, "voices", voice, voice+".onnx.json")
+	model := filepath.Join(voicesDir, voice, voice+".onnx")
+	cfg := filepath.Join(voicesDir, voice, voice+".onnx.json")
 	return binPath, model, cfg, nil
 }
 

--- a/ui.go
+++ b/ui.go
@@ -683,6 +683,9 @@ func makeDownloadsWindow() {
 
 	startedDownload := false
 	downloadSoundfont := false
+	downloadPiper := false
+	downloadPiperFem := false
+	downloadPiperMale := false
 
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL}
 
@@ -791,11 +794,18 @@ func makeDownloadsWindow() {
 		flow.AddItem(t)
 	}
 
+	if status.NeedSoundfont || status.NeedPiper || status.NeedPiperFem || status.NeedPiperMale {
+		opt, _ := eui.NewText()
+		opt.Text = "Optional downloads:"
+		opt.FontSize = 15
+		opt.Size = eui.Point{X: 320, Y: 25}
+		flow.AddItem(opt)
+	}
 	if status.NeedSoundfont {
 		sfCB, sfEvents := eui.NewCheckbox()
-		label := "Download soundfont"
+		label := "Download soundfont (music)"
 		if status.SoundfontSize > 0 {
-			label = fmt.Sprintf("Download soundfont (%s) (music test)", humanize.Bytes(uint64(status.SoundfontSize)))
+			label = fmt.Sprintf("Download soundfont (%s) (music)", humanize.Bytes(uint64(status.SoundfontSize)))
 		}
 		sfCB.Text = label
 		sfCB.Size = eui.Point{X: 320, Y: 24}
@@ -805,6 +815,51 @@ func makeDownloadsWindow() {
 			}
 		}
 		flow.AddItem(sfCB)
+	}
+	if status.NeedPiper {
+		pc, pe := eui.NewCheckbox()
+		label := "Download Piper TTS binary"
+		if status.PiperSize > 0 {
+			label = fmt.Sprintf("Download Piper TTS binary (%s)", humanize.Bytes(uint64(status.PiperSize)))
+		}
+		pc.Text = label
+		pc.Size = eui.Point{X: 320, Y: 24}
+		pe.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventCheckboxChanged {
+				downloadPiper = ev.Checked
+			}
+		}
+		flow.AddItem(pc)
+	}
+	if status.NeedPiperFem {
+		pf, pfe := eui.NewCheckbox()
+		label := "Download Piper female voice"
+		if status.PiperFemSize > 0 {
+			label = fmt.Sprintf("Download Piper female voice (%s)", humanize.Bytes(uint64(status.PiperFemSize)))
+		}
+		pf.Text = label + " (TTS)"
+		pf.Size = eui.Point{X: 320, Y: 24}
+		pfe.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventCheckboxChanged {
+				downloadPiperFem = ev.Checked
+			}
+		}
+		flow.AddItem(pf)
+	}
+	if status.NeedPiperMale {
+		pm, pme := eui.NewCheckbox()
+		label := "Download Piper male voice"
+		if status.PiperMaleSize > 0 {
+			label = fmt.Sprintf("Download Piper male voice (%s)", humanize.Bytes(uint64(status.PiperMaleSize)))
+		}
+		pm.Text = label + " (TTS)"
+		pm.Size = eui.Point{X: 320, Y: 24}
+		pme.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventCheckboxChanged {
+				downloadPiperMale = ev.Checked
+			}
+		}
+		flow.AddItem(pm)
 	}
 
 	z, _ := eui.NewText()
@@ -853,7 +908,7 @@ func makeDownloadsWindow() {
 			dlMutex.Lock()
 			defer dlMutex.Unlock()
 
-			if err := downloadDataFiles(clientVersion, status, downloadSoundfont); err != nil {
+			if err := downloadDataFiles(clientVersion, status, downloadSoundfont, downloadPiper, downloadPiperFem, downloadPiperMale); err != nil {
 				logError("download data files: %v", err)
 				// Present inline Retry and Quit buttons
 				flow.Contents = []*eui.ItemData{statusText, pb}


### PR DESCRIPTION
## Summary
- Allow downloading Piper binary and male/female voices alongside soundfont
- Show optional checkboxes for Piper and soundfont with clearer labels
- Extract downloaded Piper voice archives and reinitialize TTS

## Testing
- `go vet ./...`
- `go test ./...` *(fails: `glfw: X11: The DISPLAY environment variable is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3a964aa8832aaf9b739e68375217