### PR TITLE
docs: clarify example and default plugins

### DIFF
--- a/example_plugins/default_macros.go
+++ b/example_plugins/default_macros.go
@@ -3,14 +3,20 @@
 package main
 
 import (
-	"gt"
-	"strings"
+	"gt"      // small API exposed to plugins
+	"strings" // helpers for working with text
 )
 
+// PluginName shows in the plugin list. It must be unique so the client
+// knows which plugin this is.
 var PluginName = "Default Macros"
 
+// macroMap links short text to longer slash commands. When you type the short
+// version in the chat box the plugin swaps it for the full command.
 var macroMap = map[string]string{
+	// "??" becomes "/help "
 	"??": "/help ",
+	// "aa" becomes "/action "
 	"aa": "/action ",
 	"gg": "/give ",
 	"ii": "/info ",
@@ -20,6 +26,7 @@ var macroMap = map[string]string{
 	"pp": "/ponder ",
 	"sh": "/share ",
 	"sl": "/sleep",
+	// single letter macros work too
 	"t":  "/think ",
 	"tt": "/thinkto ",
 	"th": "/thank ",
@@ -31,14 +38,23 @@ var macroMap = map[string]string{
 	"yy": "/yell ",
 }
 
+// Init runs once when the plugin is loaded by the client.
 func Init() {
+	// Register a small function that runs every time you hit enter in the
+	// chat box. It can change what gets sent to the server.
 	gt.RegisterInputHandler(func(txt string) string {
+		// work with a lowercase copy so matching is easy
 		lower := strings.ToLower(txt)
-		for k, v := range macroMap {
-			if strings.HasPrefix(lower, k) {
-				return v + txt[len(k):]
+		// look through all known macros
+		for short, full := range macroMap {
+			// if the text starts with a macro
+			if strings.HasPrefix(lower, short) {
+				// replace the macro with the full command and
+				// keep the rest of what the user typed
+				return full + txt[len(short):]
 			}
 		}
+		// no macro matched; return the original text untouched
 		return txt
 	})
 }

--- a/example_plugins/example_ponder.go
+++ b/example_plugins/example_ponder.go
@@ -2,70 +2,75 @@
 
 package main
 
-// Example plugin showcasing most of the available scripting features.
-// This file is copied into the user's plugin directory on first run and
-// can be edited to experiment with the API.
+// This plugin shows many features of the scripting system. It is copied to the
+// user's plugin folder the first time the game runs so new users can edit it.
 
 import (
-	"fmt"
-	"strings"
+	"fmt"     // used for building strings like "HP 10/10"
+	"strings" // simple helpers for splitting and matching text
 
-	"gt"
+	"gt" // the small API exposed by the client
 )
 
 // PluginName must be unique across all loaded plugins.
 var PluginName = "Examples"
 
-// Init runs when the plugin is loaded and sets up commands, hotkeys and
-// event handlers.
+// Init runs once when the plugin is loaded and sets up everything below.
 func Init() {
-	// Log to the client log and console so the user knows we loaded.
+	// Print a message so the user knows the plugin is active.
 	gt.Logf("[examples] running on client %d", gt.ClientVersion)
 	gt.Console("[examples] hello, " + gt.PlayerName())
 
-	// Register a chat handler that notifies us when our name is mentioned.
+	// Watch chat. If someone types our name we show a popup.
 	gt.RegisterChatHandler(func(msg string) {
 		if strings.Contains(strings.ToLower(msg), strings.ToLower(gt.PlayerName())) {
 			gt.ShowNotification("Someone said your name!")
 		}
 	})
 
-	// Player updates stream through this handler.
+	// Watch player updates and print each player we see.
 	gt.RegisterPlayerHandler(func(p gt.Player) {
 		gt.Console("[examples] saw player: " + p.Name)
 	})
 
-	// Register a callable function and bind it to a hotkey.
+	// Register a function named "dance" and let Ctrl+D call it.
 	gt.RegisterFunc("dance", Dance)
 	gt.AddHotkeyFunc("ctrl+d", "dance")
 
-	// Bind a hotkey directly to a slash command.
+	// Bind Ctrl+N to run a slash command immediately.
 	gt.AddHotkey("ctrl+n", "/rad notify")
 
-	// Register the "/rad" command with many subcommands.
+	// Register the command "/rad" with many subcommands handled below.
 	gt.RegisterCommand("rad", handleRad)
 }
 
-// Dance sends a fun emote and plays a sound.
+// Dance sends a fun emote and plays a short sound.
 func Dance() {
 	gt.RunCommand("/me dances")
 	gt.PlaySound([]uint16{315})
 }
 
-// handleRad demonstrates a variety of features behind the "/rad" command.
+// handleRad runs whenever the player types "/rad ...".
+// args is everything after "/rad".
 func handleRad(args string) {
+	// Split the text into words.
 	fields := strings.Fields(args)
+	// If no words were given, show help text.
 	if len(fields) == 0 {
 		gt.Console("/rad [notify|stats|players|input <t>|equip <n>|unequip <n>|toggle <n>|hotkeys|rmhotkey <c>|click|frame|keys|say <t>|gear|has <n>|echoinput]")
 		return
 	}
+	// Look at the first word to decide what to do.
 	switch fields[0] {
 	case "notify":
+		// Show a simple popup.
 		gt.ShowNotification("Rad!")
 	case "stats":
+		// Print our HP and SP values.
 		s := gt.PlayerStats()
 		gt.Console(fmt.Sprintf("HP %d/%d SP %d/%d", s.HP, s.HPMax, s.SP, s.SPMax))
 	case "players":
+		// List the names of players we know about.
 		ps := gt.Players()
 		names := make([]string, 0, len(ps))
 		for _, p := range ps {
@@ -73,10 +78,13 @@ func handleRad(args string) {
 		}
 		gt.Console("players: " + strings.Join(names, ", "))
 	case "input":
+		// Set the chat box text.
 		gt.SetInputText(strings.Join(fields[1:], " "))
 	case "echoinput":
+		// Print whatever is in the chat box right now.
 		gt.Console("input: " + gt.InputText())
 	case "equip":
+		// Equip an item by name.
 		name := strings.Join(fields[1:], " ")
 		for _, it := range gt.Inventory() {
 			if strings.EqualFold(it.Name, name) {
@@ -86,6 +94,7 @@ func handleRad(args string) {
 		}
 		gt.Console("item not found")
 	case "unequip":
+		// Unequip an item by name.
 		name := strings.Join(fields[1:], " ")
 		for _, it := range gt.Inventory() {
 			if strings.EqualFold(it.Name, name) {
@@ -95,6 +104,7 @@ func handleRad(args string) {
 		}
 		gt.Console("item not equipped")
 	case "toggle":
+		// Toggle equip state for an item.
 		name := strings.Join(fields[1:], " ")
 		for _, it := range gt.Inventory() {
 			if strings.EqualFold(it.Name, name) {
@@ -104,6 +114,7 @@ func handleRad(args string) {
 		}
 		gt.Console("item not found")
 	case "hotkeys":
+		// List hotkeys that come from plugins.
 		for _, hk := range gt.Hotkeys() {
 			if hk.Disabled {
 				continue
@@ -120,10 +131,12 @@ func handleRad(args string) {
 			}
 		}
 	case "rmhotkey":
+		// Remove a hotkey by its combo string.
 		if len(fields) > 1 {
 			gt.RemoveHotkey(fields[1])
 		}
 	case "click":
+		// Tell us where we last clicked.
 		c := gt.LastClick()
 		if c.OnMobile {
 			gt.Console(fmt.Sprintf("clicked %s at %d,%d", c.Mobile.Name, c.X, c.Y))
@@ -131,19 +144,24 @@ func handleRad(args string) {
 			gt.Console(fmt.Sprintf("last click at %d,%d", c.X, c.Y))
 		}
 	case "frame":
+		// Show the current game frame number.
 		gt.Console(fmt.Sprintf("frame %d", gt.FrameNumber()))
 	case "keys":
+		// Show the state of some keys and mouse buttons.
 		gt.Console(fmt.Sprintf("space=%v just=%v mouse0=%v", gt.KeyPressed("space"), gt.KeyJustPressed("space"), gt.MousePressed("mouse0")))
 	case "say":
+		// Send a /say command with the rest of the text.
 		msg := strings.Join(fields[1:], " ")
 		gt.EnqueueCommand("/say " + msg)
 	case "gear":
+		// List names of currently equipped items.
 		names := []string{}
 		for _, it := range gt.EquippedItems() {
 			names = append(names, it.Name)
 		}
 		gt.Console("equipped: " + strings.Join(names, ", "))
 	case "has":
+		// Tell us if we have a specific item.
 		name := strings.Join(fields[1:], " ")
 		gt.Console(fmt.Sprintf("have %s: %v", name, gt.HasItem(name)))
 	default:


### PR DESCRIPTION
## Summary
- document how default macros expand short text into full commands
- walk through example plugin setup and command handlers in plain language

## Testing
- `gofmt -w example_plugins/default_macros.go example_plugins/example_ponder.go`
- `go vet -tags=plugin ./...` *(fails: X11/extensions/Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6788a68c832a9d686b9358ba440b