### PR TITLE
Fix @clicked hotkey var for right-click

### DIFF
--- a/game.go
+++ b/game.go
@@ -550,9 +550,6 @@ func (g *Game) Update() error {
 	hy := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
 	updateWorldHover(hx, hy)
 
-	updateHotkeyRecording()
-	checkHotkeys()
-
 	if debugWin != nil && debugWin.IsOpen() {
 		if time.Since(lastDebugStatsUpdate) >= time.Second {
 			updateDebugStats()
@@ -819,6 +816,9 @@ func (g *Game) Update() error {
 	inputMu.Lock()
 	latestInput = inputState{mouseX: x, mouseY: y, mouseDown: walk}
 	inputMu.Unlock()
+
+	updateHotkeyRecording()
+	checkHotkeys()
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- ensure hotkey processing runs after click info updates so @clicked reflects latest right-click

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6beecb34832a98146c6095d33738