### PR TITLE
Allow saving hotkeys with empty command

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -591,7 +591,7 @@ func finishHotkeyEdit(save bool) {
 				cmds = append(cmds, HotkeyCommand{Command: cmd, Function: fnName, Plugin: fnPlugin})
 			}
 		}
-		if combo != "" && len(cmds) > 0 {
+		if combo != "" {
 			hk := Hotkey{Name: name, Combo: combo, Commands: cmds}
 			hotkeysMu.Lock()
 			if editingHotkey >= 0 && editingHotkey < len(hotkeys) {

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -96,6 +96,24 @@ func TestHotkeyFunctionWithoutCommand(t *testing.T) {
 	}
 }
 
+// Test that a hotkey with an empty command saves correctly.
+func TestHotkeyEmptyCommandSaved(t *testing.T) {
+	hotkeys = nil
+	openHotkeyEditor(-1)
+	hotkeyComboText.Text = "Ctrl-E"
+	finishHotkeyEdit(true)
+
+	if len(hotkeys) != 1 {
+		t.Fatalf("hotkey not saved")
+	}
+	if len(hotkeys[0].Commands) != 0 {
+		t.Fatalf("expected no commands, got: %+v", hotkeys[0].Commands)
+	}
+	if hotkeyEditWin != nil {
+		hotkeyEditWin.Close()
+	}
+}
+
 // Test that a function-only hotkey persists through save/load cycles.
 func TestHotkeyFunctionPersisted(t *testing.T) {
 	hotkeys = []Hotkey{{Combo: "Ctrl-P", Commands: []HotkeyCommand{{Function: "ponder"}}}}


### PR DESCRIPTION
## Summary
- allow saving hotkeys even when no command text is provided
- add test ensuring an empty-command hotkey is persisted

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3e4eb8b4832a99d6d42825426e48