### PR TITLE
Remove plugin function hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ Currently exposed symbols:
 
 - `gt.Logf(format, ...any)` – write to the client log
 - `gt.AddHotkey(combo, command)` – bind a hotkey to a slash command
-- `gt.AddHotkeyFunc(combo, funcName)` – bind a hotkey to a plugin function
 - `gt.RegisterCommand(name, func(args string))` – handle a local slash command
-- `gt.RegisterFunc(name, func())` – register a callable plugin function
 - `gt.RunCommand(cmd)` – echo and send a command immediately
 - `gt.EnqueueCommand(cmd)` – queue a command silently for the next tick
 - `gt.ClientVersion` – current client version (read/write)

--- a/data/plugins/README.txt
+++ b/data/plugins/README.txt
@@ -40,17 +40,12 @@ API
 - gt.AddHotkey(combo, command)
   Registers a hotkey combo (e.g., "Digit1", "Shift-A", "Mouse Middle") that
   runs a slash-command like "/ponder hello world".
-- gt.AddHotkeyFunc(combo, funcName)
-  Binds a hotkey to a named plugin function registered via RegisterFunc.
 - gt.Hotkeys()
   Returns the hotkeys registered by the calling plugin.
 - gt.RemoveHotkey(combo)
   Removes a previously registered hotkey owned by the plugin.
 - gt.RegisterCommand(name, func(args string))
   Handles a local slash command like "/name" and receives the rest as args.
-- gt.RegisterFunc(name, func())
-  Registers a callable function invokable from hotkeys via AddHotkeyFunc or by
-  using a hotkey command string "plugin:name".
 - gt.RunCommand(cmd)
   Echoes to the console and queues a command to send immediately to the server.
 - gt.EnqueueCommand(cmd)

