### PR TITLE
test: cover motion smoothing weight cap

### DIFF
--- a/motion_smoothing_test.go
+++ b/motion_smoothing_test.go
@@ -32,3 +32,53 @@ func TestMotionSmoothingFailure(t *testing.T) {
 		t.Fatalf("pictureShift succeeded unexpectedly: (%d,%d)", dx, dy)
 	}
 }
+
+func TestPictureShiftWithStaticPictures(t *testing.T) {
+	gs.NoCaching = false
+
+	prev := []framePicture{
+		{PictID: 1, H: 0, V: 0},
+		{PictID: 2, H: 10, V: 10},
+		{PictID: 3, H: 20, V: 20},
+		{PictID: 4, H: 30, V: 30},
+	}
+	const dx, dy = 5, 7
+	cur := []framePicture{
+		{PictID: 1, H: 0 + dx, V: 0 + dy},
+		{PictID: 2, H: 10 + dx, V: 10 + dy},
+		{PictID: 3, H: 20 + dx, V: 20 + dy},
+		{PictID: 4, H: 30, V: 30}, // stationary heavy sprite
+	}
+
+	tests := []struct {
+		name    string
+		weights map[uint16]int
+	}{
+		{
+			name: "weightCap",
+			// Moving pictures outweigh the capped static sprite.
+			weights: map[uint16]int{1: 5000, 2: 5000, 3: 5000, 4: 200000},
+		},
+		{
+			name: "countFallback",
+			// Static sprite remains heavier, rely on count fallback.
+			weights: map[uint16]int{1: 10, 2: 10, 3: 10, 4: 200000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pixelCountMu.Lock()
+			pixelCountCache = make(map[uint16]int)
+			for id, w := range tt.weights {
+				pixelCountCache[id] = w
+			}
+			pixelCountMu.Unlock()
+
+			dxGot, dyGot, _, ok := pictureShift(prev, cur, maxInterpPixels)
+			if !ok || dxGot != dx || dyGot != dy {
+				t.Fatalf("pictureShift = (%d,%d) ok=%v", dxGot, dyGot, ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for pictureShift to ensure majority movement is detected even with heavy static sprites

## Testing
- `go test -run TestPictureShiftWithStaticPictures -count=1 -v` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51e7a220832ab357d3a022550641