### PR TITLE
Disable audio features on errors

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -43,6 +43,19 @@ func stopAllTTS() {
 	}
 }
 
+func disableTTS() {
+	gs.ChatTTS = false
+	settingsDirty = true
+	stopAllTTS()
+	updateSoundVolume()
+	if ttsMixCB != nil {
+		ttsMixCB.Checked = false
+	}
+	if ttsMixSlider != nil {
+		ttsMixSlider.Disabled = true
+	}
+}
+
 func chatTTSWorker() {
 	for msg := range chatTTSQueue {
 		msgs := []string{msg}
@@ -80,17 +93,20 @@ func playChatTTS(text string) {
 	}
 	if !ensurePiper() {
 		logError("chat tts: piper not initialized")
+		disableTTS()
 		return
 	}
 
 	wavData, err := synthesizeWithPiper(text)
 	if err != nil {
 		logError("chat tts synthesize: %v", err)
+		disableTTS()
 		return
 	}
 	stream, err := wav.DecodeWithSampleRate(audioContext.SampleRate(), bytes.NewReader(wavData))
 	if err != nil {
 		logError("chat tts decode: %v", err)
+		disableTTS()
 		return
 	}
 
@@ -100,6 +116,7 @@ func playChatTTS(text string) {
 	p, err := audioContext.NewPlayer(stream)
 	if err != nil {
 		logError("chat tts player: %v", err)
+		disableTTS()
 		return
 	}
 

--- a/tune.go
+++ b/tune.go
@@ -80,11 +80,26 @@ var (
 	currentWho int
 )
 
+func disableMusic() {
+	gs.Music = false
+	settingsDirty = true
+	stopAllMusic()
+	clearTuneQueue()
+	updateSoundVolume()
+	if musicMixCB != nil {
+		musicMixCB.Checked = false
+	}
+	if musicMixSlider != nil {
+		musicMixSlider.Disabled = true
+	}
+}
+
 func startTuneWorker() {
 	tuneQueue = make(chan tuneJob, 128)
 	go func() {
 		for job := range tuneQueue {
 			if audioContext == nil {
+				disableMusic()
 				continue
 			}
 			currentMu.Lock()
@@ -96,6 +111,7 @@ func startTuneWorker() {
 					consoleMessage("play tune: " + err.Error())
 					chatMessage("play tune: " + err.Error())
 				}
+				disableMusic()
 			}
 			currentMu.Lock()
 			currentWho = 0
@@ -150,6 +166,7 @@ type parsedTune struct {
 // For example: "3 cde" plays on instrument #3. It returns any playback error.
 func playClanLordTune(tune string) error {
 	if audioContext == nil {
+		disableMusic()
 		return fmt.Errorf("audio disabled")
 	}
 	if blockMusic {


### PR DESCRIPTION
## Summary
- automatically disable chat TTS when synthesis or playback fails
- shut off music and queue when audio errors occur

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c19e3a8832a84266015ce8f155b