### PR TITLE
Initialize game before hotkey handling

### DIFF
--- a/game.go
+++ b/game.go
@@ -536,6 +536,10 @@ func (g *Game) Update() error {
 		return errors.New("shutdown")
 	default:
 	}
+	once.Do(func() {
+		initGame()
+	})
+
 	eui.Update() //We really need this to return eaten clicks
 	updateNotifications()
 	updateThinkMessages()
@@ -548,10 +552,6 @@ func (g *Game) Update() error {
 
 	updateHotkeyRecording()
 	checkHotkeys()
-
-	once.Do(func() {
-		initGame()
-	})
 
 	if debugWin != nil && debugWin.IsOpen() {
 		if time.Since(lastDebugStatsUpdate) >= time.Second {
@@ -763,9 +763,9 @@ func (g *Game) Update() error {
 		}
 	}
 
-	mx, my := ebiten.CursorPosition()
+	mx, my = ebiten.CursorPosition()
 	// Map mouse to world coordinates accounting for current draw scale/offset.
-	origX, origY, worldScale := worldDrawInfo()
+	origX, origY, worldScale = worldDrawInfo()
 	baseX := int16(float64(mx-origX)/worldScale - float64(fieldCenterX))
 	baseY := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
 	heldTime := inpututil.MouseButtonPressDuration(ebiten.MouseButtonLeft)


### PR DESCRIPTION
## Summary
- run initGame at the start of Game.Update so hotkeys are processed only after initialization
- fix repeated variable redeclarations during cursor updates to satisfy go vet

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac676ba8e8832ab7a617933e164fce