### PR TITLE
Add community macro plugins

### DIFF
--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -83,3 +83,25 @@ Notes
   gothoom binary; both locations are scanned.
 - Hotkeys added by plugins appear in a separate "Plugin Hotkeys" section of
   the hotkeys window and can be enabled or disabled there.
+
+Additional Example Plugins
+-------------------------
+sharecads.go
+  - Command: /shcads toggles automatic sharing when heal messages are seen.
+  - Hotkey: Shift-S toggles Sharecads.
+
+kudzu.go
+  - Commands: /zu plants a seed, /zuget adds a seed to a bag, /zustore removes seeds, /zutrans <args> transfers seeds.
+  - Hotkey: Shift-K plants a seed.
+
+coin_lord.go
+  - Commands: /cw start or stop tracking, /cwnew resets totals, /cwdata shows current coin statistics.
+  - Hotkey: Shift-C prints coin statistics.
+
+bard.go
+  - Command: /playsong <instrument> <notes> pulls an instrument from the case, plays it, and stores it again.
+  - Hotkey: Shift-B plays a sample Windweft tune.
+
+dance.go
+  - Command: /dance performs the standard dance.
+  - Hotkey: Shift-D runs /dance.

--- a/example_plugins/bard.go
+++ b/example_plugins/bard.go
@@ -1,0 +1,27 @@
+//go:build plugin
+
+package main
+
+import (
+	"gt"
+	"strings"
+)
+
+var PluginName = "bard_macros"
+
+func Init() {
+	gt.RegisterCommand("playsong", func(args string) {
+		parts := strings.Fields(args)
+		if len(parts) < 2 {
+			return
+		}
+		inst := parts[0]
+		notes := strings.Join(parts[1:], " ")
+		gt.RunCommand("/equip instrument case")
+		gt.RunCommand("/useitem instrument case /remove " + inst)
+		gt.RunCommand("/equip " + inst)
+		gt.RunCommand("/useitem " + inst + " " + notes)
+		gt.RunCommand("/useitem instrument case /add " + inst)
+	})
+	gt.AddHotkey("Shift-B", "/playsong pine_flute cfedcgdec")
+}

--- a/example_plugins/coin_lord.go
+++ b/example_plugins/coin_lord.go
@@ -1,0 +1,65 @@
+//go:build plugin
+
+package main
+
+import (
+	"fmt"
+	"gt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var PluginName = "coin_lord"
+
+var (
+	clRunning bool
+	clTotal   int
+	clStart   time.Time
+)
+
+func Init() {
+	gt.RegisterCommand("cw", func(args string) {
+		clRunning = !clRunning
+		if clRunning {
+			clStart = time.Now()
+			clTotal = 0
+			gt.Console("Coin Lord started")
+		} else {
+			gt.Console("Coin Lord stopped")
+		}
+	})
+	gt.RegisterCommand("cwnew", func(args string) {
+		clStart = time.Now()
+		clTotal = 0
+		gt.Console("Coin data reset")
+	})
+	gt.RegisterCommand("cwdata", func(args string) {
+		hours := time.Since(clStart).Hours()
+		rate := 0.0
+		if hours > 0 {
+			rate = float64(clTotal) / hours
+		}
+		gt.Console(fmt.Sprintf("Coins: %d (%.0f/hr)", clTotal, rate))
+	})
+	gt.RegisterChatHandler(clHandle)
+	gt.AddHotkey("Shift-C", "/cwdata")
+}
+
+func clHandle(msg string) {
+	if !clRunning {
+		return
+	}
+	if !strings.HasPrefix(msg, "You get ") || !strings.Contains(msg, " coin") {
+		return
+	}
+	fields := strings.Fields(msg)
+	if len(fields) < 3 {
+		return
+	}
+	n, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return
+	}
+	clTotal += n
+}

--- a/example_plugins/dance.go
+++ b/example_plugins/dance.go
@@ -1,0 +1,14 @@
+//go:build plugin
+
+package main
+
+import "gt"
+
+var PluginName = "dance_macros"
+
+func Init() {
+	gt.RegisterCommand("dance", func(args string) {
+		gt.RunCommand("/dance")
+	})
+	gt.AddHotkey("Shift-D", "/dance")
+}

