### PR TITLE
Add TTS substitutions for directional and chat abbreviations

### DIFF
--- a/data/tts_substitute.txt
+++ b/data/tts_substitute.txt
@@ -1,0 +1,40 @@
+//Clan Lord creature names
+Darshak, dar shack
+Orga, or gah
+Wendecka, wen deck uh
+Noth, nawth
+Undine, un deen
+Arachne, uh rack nee
+Lyfelidae, lie fell ih day
+Yorilla, yo rilla
+T'rool, trool
+Scarmis, scar miss
+
+//Common places and terms
+Lok'Groton, lowk grow ton
+Thoom, thoom
+Anura, ah new rah
+Meshra, mesh rah
+
+//Abbreviations
+FMOCR, eff em oh see ar
+PJR, pee jay ar
+
+//Directions
+N, north
+S, south
+E, east
+W, west
+NE, north east
+NW, north west
+SE, south east
+SW, south west
+
+//Common chat terms
+LOL, ell oh ell
+AFK, ay eff kay
+BRB, bee are bee
+BBL, bee bee ell
+BTW, bee tee double you
+FYI, eff why eye
+OMG, oh em gee


### PR DESCRIPTION
## Summary
- expand `tts_substitute.txt` with common direction abbreviations (N, SW, etc.) and chat slang (LOL, AFK, etc.) so the TTS pronounces them clearly

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac711fefd8832a99c10972c3689dd0