### PR TITLE
docs: show hotkey variable hints

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -166,6 +166,11 @@ func makeHotkeysWindow() {
 	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
 	hotkeysWin.AddItem(flow)
 
+	help := &eui.ItemData{ItemType: eui.ITEM_TEXT, Text: "@/@clicked -> last clicked, @hovered -> last hovered", Fixed: true}
+	help.Size = eui.Point{X: hotkeysWin.Size.X, Y: 20}
+	help.FontSize = 10
+	flow.AddItem(help)
+
 	btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
 	addBtn, addEvents := eui.NewButton()
 	addBtn.Text = "+"


### PR DESCRIPTION
## Summary
- document allowed variables (@/@clicked, @hovered) in hotkeys window

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69b6ccbc832a8a5ed40fc8e028b4