### PR TITLE
Cap pictureShift weight and add background test

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -346,6 +346,8 @@ func pictureShift(prev, cur []framePicture, max int) (int, int, []int, bool) {
 		return 0, 0, nil, false
 	}
 
+	const maxWeight = 100000
+
 	counts := make(map[[2]int]int)
 	idxMap := make(map[[2]int]map[int]struct{})
 	total := 0
@@ -392,6 +394,9 @@ func pictureShift(prev, cur []framePicture, max int) (int, int, []int, bool) {
 				pixels = nonTransparentPixels(p.PictID)
 				pixelCache[p.PictID] = pixels
 			}
+			if pixels > maxWeight {
+				pixels = maxWeight
+			}
 			key := [2]int{bestDx, bestDy}
 			counts[key] += pixels
 			if idxMap[key] == nil {
@@ -426,7 +431,9 @@ func pictureShift(prev, cur []framePicture, max int) (int, int, []int, bool) {
 
 	// Collect candidate background indices for the winning motion.
 	// Filter out tiny sprites so we don't pin small pictures to
-	// the screen background when the camera pans.
+	// the screen background when the camera pans. Pixel weights above
+	// maxWeight (100k) are clamped so a single large background doesn't
+	// dominate motion detection.
 	const minBackgroundPixels = 900
 	idxs := make([]int, 0, len(idxMap[best]))
 	for idx := range idxMap[best] {
@@ -437,6 +444,9 @@ func pictureShift(prev, cur []framePicture, max int) (int, int, []int, bool) {
 				pixels = p
 			} else {
 				pixels = nonTransparentPixels(cur[idx].PictID)
+			}
+			if pixels > maxWeight {
+				pixels = maxWeight
 			}
 			if pixels >= minBackgroundPixels {
 				idxs = append(idxs, idx)

--- a/draw_test.go
+++ b/draw_test.go
@@ -71,3 +71,36 @@ func TestPictureOnEdge(t *testing.T) {
 		})
 	}
 }
+
+func TestPictureShiftBackgroundCap(t *testing.T) {
+	gs.NoCaching = false
+	pixelCountMu.Lock()
+	origCache := pixelCountCache
+	pixelCountCache = map[uint16]int{
+		1: 1000000,
+		2: 60000,
+		3: 60000,
+	}
+	pixelCountMu.Unlock()
+	defer func() {
+		pixelCountMu.Lock()
+		pixelCountCache = origCache
+		pixelCountMu.Unlock()
+	}()
+
+	prev := []framePicture{
+		{PictID: 1, H: 0, V: 0},
+		{PictID: 2, H: 10, V: 0},
+		{PictID: 3, H: 20, V: 0},
+	}
+	cur := []framePicture{
+		{PictID: 1, H: 0, V: 0},
+		{PictID: 2, H: 15, V: 0},
+		{PictID: 3, H: 25, V: 0},
+	}
+
+	dx, dy, _, ok := pictureShift(prev, cur, 100)
+	if !ok || dx != 5 || dy != 0 {
+		t.Fatalf("pictureShift = (%d,%d) ok=%v, want (5,0) true", dx, dy, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- Clamp per-picture pixel weight in `pictureShift` to avoid large backgrounds dominating
- Document pixel weight cap alongside `minBackgroundPixels`
- Add regression test verifying motion detection with oversized background

## Testing
- `xvfb-run -a go test -run PictureShiftBackgroundCap -count=1`
- `xvfb-run -a go test ./...` *(fails: missing assets / initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51e4a6f8832a9c9324b910e4403b