### PR TITLE
Skip TTS for self chat messages

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -1,6 +1,9 @@
 package main
 
-import "sync"
+import (
+	"strings"
+	"sync"
+)
 
 const (
 	maxChatMessages = 1000
@@ -20,7 +23,7 @@ func chatMessage(msg string) {
 
 	updateChatWindow()
 
-	if gs.ChatTTS && !blockTTS {
+	if gs.ChatTTS && !blockTTS && !isSelfChatMessage(msg) {
 		speakChatMessage(msg)
 	} else if !gs.ChatTTS {
 		chatTTSDisabledOnce.Do(func() {
@@ -42,4 +45,26 @@ func getChatMessages() []string {
 		format = "3:04PM"
 	}
 	return chatLog.Entries(format, gs.ChatTimestamps)
+}
+
+func isSelfChatMessage(msg string) bool {
+	if playerName == "" {
+		return false
+	}
+	m := strings.ToLower(strings.TrimSpace(msg))
+	name := strings.ToLower(playerName)
+
+	if strings.HasPrefix(m, "("+name+" ") {
+		return true
+	}
+	if strings.HasPrefix(m, name+" ") {
+		rest := m[len(name)+1:]
+		verbs := []string{"says", "whispers", "yells", "thinks", "ponders"}
+		for _, v := range verbs {
+			if strings.HasPrefix(rest, v) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/chat_messages_test.go
+++ b/chat_messages_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestIsSelfChatMessage(t *testing.T) {
+	playerName = "Hero"
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"Hero says, hello there", true},
+		{"(Hero waves)", true},
+		{"Hero yells, hey!", true},
+		{"Bob says, hi", false},
+		{"You are sharing experiences with Bob.", false},
+		{"Hero has fallen", false},
+	}
+	for _, c := range cases {
+		if got := isSelfChatMessage(c.msg); got != c.want {
+			t.Errorf("isSelfChatMessage(%q) = %v; want %v", c.msg, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- avoid reading chat messages that originate from the player
- add unit tests for self-message detection

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac720fc0f4832aa7b744a4b5ddd5bf