### PR TITLE
Lazily initialize piper for chat TTS

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -31,11 +31,6 @@ var (
 )
 
 func init() {
-	var err error
-	piperPath, piperModel, piperConfig, err = preparePiper(dataDirPath)
-	if err != nil {
-		logError("chat tts init: %v", err)
-	}
 	go chatTTSWorker()
 }
 
@@ -66,11 +61,24 @@ func chatTTSWorker() {
 	}
 }
 
+func ensurePiper() bool {
+	if piperPath != "" && piperModel != "" {
+		return true
+	}
+	var err error
+	piperPath, piperModel, piperConfig, err = preparePiper(dataDirPath)
+	if err != nil {
+		logError("chat tts init: %v", err)
+		return false
+	}
+	return true
+}
+
 func playChatTTS(text string) {
 	if audioContext == nil || blockTTS || gs.Mute {
 		return
 	}
-	if piperPath == "" {
+	if !ensurePiper() {
 		logError("chat tts: piper not initialized")
 		return
 	}


### PR DESCRIPTION
## Summary
- Initialize piper on demand for chat TTS instead of during package init
- Fall back to prepare piper if it hasn't been set up yet before synthesis

## Testing
- `go vet ./...` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3d675b14832a9d50340876b11228