### PR TITLE
add motion smoothing test

### DIFF
--- a/motion_smoothing_test.go
+++ b/motion_smoothing_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMotionSmoothingFailure(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	moviePath := filepath.Join(filepath.Dir(file), "clmovFiles", "2025a.clMov")
+	resetState()
+	initFont()
+	frames, err := parseMovie(moviePath, 200)
+	if err != nil {
+		t.Fatalf("parseMovie: %v", err)
+	}
+	parsed := 0
+	for _, f := range frames {
+		if err := parseDrawState(f.data, false); err != nil {
+			continue
+		}
+		parsed++
+		if parsed == 2 {
+			break
+		}
+	}
+	if parsed < 2 {
+		t.Fatalf("parsed %d frames", parsed)
+	}
+	if dx, dy, _, ok := pictureShift(state.prevPictures, state.pictures, maxInterpPixels); ok {
+		t.Fatalf("pictureShift succeeded unexpectedly: (%d,%d)", dx, dy)
+	}
+}


### PR DESCRIPTION
## Summary
- add regression test demonstrating pictureShift failure when parsing frames from 2025a movie

## Testing
- `xvfb-run -a go test -run TestMotionSmoothingFailure -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ac44ec3ad8832a970458a8f0f02878