### PR TITLE
Add plugin info view in plugin window

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -580,6 +580,42 @@ func pluginPlaySound(ids []uint16) {
 	playSound(ids)
 }
 
+func pluginCommandsFor(owner string) []string {
+	pluginMu.RLock()
+	defer pluginMu.RUnlock()
+	var list []string
+	for cmd, o := range pluginCommandOwners {
+		if o == owner {
+			list = append(list, cmd)
+		}
+	}
+	return list
+}
+
+func pluginFunctionsFor(owner string) []string {
+	pluginMu.RLock()
+	defer pluginMu.RUnlock()
+	var list []string
+	for fn := range pluginFuncs[owner] {
+		list = append(list, fn)
+	}
+	return list
+}
+
+func pluginSource(owner string) string {
+	pluginMu.RLock()
+	path := pluginPaths[owner]
+	pluginMu.RUnlock()
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func loadPlugins() {
 	ensureDefaultPlugins()
 


### PR DESCRIPTION
## Summary
- add helper functions to inspect plugin commands, functions, and source
- add "View" button for each plugin and display detailed info window

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac780d30ac832ab6f4eb985a1c6052