### PR TITLE
Ensure data files resolve relative to executable

### DIFF
--- a/datadir_test.go
+++ b/datadir_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDataDirPathRelativeToExecutable(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("dataDirPath uses user home on darwin")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	want := filepath.Join(filepath.Dir(exe), "data")
+	if dataDirPath != want {
+		t.Fatalf("dataDirPath = %q, want %q", dataDirPath, want)
+	}
+}

--- a/stats.go
+++ b/stats.go
@@ -18,9 +18,8 @@ type assetStats struct {
 const statsFile = "stats.json"
 
 // dataDirPath holds the absolute path to the "data" directory containing game
-// assets. Tests run from subpackages, so relying on the process working
-// directory is fragile. By resolving the path relative to this source file, the
-// assets can be found regardless of the current working directory.
+// assets. The path is resolved relative to the executable so assets are placed
+// alongside the binary regardless of the current working directory.
 var dataDirPath = func() string {
 	if runtime.GOOS == "darwin" {
 		if home, err := os.UserHomeDir(); err == nil {
@@ -29,9 +28,10 @@ var dataDirPath = func() string {
 			return p
 		}
 	}
-	// Determine the module root from this source file and append "data".
-	if _, file, _, ok := runtime.Caller(0); ok {
-		return filepath.Join(filepath.Dir(file), "data")
+	if exe, err := os.Executable(); err == nil {
+		if dir, err := filepath.Abs(filepath.Dir(exe)); err == nil {
+			return filepath.Join(dir, "data")
+		}
 	}
 	// Fallback to relative path.
 	return "data"


### PR DESCRIPTION
## Summary
- resolve data directory from executable location instead of build path
- add test ensuring dataDirPath points beside binary

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ac55b3c3c4832ab5b787c1f753351b