### PR TITLE
Respect mixer music disable

### DIFF
--- a/synth.go
+++ b/synth.go
@@ -227,6 +227,10 @@ func Play(ctx *audio.Context, program int, notes []Note) error {
 		return errors.New("nil audio context")
 	}
 
+	if gs.Mute || !gs.Music || gs.MasterVolume <= 0 || gs.MusicVolume <= 0 {
+		return errors.New("music muted")
+	}
+
 	leftAll, rightAll, err := renderSong(program, notes)
 	if err != nil {
 		return err

--- a/synth_test.go
+++ b/synth_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hajimehoshi/ebiten/v2/audio"
 	meltysynth "github.com/sinshu/go-meltysynth/meltysynth"
 )
 
@@ -142,5 +143,18 @@ func TestPCMBufferDuration(t *testing.T) {
 	}
 	if diff > sampleRate/20 {
 		t.Fatalf("pcm length = %d samples, want ~%d", got, want)
+	}
+}
+
+func TestPlayMuted(t *testing.T) {
+	ctx := &audio.Context{}
+	orig := gs
+	gs.Mute = false
+	gs.Music = false
+	gs.MasterVolume = 1
+	gs.MusicVolume = 1
+	t.Cleanup(func() { gs = orig })
+	if err := Play(ctx, 0, nil); err == nil || err.Error() != "music muted" {
+		t.Fatalf("expected music muted error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- prevent tunes from playing when music is disabled in mixer
- add regression test for muted music playback

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac496e371c832a9bdd5ec98155e1fa