--- a/data/plugins/example_ponder.go
+++ b/data/plugins/example_ponder.go
@@ -9,20 +9,13 @@ import (
 var PluginName = "Example"
 
 // Highly recommend vscodium or vscode with the official golang plugin!
-func Wave() {
-	gt.RunCommand("/ponder hello world")
-}
-
 func Init() {
-	//This makes the function available in the hotkey editor
-	gt.RegisterFunc("wave", Wave)
-
-	//This registers a slash command '/example'
+	// This registers a slash command '/example'
 	gt.RegisterCommand("example", func(args string) {
 		if args == "" {
 			args = "hello world"
 		}
-		//This enters this command and sends it
+		// This enters this command and sends it
 		gt.RunCommand("/ponder " + args)
 	})
 }

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -42,17 +42,12 @@ API
 - gt.AddHotkey(combo, command)
   Registers a hotkey combo (e.g., "Digit1", "Shift-A", "Mouse Middle", "WheelUp") that
   runs a slash-command like "/ponder hello world".
-- gt.AddHotkeyFunc(combo, funcName)
-  Binds a hotkey to a named plugin function registered via RegisterFunc.
 - gt.Hotkeys()
   Returns the hotkeys registered by the calling plugin.
 - gt.RemoveHotkey(combo)
   Removes a previously registered hotkey owned by the plugin.
 - gt.RegisterCommand(name, func(args string))
   Handles a local slash command like "/name" and receives the rest as args.
-- gt.RegisterFunc(name, func())
-  Registers a callable function invokable from hotkeys via AddHotkeyFunc or by
-  using a hotkey command string "plugin:name".
 - gt.RunCommand(cmd)
   Echoes to the console and queues a command to send immediately to the server.
 - gt.EnqueueCommand(cmd)

--- a/example_plugins/chain_swap.go
+++ b/example_plugins/chain_swap.go
@@ -14,9 +14,9 @@ var savedID uint16
 var lastFrame int
 
 func Init() {
-	gt.RegisterFunc("swapChain", swapChain)
-	gt.AddHotkeyFunc("WheelUp", "swapChain")
-	gt.AddHotkeyFunc("WheelDown", "swapChain")
+	gt.RegisterCommand("swapchain", func(string) { swapChain() })
+	gt.AddHotkey("WheelUp", "/swapchain")
+	gt.AddHotkey("WheelDown", "/swapchain")
 }
 
 func swapChain() {

--- a/example_plugins/example_ponder.go
+++ b/example_plugins/example_ponder.go
@@ -33,9 +33,8 @@ func Init() {
 		gt.Console("[examples] saw player: " + p.Name)
 	})
 
-	// Register a function named "dance" and let Ctrl+D call it.
-	gt.RegisterFunc("dance", Dance)
-	gt.AddHotkeyFunc("ctrl+d", "dance")
+	// Bind Ctrl+D to call our "dance" subcommand.
+	gt.AddHotkey("ctrl+d", "/rad dance")
 
 	// Bind Ctrl+N to run a slash command immediately.
 	gt.AddHotkey("ctrl+n", "/rad notify")
@@ -164,6 +163,9 @@ func handleRad(args string) {
 		// Tell us if we have a specific item.
 		name := strings.Join(fields[1:], " ")
 		gt.Console(fmt.Sprintf("have %s: %v", name, gt.HasItem(name)))
+	case "dance":
+		// Run the dance action.
+		Dance()
 	default:
 		gt.Console("unknown subcommand")
 	}

--- a/example_plugins/weapon_cycle.go
+++ b/example_plugins/weapon_cycle.go
@@ -15,8 +15,8 @@ var cycleItems = []string{"Axe", "Short Sword", "Dagger", "Chocolate"}
 
 // Init binds F3 to cycle through weapons.
 func Init() {
-	gt.RegisterFunc("cycleWeapon", cycleWeapon)
-	gt.AddHotkeyFunc("F3", "cycleWeapon")
+	gt.RegisterCommand("cycleweapon", func(string) { cycleWeapon() })
+	gt.AddHotkey("F3", "/cycleweapon")
 }
 
 func cycleWeapon() {

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -24,14 +24,9 @@ func ShowNotification(msg string) {}
 // AddHotkey binds a key combo to a slash command.
 func AddHotkey(combo, command string) {}
 
-// AddHotkeyFunc binds a key combo to a registered plugin function.
-func AddHotkeyFunc(combo, funcName string) {}
-
-// HotkeyCommand mirrors the command or function bound to a hotkey.
+// HotkeyCommand mirrors the command bound to a hotkey.
 type HotkeyCommand struct {
-	Command  string
-	Function string
-	Plugin   string
+	Command string
 }
 
 // Hotkey represents a single key binding and its metadata.
@@ -51,9 +46,6 @@ func RemoveHotkey(combo string) {}
 
 // RegisterCommand handles a local slash command like "/example".
 func RegisterCommand(command string, handler func(args string)) {}
-
-// RegisterFunc registers a callable function invokable via AddHotkeyFunc.
-func RegisterFunc(command string, handler func()) {}
 
 // RunCommand queues a command to send immediately to the server.
 func RunCommand(cmd string) {}

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,9 +23,7 @@ import (
 const hotkeysFile = "global-hotkeys.json"
 
 type HotkeyCommand struct {
-	Command  string `json:"command,omitempty"`
-	Function string `json:"function,omitempty"`
-	Plugin   string `json:"plugin,omitempty"`
+	Command string `json:"command,omitempty"`
 }
 
 type Hotkey struct {
@@ -35,11 +32,6 @@ type Hotkey struct {
 	Commands []HotkeyCommand `json:"commands"`
 	Plugin   string          `json:"plugin,omitempty"`
 	Disabled bool            `json:"disabled,omitempty"`
-}
-
-type hotkeyFuncRef struct {
-	Name   string
-	Plugin string
 }
 
 var (
@@ -52,8 +44,6 @@ var (
 	hotkeyNameInput  *eui.ItemData
 	hotkeyCmdSection *eui.ItemData
 	hotkeyCmdInputs  []*eui.ItemData
-	hotkeyCmdFuncs   []hotkeyFuncRef
-	hotkeyFnLabel    *eui.ItemData
 	editingHotkey    int = -1
 
 	recording     bool
@@ -84,21 +74,15 @@ func loadHotkeys() {
 		for _, r := range raw {
 			hk := Hotkey{Combo: r.Combo, Name: r.Name, Plugin: r.Plugin, Disabled: r.Disabled}
 			if len(r.Commands) > 0 {
-				hk.Commands = make([]HotkeyCommand, len(r.Commands))
-				copy(hk.Commands, r.Commands)
-				for i := range hk.Commands {
-					c := &hk.Commands[i]
-					if c.Function == "" && strings.HasPrefix(strings.ToLower(c.Command), "plugin:") {
-						c.Function = strings.TrimSpace(strings.TrimPrefix(c.Command, "plugin:"))
-						c.Command = ""
+				for _, c := range r.Commands {
+					cmd := strings.TrimSpace(c.Command)
+					if cmd != "" {
+						hk.Commands = append(hk.Commands, HotkeyCommand{Command: cmd})
 					}
 				}
 			} else if r.Command != "" {
 				cmd := strings.TrimSpace(r.Command + " " + r.Text)
-				if strings.HasPrefix(strings.ToLower(cmd), "plugin:") {
-					fn := strings.TrimSpace(strings.TrimPrefix(cmd, "plugin:"))
-					hk.Commands = []HotkeyCommand{{Function: fn}}
-				} else if cmd != "" {
+				if cmd != "" {
 					hk.Commands = []HotkeyCommand{{Command: cmd}}
 				}
 			}
@@ -235,13 +219,6 @@ func refreshHotkeysList() {
 		}
 		if len(hk.Commands) > 0 {
 			text := hk.Commands[0].Command
-			if text == "" && hk.Commands[0].Function != "" {
-				if hk.Commands[0].Plugin != "" {
-					text = hk.Commands[0].Plugin + "->" + hk.Commands[0].Function
-				} else {
-					text = "plugin:" + hk.Commands[0].Function
-				}
-			}
 			if len(hk.Commands) > 1 {
 				text += " ..."
 			}
@@ -400,77 +377,18 @@ func openHotkeyEditor(idx int) {
 	hotkeyCmdSection = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
 	flow.AddItem(hotkeyCmdSection)
 	hotkeyCmdInputs = nil
-	hotkeyCmdFuncs = nil
 
-	// Row to add a plain command input
+	// Row to add a command input
 	addCmdRow, addCmdEvents := eui.NewButton()
 	addCmdRow.Text = "+"
 	addCmdRow.Size = eui.Point{X: 20, Y: 20}
 	addCmdRow.FontSize = 14
 	addCmdEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-			addHotkeyCommand("", "", "")
+			addHotkeyCommand("")
 		}
 	}
 	flow.AddItem(addCmdRow)
-
-	// Row to add a plugin function via dropdown
-	fnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
-	fnLabel, _ := eui.NewText()
-	fnLabel.Text = "Function:"
-	fnLabel.Size = eui.Point{X: 64, Y: 20}
-	fnLabel.FontSize = 12
-	fnRow.AddItem(fnLabel)
-
-	fnDD, fnDDEvents := eui.NewDropdown()
-	fnDD.Size = eui.Point{X: hotkeyEditWin.Size.X - 120, Y: 20}
-	infos := pluginFunctionInfos()
-	fnNames := make([]string, len(infos))
-	fnKeys := make([]string, len(infos))
-	fnDisp := make([]string, len(infos))
-	for i, inf := range infos {
-		fnNames[i] = inf.Name
-		fnKeys[i] = inf.Plugin
-		if inf.Plugin != "" {
-			fnDisp[i] = inf.Plugin + "->" + inf.Name
-		} else {
-			fnDisp[i] = inf.Name
-		}
-	}
-	fnDD.Options = append([]string{"none"}, fnDisp...)
-	fnDD.Selected = 0
-	fnSel := ""
-	fnSelKey := ""
-	fnDDEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventDropdownSelected {
-			fnDD.Selected = ev.Index
-			if ev.Index > 0 && ev.Index <= len(fnNames) {
-				fnSel = fnNames[ev.Index-1]
-				fnSelKey = fnKeys[ev.Index-1]
-			} else {
-				fnSel = ""
-				fnSelKey = ""
-			}
-			selectHotkeyFunction(fnSel, fnSelKey)
-		}
-	}
-	fnRow.AddItem(fnDD)
-
-	addFnBtn, addFnEv := eui.NewButton()
-	addFnBtn.Text = "+"
-	addFnBtn.Size = eui.Point{X: 20, Y: 20}
-	addFnBtn.FontSize = 14
-	addFnBtn.Disabled = len(fnNames) == 0
-	addFnEv.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			if fnSel == "" {
-				return
-			}
-			addHotkeyCommand("", fnSel, fnSelKey)
-		}
-	}
-	fnRow.AddItem(addFnBtn)
-	flow.AddItem(fnRow)
 
 	btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
 	okBtn, okEvents := eui.NewButton()
@@ -505,27 +423,15 @@ func openHotkeyEditor(idx int) {
 		hotkeyComboText.Text = hk.Combo
 		hotkeyNameInput.Text = hk.Name
 		if len(hk.Commands) > 0 {
-			firstFn := hk.Commands[0].Function
-			firstPlugin := hk.Commands[0].Plugin
-			if firstFn != "" {
-				fnSel = firstFn
-				fnSelKey = firstPlugin
-				for i, inf := range infos {
-					if inf.Name == firstFn && inf.Plugin == firstPlugin {
-						fnDD.Selected = i + 1
-						break
-					}
-				}
-			}
 			for _, c := range hk.Commands {
-				addHotkeyCommand(c.Command, c.Function, c.Plugin)
+				addHotkeyCommand(c.Command)
 			}
 		} else {
-			addHotkeyCommand("", "", "")
+			addHotkeyCommand("")
 		}
 	} else {
 		hotkeysMu.RUnlock()
-		addHotkeyCommand("", "", "")
+		addHotkeyCommand("")
 	}
 
 	hotkeyEditWin.AddWindow(true)
@@ -533,23 +439,9 @@ func openHotkeyEditor(idx int) {
 	wrapHotkeyInputs()
 }
 
-func addHotkeyCommand(cmd, fn, plugin string) {
+func addHotkeyCommand(cmd string) {
 	if hotkeyCmdSection == nil {
 		return
-	}
-	if fn != "" {
-		fnLabel, _ := eui.NewText()
-		disp := fn
-		if plugin != "" {
-			disp = plugin + "->" + fn
-		}
-		fnLabel.Text = "Function: " + disp
-		fnLabel.Size = eui.Point{X: hotkeyEditWin.Size.X - 40, Y: 20}
-		fnLabel.FontSize = 12
-		hotkeyCmdSection.AddItem(fnLabel)
-		if len(hotkeyCmdInputs) == 0 {
-			hotkeyFnLabel = fnLabel
-		}
 	}
 	cmdLabel, _ := eui.NewText()
 	cmdLabel.Text = "Command:"
@@ -570,45 +462,9 @@ func addHotkeyCommand(cmd, fn, plugin string) {
 	}
 	hotkeyCmdSection.AddItem(cmdInput)
 	hotkeyCmdInputs = append(hotkeyCmdInputs, cmdInput)
-	hotkeyCmdFuncs = append(hotkeyCmdFuncs, hotkeyFuncRef{Name: fn, Plugin: plugin})
 
 	hotkeyEditWin.Refresh()
 	wrapHotkeyInputs()
-}
-
-// selectHotkeyFunction applies a function selection to the first blank
-// hotkey command slot. It updates the stored function reference and shows a
-// label in the editor so users don't need to press the add button for the
-// initial function choice.
-func selectHotkeyFunction(fn, plugin string) {
-	if hotkeyCmdSection == nil {
-		return
-	}
-	// Only apply to a single empty command slot.
-	if len(hotkeyCmdInputs) != 1 || hotkeyCmdInputs[0].Text != "" {
-		return
-	}
-	hotkeyCmdFuncs[0] = hotkeyFuncRef{Name: fn, Plugin: plugin}
-	if fn == "" {
-		if hotkeyFnLabel != nil {
-			hotkeyCmdSection.Contents = hotkeyCmdSection.Contents[1:]
-			hotkeyFnLabel = nil
-			hotkeyEditWin.Refresh()
-		}
-		return
-	}
-	if hotkeyFnLabel == nil {
-		hotkeyFnLabel, _ = eui.NewText()
-		hotkeyFnLabel.Size = eui.Point{X: hotkeyEditWin.Size.X - 40, Y: 20}
-		hotkeyFnLabel.FontSize = 12
-		hotkeyCmdSection.Contents = append([]*eui.ItemData{hotkeyFnLabel}, hotkeyCmdSection.Contents...)
-	}
-	disp := fn
-	if plugin != "" {
-		disp = plugin + "->" + fn
-	}
-	hotkeyFnLabel.Text = "Plugin Function: " + fn
-	hotkeyEditWin.Refresh()
 }
 
 func wrapHotkeyInputs() {
@@ -665,23 +521,10 @@ func finishHotkeyEdit(save bool) {
 		combo := strings.ReplaceAll(hotkeyComboText.Text, "\n", " ")
 		name := strings.ReplaceAll(hotkeyNameInput.Text, "\n", " ")
 		cmds := []HotkeyCommand{}
-		max := len(hotkeyCmdInputs)
-		if len(hotkeyCmdFuncs) > max {
-			max = len(hotkeyCmdFuncs)
-		}
-		for i := 0; i < max; i++ {
-			cmd := ""
-			if i < len(hotkeyCmdInputs) {
-				cmd = strings.ReplaceAll(hotkeyCmdInputs[i].Text, "\n", " ")
-			}
-			fnName := ""
-			fnPlugin := ""
-			if i < len(hotkeyCmdFuncs) {
-				fnName = hotkeyCmdFuncs[i].Name
-				fnPlugin = hotkeyCmdFuncs[i].Plugin
-			}
-			if cmd != "" || fnName != "" {
-				cmds = append(cmds, HotkeyCommand{Command: cmd, Function: fnName, Plugin: fnPlugin})
+		for _, in := range hotkeyCmdInputs {
+			cmd := strings.ReplaceAll(in.Text, "\n", " ")
+			if cmd != "" {
+				cmds = append(cmds, HotkeyCommand{Command: cmd})
 			}
 		}
 		if combo != "" {
@@ -933,45 +776,6 @@ func checkHotkeys() {
 			if hk.Combo == combo && !hk.Disabled {
 				for _, c := range hk.Commands {
 					cmd := strings.TrimSpace(c.Command)
-					if c.Function != "" {
-						name := strings.ToLower(strings.TrimSpace(c.Function))
-						pluginMu.RLock()
-						fnMap := pluginFuncs[c.Plugin]
-						disabled := pluginDisabled[c.Plugin]
-						fn, ok := fnMap[name]
-						pluginMu.RUnlock()
-						if !disabled && ok && fn != nil {
-							consoleMessage("> [plugin] " + name)
-							go fn()
-						} else {
-							consoleMessage("[plugin] function not found: " + name)
-						}
-						continue
-					}
-					if strings.HasPrefix(strings.ToLower(cmd), "plugin:") {
-						name := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(cmd, "plugin:")))
-						pluginMu.RLock()
-						var fn PluginFunc
-						var found bool
-						for owner, m := range pluginFuncs {
-							if pluginDisabled[owner] {
-								continue
-							}
-							if f, ok := m[name]; ok {
-								fn = f
-								found = true
-								break
-							}
-						}
-						pluginMu.RUnlock()
-						if found && fn != nil {
-							consoleMessage("> [plugin] " + name)
-							go fn()
-						} else {
-							consoleMessage("[plugin] function not found: " + name)
-						}
-						continue
-					}
 					// Show hotkey-triggered command as if it were typed
 					var ok bool
 					cmd, ok = applyHotkeyVars(cmd)
@@ -993,28 +797,4 @@ func checkHotkeys() {
 			}
 		}
 	}
-}
-
-type pluginFuncInfo struct {
-	Name   string
-	Plugin string
-}
-
-// pluginFunctionInfos returns a snapshot of registered plugin functions with their owning plugin.
-func pluginFunctionInfos() []pluginFuncInfo {
-	pluginMu.RLock()
-	var infos []pluginFuncInfo
-	for owner, funcs := range pluginFuncs {
-		for name := range funcs {
-			infos = append(infos, pluginFuncInfo{Name: name, Plugin: owner})
-		}
-	}
-	pluginMu.RUnlock()
-	sort.Slice(infos, func(i, j int) bool {
-		if infos[i].Name == infos[j].Name {
-			return infos[i].Plugin < infos[j].Plugin
-		}
-		return infos[i].Name < infos[j].Name
-	})
-	return infos
 }

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -76,46 +76,6 @@ func TestHotkeyCommandInput(t *testing.T) {
 	}
 }
 
-// Test that a hotkey invoking a function can omit the command text.
-func TestHotkeyFunctionWithoutCommand(t *testing.T) {
-	hotkeys = nil
-	openHotkeyEditor(-1)
-	hotkeyComboText.Text = "Ctrl-F"
-	addHotkeyCommand("", "ponder", "")
-	finishHotkeyEdit(true)
-
-	if len(hotkeys) != 1 {
-		t.Fatalf("hotkey not saved")
-	}
-	cmd := hotkeys[0].Commands[0]
-	if cmd.Command != "" || cmd.Function != "ponder" {
-		t.Fatalf("unexpected hotkey command: %+v", cmd)
-	}
-	if hotkeyEditWin != nil {
-		hotkeyEditWin.Close()
-	}
-}
-
-// Test that selecting a function without clicking add saves the hotkey.
-func TestHotkeyFunctionSelectionSaves(t *testing.T) {
-	hotkeys = nil
-	openHotkeyEditor(-1)
-	hotkeyComboText.Text = "Ctrl-H"
-	selectHotkeyFunction("ponder", "")
-	finishHotkeyEdit(true)
-
-	if len(hotkeys) != 1 {
-		t.Fatalf("hotkey not saved")
-	}
-	cmd := hotkeys[0].Commands[0]
-	if cmd.Command != "" || cmd.Function != "ponder" {
-		t.Fatalf("unexpected hotkey command: %+v", cmd)
-	}
-	if hotkeyEditWin != nil {
-		hotkeyEditWin.Close()
-	}
-}
-
 // Test that a hotkey with an empty command saves correctly.
 func TestHotkeyEmptyCommandSaved(t *testing.T) {
 	hotkeys = nil
@@ -132,50 +92,6 @@ func TestHotkeyEmptyCommandSaved(t *testing.T) {
 	if hotkeyEditWin != nil {
 		hotkeyEditWin.Close()
 	}
-}
-
-// Test that a function-only hotkey persists through save/load cycles.
-func TestHotkeyFunctionPersisted(t *testing.T) {
-	hotkeys = []Hotkey{{Combo: "Ctrl-P", Commands: []HotkeyCommand{{Function: "ponder"}}}}
-	dir := t.TempDir()
-	origDir := dataDirPath
-	dataDirPath = dir
-	defer func() { dataDirPath = origDir }()
-
-	saveHotkeys()
-	hotkeys = nil
-	loadHotkeys()
-
-	if len(hotkeys) != 2 {
-		t.Fatalf("hotkeys not loaded: %d", len(hotkeys))
-	}
-	cmd := hotkeys[0].Commands[0]
-	if cmd.Command != "" || cmd.Function != "ponder" {
-		t.Fatalf("unexpected hotkey after load: %+v", cmd)
-	}
-}
-
-// Test that editing a hotkey preselects its function in the dropdown.
-func TestHotkeyEditPreselectsFunction(t *testing.T) {
-	hotkeys = []Hotkey{{Combo: "Ctrl-P", Commands: []HotkeyCommand{{Function: "ponder"}}}}
-	pluginMu.Lock()
-	origFuncs := pluginFuncs
-	pluginFuncs = map[string]map[string]PluginFunc{"": {"ponder": nil}}
-	pluginMu.Unlock()
-	defer func() {
-		pluginMu.Lock()
-		pluginFuncs = origFuncs
-		pluginMu.Unlock()
-	}()
-
-	openHotkeyEditor(0)
-	flow := hotkeyEditWin.Contents[0]
-	fnRow := flow.Contents[4]
-	fnDD := fnRow.Contents[1]
-	if fnDD.Selected != 1 {
-		t.Fatalf("function dropdown not preselected: %d", fnDD.Selected)
-	}
-	hotkeyEditWin.Close()
 }
 
 // Test that editing a hotkey with no name still saves changes.

--- a/ui.go
+++ b/ui.go
@@ -396,12 +396,10 @@ func refreshPluginsWindow() {
 
 func showPluginInfo(owner string) {
 	cmds := pluginCommandsFor(owner)
-	funcs := pluginFunctionsFor(owner)
 	hks := pluginHotkeys(owner)
 	src := pluginSource(owner)
 
 	sort.Strings(cmds)
-	sort.Strings(funcs)
 	sort.Slice(hks, func(i, j int) bool { return strings.ToLower(hks[i].Combo) < strings.ToLower(hks[j].Combo) })
 
 	pluginMu.RLock()
@@ -433,33 +431,21 @@ func showPluginInfo(owner string) {
 		}
 	}
 
-	if len(funcs) > 0 {
-		header, _ := eui.NewText()
-		header.Text = "Functions:"
-		flow.AddItem(header)
-		for _, f := range funcs {
-			line, _ := eui.NewText()
-			line.Text = f
-			flow.AddItem(line)
-		}
-	}
-
 	if len(hks) > 0 {
 		header, _ := eui.NewText()
-		header.Text = "Hotkeys:"
+		header.Text = "Key Inputs:"
 		flow.AddItem(header)
 		for _, hk := range hks {
-			target := hk.Name
+			target := ""
 			if len(hk.Commands) > 0 {
-				cmd := hk.Commands[0]
-				if cmd.Command != "" {
-					target = cmd.Command
-				} else if cmd.Function != "" {
-					target = "plugin:" + cmd.Function
-				}
+				target = hk.Commands[0].Command
 			}
 			line, _ := eui.NewText()
-			line.Text = hk.Combo + " -> " + target
+			if target != "" {
+				line.Text = hk.Combo + " -> " + target
+			} else {
+				line.Text = hk.Combo
+			}
 			flow.AddItem(line)
 		}
 	}


### PR DESCRIPTION
## Summary
- drop support for plugin function hotkeys and related API
- list each plugin's key combos in the plugin window
- update example plugins and docs for command-only hotkeys

## Testing
- `go test ./...` *(fails: Package alsa was not found; Xrandr.h missing; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bf214e0832a9aab3a741477e965