### PR TITLE
Fix piper binary path after extraction

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -213,6 +213,9 @@ func preparePiper(dataDir string) (string, string, string, error) {
 			return "", "", "", err
 		}
 	}
+	if info, err := os.Stat(binPath); err == nil && info.IsDir() {
+		binPath = filepath.Join(binPath, binName)
+	}
 	_ = os.Chmod(binPath, 0o755)
 
 	voicesDir := filepath.Join(piperDir, "voices")

--- a/prepare_piper_test.go
+++ b/prepare_piper_test.go
@@ -13,11 +13,11 @@ func TestPreparePiperVoiceArchive(t *testing.T) {
 	dataDir := t.TempDir()
 	piperDir := filepath.Join(dataDir, "piper")
 	binDir := filepath.Join(piperDir, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(binDir, "piper"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// create dummy piper binary to skip download
-	binPath := filepath.Join(binDir, "piper")
+	// create dummy piper binary inside nested directory to skip download
+	binPath := filepath.Join(binDir, "piper", "piper")
 	if err := os.WriteFile(binPath, []byte(""), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -56,9 +56,12 @@ func TestPreparePiperVoiceArchive(t *testing.T) {
 		t.Fatal(err)
 	}
 	// run preparePiper which should extract and remove tarball
-	_, model, cfg, err := preparePiper(dataDir)
+	path, model, cfg, err := preparePiper(dataDir)
 	if err != nil {
 		t.Fatalf("preparePiper: %v", err)
+	}
+	if path != binPath {
+		t.Fatalf("bin path = %v, want %v", path, binPath)
 	}
 	if _, err := os.Stat(tarPath); !os.IsNotExist(err) {
 		t.Fatalf("archive not removed")

--- a/update.go
+++ b/update.go
@@ -460,10 +460,14 @@ func checkDataFiles(clientVer int) (dataFilesStatus, error) {
 		archiveName = "piper_windows_amd64.zip"
 	}
 	binPath := filepath.Join(binDir, binName)
-	if _, err := os.Stat(binPath); err != nil {
-		if _, err := os.Stat(filepath.Join(piperDir, archiveName)); errors.Is(err, os.ErrNotExist) {
-			status.NeedPiper = true
-			status.PiperSize = headSize(extraDataBase + archiveName)
+	info, err := os.Stat(binPath)
+	if err != nil || info.IsDir() {
+		altPath := filepath.Join(binPath, binName)
+		if altInfo, altErr := os.Stat(altPath); altErr != nil || altInfo.IsDir() {
+			if _, err := os.Stat(filepath.Join(piperDir, archiveName)); errors.Is(err, os.ErrNotExist) {
+				status.NeedPiper = true
+				status.PiperSize = headSize(extraDataBase + archiveName)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- handle nested piper binary directory after extraction
- ensure update status checks for nested piper binary
- adapt tests to nested piper binary path

## Testing
- `go test ./...` *(fails: Package alsa was not found; fatal error: X11/extensions/Xrandr.h: No such file or directory; Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4fa90dd8832a9455471b82b3974b