--- a/example_plugins/kudzu.go
+++ b/example_plugins/kudzu.go
@@ -1,0 +1,25 @@
+//go:build plugin
+
+package main
+
+import "gt"
+
+var PluginName = "kudzu"
+
+func Init() {
+	gt.RegisterCommand("zu", func(args string) {
+		gt.RunCommand("/plant kudzu")
+	})
+	gt.RegisterCommand("zuget", func(args string) {
+		gt.RunCommand("/useitem bag of kudzu seedlings /add")
+	})
+	gt.RegisterCommand("zustore", func(args string) {
+		gt.RunCommand("/useitem bag of kudzu seedlings /remove")
+	})
+	gt.RegisterCommand("zutrans", func(args string) {
+		if args != "" {
+			gt.RunCommand("/transfer " + args)
+		}
+	})
+	gt.AddHotkey("Shift-K", "/zu")
+}

--- a/example_plugins/sharecads.go
+++ b/example_plugins/sharecads.go
@@ -1,0 +1,59 @@
+//go:build plugin
+
+package main
+
+import (
+	"gt"
+	"strings"
+	"time"
+)
+
+var PluginName = "sharecads"
+
+var (
+	scOn    bool
+	scShare = map[string]time.Time{}
+)
+
+func Init() {
+	gt.RegisterCommand("shcads", func(args string) {
+		scOn = !scOn
+		if scOn {
+			gt.Console("* Sharecads enabled")
+		} else {
+			gt.Console("* Sharecads disabled")
+		}
+	})
+	gt.RegisterChatHandler(handleSharecads)
+	gt.AddHotkey("Shift-S", "/shcads")
+}
+
+func handleSharecads(msg string) {
+	if !scOn {
+		return
+	}
+	const prefix = "You sense healing energy from "
+	if !strings.HasPrefix(msg, prefix) {
+		return
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(msg, prefix), ".")
+	now := time.Now()
+	if t, ok := scShare[name]; ok && now.Sub(t) < 3*time.Second {
+		return
+	}
+	if len(scShare) >= 5 {
+		oldest := now
+		oldestName := ""
+		for n, ts := range scShare {
+			if ts.Before(oldest) {
+				oldest = ts
+				oldestName = n
+			}
+		}
+		if oldestName != "" {
+			delete(scShare, oldestName)
+		}
+	}
+	scShare[name] = now
+	gt.EnqueueCommand("/share " + name)
+}

--- a/plugin.go
+++ b/plugin.go
@@ -78,7 +78,7 @@ func exportsForPlugin(owner string) interp.Exports {
 	return ex
 }
 
-//go:embed example_plugins/example_ponder.go example_plugins/default_macros.go example_plugins/README.txt example_plugins/chain_swap.go example_plugins/healer_selfheal.go
+//go:embed example_plugins/example_ponder.go example_plugins/default_macros.go example_plugins/README.txt example_plugins/chain_swap.go example_plugins/healer_selfheal.go example_plugins/coin_lord.go example_plugins/sharecads.go example_plugins/kudzu.go example_plugins/bard.go example_plugins/dance.go
 var pluginExamples embed.FS
 
 func userPluginsDir() string {
@@ -113,6 +113,11 @@ func ensureDefaultPlugins() {
 		"plugins/healer_selfheal.go",
 		"plugins/README.txt",
 		"plugins/chain_swap.go",
+		"plugins/coin_lord.go",
+		"plugins/sharecads.go",
+		"plugins/kudzu.go",
+		"plugins/bard.go",
+		"plugins/dance.go",
 	}
 	for _, src := range files {
 		data, err := pluginExamples.ReadFile(src)


### PR DESCRIPTION
## Summary
- add plugins for Sharecads, Kudzu, Coin Lord, Bard instruments, and dance macros
- embed new example plugins and install them by default

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; Package gtk+-3.0 was not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bffee9c832a9ac5c9dd13b6de4a