### PR TITLE
Ensure plugin viewer shows errors when source missing

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -607,11 +607,11 @@ func pluginSource(owner string) string {
 	path := pluginPaths[owner]
 	pluginMu.RUnlock()
 	if path == "" {
-		return ""
+		return "plugin source not found"
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return ""
+		return fmt.Sprintf("error reading %s: %v", path, err)
 	}
 	return string(data)
 }


### PR DESCRIPTION
## Summary
- return helpful fallback text when a plugin's source file can't be read

## Testing
- `go vet ./...`
- `go test ./...` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7d13e9dc832ab124515a6c476cf3