### PR TITLE
Skip hotkeys lacking target for @clicked/@hovered

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -776,25 +776,36 @@ func isModifier(k ebiten.Key) bool {
 	return false
 }
 
-func applyHotkeyVars(cmd string) string {
-	if strings.Contains(cmd, "@clicked") || strings.Contains(cmd, "@hovered") || strings.Contains(cmd, "@") {
+func applyHotkeyVars(cmd string) (string, bool) {
+	needClicked := strings.Contains(cmd, "@clicked") || strings.Contains(cmd, "@")
+	needHovered := strings.Contains(cmd, "@hovered")
+
+	var clickedName, hoveredName string
+	if needClicked {
 		lastClickMu.Lock()
-		clickedName := lastClick.Mobile.Name
+		clickedName = lastClick.Mobile.Name
 		lastClickMu.Unlock()
-
-		lastHoverMu.Lock()
-		hoveredName := lastHover.Mobile.Name
-		lastHoverMu.Unlock()
-
-		if clickedName != "" {
-			cmd = strings.ReplaceAll(cmd, "@clicked", clickedName)
-			cmd = strings.ReplaceAll(cmd, "@", clickedName)
-		}
-		if hoveredName != "" {
-			cmd = strings.ReplaceAll(cmd, "@hovered", hoveredName)
+		if clickedName == "" {
+			return "", false
 		}
 	}
-	return cmd
+	if needHovered {
+		lastHoverMu.Lock()
+		hoveredName = lastHover.Mobile.Name
+		lastHoverMu.Unlock()
+		if hoveredName == "" {
+			return "", false
+		}
+	}
+
+	if needClicked {
+		cmd = strings.ReplaceAll(cmd, "@clicked", clickedName)
+		cmd = strings.ReplaceAll(cmd, "@", clickedName)
+	}
+	if needHovered {
+		cmd = strings.ReplaceAll(cmd, "@hovered", hoveredName)
+	}
+	return cmd, true
 }
 
 func updateHotkeyRecording() {
@@ -867,7 +878,11 @@ func checkHotkeys() {
 						continue
 					}
 					// Show hotkey-triggered command as if it were typed
-					cmd = applyHotkeyVars(cmd)
+					var ok bool
+					cmd, ok = applyHotkeyVars(cmd)
+					if !ok {
+						return
+					}
 					if cmd != "" {
 						consoleMessage("> " + cmd)
 					}

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -288,9 +288,9 @@ func TestApplyHotkeyVars(t *testing.T) {
 	lastClickMu.Lock()
 	lastClick = ClickInfo{OnMobile: true, Mobile: Mobile{Name: "Target"}}
 	lastClickMu.Unlock()
-	got := applyHotkeyVars("/use @clicked")
-	if got != "/use Target" {
-		t.Fatalf("got %q, want %q", got, "/use Target")
+	got, ok := applyHotkeyVars("/use @clicked")
+	if !ok || got != "/use Target" {
+		t.Fatalf("got %q, ok %v", got, ok)
 	}
 }
 
@@ -299,8 +299,28 @@ func TestApplyHotkeyVarsHovered(t *testing.T) {
 	lastHoverMu.Lock()
 	lastHover = ClickInfo{OnMobile: true, Mobile: Mobile{Name: "Hover"}}
 	lastHoverMu.Unlock()
-	got := applyHotkeyVars("/inspect @hovered")
-	if got != "/inspect Hover" {
-		t.Fatalf("got %q, want %q", got, "/inspect Hover")
+	got, ok := applyHotkeyVars("/inspect @hovered")
+	if !ok || got != "/inspect Hover" {
+		t.Fatalf("got %q, ok %v", got, ok)
+	}
+}
+
+// Test that commands referencing @clicked don't fire without a target.
+func TestApplyHotkeyVarsNoClicked(t *testing.T) {
+	lastClickMu.Lock()
+	lastClick = ClickInfo{}
+	lastClickMu.Unlock()
+	if got, ok := applyHotkeyVars("/use @clicked"); ok || got != "" {
+		t.Fatalf("got %q, ok %v", got, ok)
+	}
+}
+
+// Test that commands referencing @hovered don't fire without a target.
+func TestApplyHotkeyVarsNoHovered(t *testing.T) {
+	lastHoverMu.Lock()
+	lastHover = ClickInfo{}
+	lastHoverMu.Unlock()
+	if got, ok := applyHotkeyVars("/inspect @hovered"); ok || got != "" {
+		t.Fatalf("got %q, ok %v", got, ok)
 	}
 }


### PR DESCRIPTION
## Summary
- Ensure hotkeys using `@clicked`, `@hovered`, or `@` only run when a target is available
- Show substituted target text in echoed command
- Cover missing target cases in tests

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6adc9790832a92b6ffd764f84088