### PR TITLE
Add plugin scroll-wheel input and chain swap example

### DIFF
--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -40,7 +40,7 @@ API
 - gt.Console(msg)
   Writes a message to the in-client console.
 - gt.AddHotkey(combo, command)
-  Registers a hotkey combo (e.g., "Digit1", "Shift-A", "Mouse Middle") that
+  Registers a hotkey combo (e.g., "Digit1", "Shift-A", "Mouse Middle", "WheelUp") that
   runs a slash-command like "/ponder hello world".
 - gt.AddHotkeyFunc(combo, funcName)
   Binds a hotkey to a named plugin function registered via RegisterFunc.
@@ -71,6 +71,8 @@ API
   Returns a slice of inventory items with ID, name, equipped state and quantity.
 - gt.ToggleEquip(id)
   Toggles the equipped state of the first matching item by ID.
+- gt.MouseWheel()
+  Returns the scroll wheel delta since the last frame as (dx, dy).
 
 
 Notes

--- a/example_plugins/chain_swap.go
+++ b/example_plugins/chain_swap.go
@@ -1,0 +1,49 @@
+//go:build plugin
+
+package main
+
+import (
+	"strings"
+
+	"gt"
+)
+
+var PluginName = "Chain Swap"
+
+var savedID uint16
+var lastFrame int
+
+func Init() {
+	gt.RegisterFunc("swapChain", swapChain)
+	gt.AddHotkeyFunc("WheelUp", "swapChain")
+	gt.AddHotkeyFunc("WheelDown", "swapChain")
+}
+
+func swapChain() {
+	frame := gt.FrameNumber()
+	if frame == lastFrame {
+		return
+	}
+	lastFrame = frame
+
+	var chainID uint16
+	var equipped *gt.InventoryItem
+	for _, it := range gt.Inventory() {
+		if strings.EqualFold(it.Name, "chain") {
+			chainID = it.ID
+		}
+		if it.Equipped && !strings.EqualFold(it.Name, "chain") {
+			item := it
+			equipped = &item
+		}
+	}
+	if chainID == 0 {
+		return
+	}
+	if equipped != nil {
+		savedID = equipped.ID
+		gt.Equip(chainID)
+	} else if savedID != 0 {
+		gt.Equip(savedID)
+	}
+}

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -151,6 +151,9 @@ func MousePressed(name string) bool { return false }
 // MouseJustPressed reports whether the given mouse button was pressed this frame.
 func MouseJustPressed(name string) bool { return false }
 
+// MouseWheel returns the scroll wheel delta since the last frame.
+func MouseWheel() (float64, float64) { return 0, 0 }
+
 // Mobile contains basic info about a clicked mobile.
 type Mobile struct {
 	Index  uint8

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -713,6 +713,19 @@ func detectCombo() string {
 	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonMiddle) {
 		return comboFromMouse(ebiten.MouseButtonMiddle)
 	}
+	wx, wy := ebiten.Wheel()
+	if wy > 0 {
+		return comboFromWheel("WheelUp")
+	}
+	if wy < 0 {
+		return comboFromWheel("WheelDown")
+	}
+	if wx > 0 {
+		return comboFromWheel("WheelRight")
+	}
+	if wx < 0 {
+		return comboFromWheel("WheelLeft")
+	}
 	for _, k := range inpututil.AppendJustPressedKeys(nil) {
 		if isModifier(k) {
 			continue
@@ -732,6 +745,12 @@ func comboFromMouse(b ebiten.MouseButton) string {
 	mods := currentMods()
 	name := mouseButtonName(b)
 	mods = append(mods, name)
+	return strings.Join(mods, "-")
+}
+
+func comboFromWheel(dir string) string {
+	mods := currentMods()
+	mods = append(mods, dir)
 	return strings.Join(mods, "-")
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -46,6 +46,7 @@ var basePluginExports = interp.Exports{
 		"KeyJustPressed":        reflect.ValueOf(pluginKeyJustPressed),
 		"MousePressed":          reflect.ValueOf(pluginMousePressed),
 		"MouseJustPressed":      reflect.ValueOf(pluginMouseJustPressed),
+		"MouseWheel":            reflect.ValueOf(pluginMouseWheel),
 		"LastClick":             reflect.ValueOf(pluginLastClick),
 		"ClickInfo":             reflect.ValueOf((*ClickInfo)(nil)),
 		"Mobile":                reflect.ValueOf((*Mobile)(nil)),
@@ -77,7 +78,7 @@ func exportsForPlugin(owner string) interp.Exports {
 	return ex
 }
 
-//go:embed example_plugins/example_ponder.go example_plugins/default_macros.go example_plugins/README.txt
+//go:embed example_plugins/example_ponder.go example_plugins/default_macros.go example_plugins/README.txt example_plugins/chain_swap.go
 var pluginExamples embed.FS
 
 func userPluginsDir() string {
@@ -110,6 +111,7 @@ func ensureDefaultPlugins() {
 		"plugins/example_ponder.go",
 		"plugins/default_macros.go",
 		"plugins/README.txt",
+		"plugins/chain_swap.go",
 	}
 	for _, src := range files {
 		data, err := pluginExamples.ReadFile(src)

--- a/plugin_extra.go
+++ b/plugin_extra.go
@@ -72,6 +72,10 @@ func pluginMouseJustPressed(name string) bool {
 	return false
 }
 
+func pluginMouseWheel() (float64, float64) {
+	return ebiten.Wheel()
+}
+
 func pluginLastClick() ClickInfo {
 	lastClickMu.Lock()
 	defer lastClickMu.Unlock()


### PR DESCRIPTION
## Summary
- Allow hotkeys to respond to mouse wheel directions
- Expose `MouseWheel` to plugin API and runtime
- Add Chain Swap plugin to toggle equipped item and chain

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6f767b60832a818d29b89917b798