### PR TITLE
Use raw Piper voice files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ If you build from source, you'll need Go **1.24+** and OpenGL/X11 dev libs on Li
 ### Optional extras
 - Drop a `background.png` and/or `splash.png` into `data/` for a custom look.
 
+### Text-to-speech voices
+Piper voices are stored as raw `.onnx` models with matching `.onnx.json` configs in `data/piper/voices`. The helper script `scripts/download_piper.sh` downloads these files individually.
+
 ---
 
 ## Power-user tricks

--- a/chat_tts.go
+++ b/chat_tts.go
@@ -191,17 +191,15 @@ func preparePiper(dataDir string) (string, string, string, error) {
 	_ = os.Chmod(binPath, 0o755)
 
 	voicesDir := filepath.Join(piperDir, "voices")
-	voices := []string{"en_US-hfc_female-medium", "en_US-hfc_male-medium"}
-	for _, v := range voices {
-		modelPath := filepath.Join(voicesDir, v, v+".onnx")
-		if _, err := os.Stat(modelPath); err != nil {
-			archive := filepath.Join(piperDir, v+".tar.gz")
-			_ = extractArchive(archive, voicesDir)
-		}
-	}
 	voice := "en_US-hfc_female-medium"
 	model := filepath.Join(voicesDir, voice, voice+".onnx")
 	cfg := filepath.Join(voicesDir, voice, voice+".onnx.json")
+	if _, err := os.Stat(model); err != nil {
+		return "", "", "", fmt.Errorf("missing piper voice model: %w", err)
+	}
+	if _, err := os.Stat(cfg); err != nil {
+		return "", "", "", fmt.Errorf("missing piper voice config: %w", err)
+	}
 	return binPath, model, cfg, nil
 }
 


### PR DESCRIPTION
## Summary
- load Piper voices as raw `.onnx` models without extracting tarballs
- fetch individual voice files during update
- document raw voice format in README

## Testing
- `go vet ./...` *(fails: X11, ALSA, GTK development libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac430e4c98832aaf1bee513a2ab1e5