### PR TITLE
Skip hotkey equip when item already equipped

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -347,3 +347,17 @@ func TestApplyHotkeyVarsNoHovered(t *testing.T) {
 		t.Fatalf("got %q, ok %v", got, ok)
 	}
 }
+
+// Test that hotkey equip commands skip already equipped items.
+func TestHotkeyEquipAlreadyEquipped(t *testing.T) {
+	resetInventory()
+	addInventoryItem(100, -1, "Sword", true)
+	consoleLog = messageLog{max: maxMessages}
+	if !hotkeyEquipAlreadyEquipped("/equip 100") {
+		t.Fatalf("expected command to be skipped")
+	}
+	msgs := getConsoleMessages()
+	if len(msgs) == 0 || msgs[len(msgs)-1] != "Sword already equipped, skipping" {
+		t.Fatalf("unexpected console messages %v", msgs)
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -496,6 +496,11 @@ func pluginEquip(id uint16) {
 			continue
 		}
 		if it.Equipped {
+			name := it.Name
+			if name == "" {
+				name = fmt.Sprintf("%d", id)
+			}
+			consoleMessage(name + " already equipped, skipping")
 			return
 		}
 		if idx < 0 {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+// Test that plugin equip command skips already equipped items.
+func TestPluginEquipAlreadyEquipped(t *testing.T) {
+	resetInventory()
+	addInventoryItem(200, -1, "Shield", true)
+	consoleLog = messageLog{max: maxMessages}
+	pendingCommand = ""
+	pluginEquip(200)
+	msgs := getConsoleMessages()
+	if len(msgs) == 0 || msgs[len(msgs)-1] != "Shield already equipped, skipping" {
+		t.Fatalf("unexpected console messages %v", msgs)
+	}
+	if pendingCommand != "" {
+		t.Fatalf("pending command queued: %q", pendingCommand)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid equipping items via hotkeys when already equipped and log a message
- log message when plugin Equip is called on an equipped item
- add unit tests for equip skipping

## Testing
- `go test ./...` *(fails: GLFW library requires a display)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c869454832a957254e4bd3a0d66