### PR TITLE
Disable plugins and hotkeys by default

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -109,7 +109,7 @@ func loadHotkeys() {
 	}
 
 	// Ensure the default right-click use hotkey exists.
-	def := Hotkey{Name: "Click To Use", Combo: "RightClick", Commands: []HotkeyCommand{{Command: "/use @clicked"}}}
+	def := Hotkey{Name: "Click To Use", Combo: "RightClick", Commands: []HotkeyCommand{{Command: "/use @clicked"}}, Disabled: true}
 	exists := false
 	for _, hk := range newList {
 		if hk.Combo == def.Combo && hk.Plugin == "" {


### PR DESCRIPTION
## Summary
- Load available plugins without activating them and mark plugin hotkeys as disabled
- Add plugin hotkeys in a disabled state and include plugin context for function hotkeys
- Ship the default right-click hotkey disabled so users must opt-in

## Testing
- `go test ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7683e234832a935d3a71c053742f