### PR TITLE
Add hotkey target substitution and right-click mobile capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Currently exposed symbols:
 - `gt.EnqueueCommand(cmd)` – queue a command silently for the next tick
 - `gt.ClientVersion` – current client version (read/write)
 
+Hotkey command strings may include `@`, which expands to the name of the last
+right-clicked mobile.
+
 All plugin code runs in the same process but is sandboxed to this approved list of
 functions and variables.
 

--- a/click_info.go
+++ b/click_info.go
@@ -11,7 +11,7 @@ type Mobile struct {
 	Colors uint8
 }
 
-// ClickInfo describes the last left-click in the game world.
+// ClickInfo describes the last click in the game world.
 type ClickInfo struct {
 	X, Y     int16
 	OnMobile bool
@@ -23,7 +23,7 @@ var (
 	lastClickMu sync.Mutex
 )
 
-// handleWorldClick records a left-click in the game world and captures
+// handleWorldClick records a click in the game world and captures
 // information about any mobile under the cursor.
 func handleWorldClick(x, y int16) {
 	info := ClickInfo{X: x, Y: y}

--- a/game.go
+++ b/game.go
@@ -758,6 +758,7 @@ func (g *Game) Update() error {
 	baseY := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
 	heldTime := inpututil.MouseButtonPressDuration(ebiten.MouseButtonLeft)
 	click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
+	rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
 
 	if click && pointInUI(mx, my) {
 		uiMouseDown = true
@@ -771,6 +772,9 @@ func (g *Game) Update() error {
 		}
 	}
 	if click && !uiMouseDown {
+		handleWorldClick(baseX, baseY)
+	}
+	if rightClick && !pointInUI(mx, my) {
 		handleWorldClick(baseX, baseY)
 	}
 

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -776,6 +776,18 @@ func isModifier(k ebiten.Key) bool {
 	return false
 }
 
+func applyHotkeyVars(cmd string) string {
+	if strings.Contains(cmd, "@") {
+		lastClickMu.Lock()
+		name := lastClick.Mobile.Name
+		lastClickMu.Unlock()
+		if name != "" {
+			cmd = strings.ReplaceAll(cmd, "@", name)
+		}
+	}
+	return cmd
+}
+
 func updateHotkeyRecording() {
 	if !recording {
 		return
@@ -842,6 +854,7 @@ func checkHotkeys() {
 						continue
 					}
 					// Show hotkey-triggered command as if it were typed
+					cmd = applyHotkeyVars(cmd)
 					if cmd != "" {
 						consoleMessage("> " + cmd)
 					}

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -282,3 +282,14 @@ func TestHotkeyEditorWrapsAndResizes(t *testing.T) {
 	}
 	hotkeyEditWin.Close()
 }
+
+// Test that @ in commands expands to the last clicked mobile name.
+func TestApplyHotkeyVars(t *testing.T) {
+	lastClickMu.Lock()
+	lastClick = ClickInfo{OnMobile: true, Mobile: Mobile{Name: "Target"}}
+	lastClickMu.Unlock()
+	got := applyHotkeyVars("/use @")
+	if got != "/use Target" {
+		t.Fatalf("got %q, want %q", got, "/use Target")
+	}
+}


### PR DESCRIPTION
## Summary
- Capture right-clicked mobiles so hotkeys can target them
- Support `@` placeholder in hotkey commands for last clicked mobile
- Document new hotkey `@` usage and cover with tests

## Testing
- `go vet ./...` *(fails: undefined references in dialog and GLFW packages)*
- `go test ./...` *(fails: GLFW requires DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac61f3b884832abd954333f3303565