### PR TITLE
Add bubble life slider

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1284,7 +1284,15 @@ func parseDrawState(data []byte, buildCache bool) error {
 				showBubble = typeOK && originOK
 			}
 			if showBubble {
-				b := bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter}
+				words := len(strings.Fields(txt))
+				if words < 1 {
+					words = 1
+				}
+				life := int(gs.BubbleLife * float64(words) * float64(1000/framems))
+				if life < 1 {
+					life = 1
+				}
+				b := bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter, LifeFrames: life}
 				switch bubbleType {
 				case kBubbleRealAction, kBubblePlayerAction, kBubbleNarrate:
 					b.NoArrow = true

--- a/fake.go
+++ b/fake.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -52,7 +53,15 @@ func runFakeMode(ctx context.Context) {
 
 		// Helper to append a bubble and show corresponding chat message.
 		emitBubble := func(idx uint8, typ int, name, verb, txt string) {
-			b := bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter}
+			words := len(strings.Fields(txt))
+			if words < 1 {
+				words = 1
+			}
+			life := int(gs.BubbleLife * float64(words) * float64(1000/framems))
+			if life < 1 {
+				life = 1
+			}
+			b := bubble{Index: idx, Text: txt, Type: typ, CreatedFrame: frameCounter, LifeFrames: life}
 			switch typ & kBubbleTypeMask {
 			case kBubbleRealAction, kBubblePlayerAction, kBubbleNarrate:
 				b.NoArrow = true
@@ -108,7 +117,12 @@ func runFakeMode(ctx context.Context) {
 			case 11: // Monster growls
 				emitBubble(1, kBubbleMonster, p2, "growls", "Grrr!")
 			case 12: // Off-screen bubble
-				b := bubble{Index: 1, H: int16(fieldCenterX + 10), V: 0, Far: true, Text: "Over here!", Type: kBubbleNormal, CreatedFrame: frameCounter}
+				words := len(strings.Fields("Over here!"))
+				life := int(gs.BubbleLife * float64(words) * float64(1000/framems))
+				if life < 1 {
+					life = 1
+				}
+				b := bubble{Index: 1, H: int16(fieldCenterX + 10), V: 0, Far: true, Text: "Over here!", Type: kBubbleNormal, CreatedFrame: frameCounter, LifeFrames: life}
 				stateMu.Lock()
 				state.bubbles = append(state.bubbles, b)
 				stateMu.Unlock()

--- a/game.go
+++ b/game.go
@@ -308,10 +308,8 @@ func prepareRenderCacheLocked() {
 }
 
 // bubble stores temporary chat bubble information. Bubbles expire after a
-// fixed number of game update frames from when they were created — no FPS
-// correction or wall-clock timing is applied to keep playback simple.
-const bubbleLifeFrames = (1000 / framems) * 4 // ~4s
-
+// number of frames determined when they are created. No FPS correction or
+// wall-clock timing is applied to keep playback simple.
 type bubble struct {
 	Index        uint8
 	H, V         int16
@@ -320,6 +318,7 @@ type bubble struct {
 	Text         string
 	Type         int
 	CreatedFrame int
+	LifeFrames   int
 }
 
 // drawSnapshot is a read-only copy of the current draw state.
@@ -397,7 +396,7 @@ func captureDrawSnapshot() drawSnapshot {
 		curFrame := frameCounter
 		kept := state.bubbles[:0]
 		for _, b := range state.bubbles {
-			if (curFrame - b.CreatedFrame) < bubbleLifeFrames {
+			if (curFrame - b.CreatedFrame) < b.LifeFrames {
 				if !b.Far {
 					if m, ok := state.mobiles[b.Index]; ok {
 						b.H, b.V = m.H, m.V

--- a/settings.go
+++ b/settings.go
@@ -40,6 +40,7 @@ var gsdef settings = settings{
 	InventoryFontSize:  18,
 	PlayersFontSize:    18,
 	BubbleOpacity:      0.7,
+	BubbleLife:         1.0,
 	NameBgOpacity:      0.7,
 	BarOpacity:         0.5,
 	SpeechBubbles:      true,
@@ -117,6 +118,7 @@ type settings struct {
 	InventoryFontSize     float64
 	PlayersFontSize       float64
 	BubbleOpacity         float64
+	BubbleLife            float64
 	NameBgOpacity         float64
 	BarOpacity            float64
 	SpeechBubbles         bool

--- a/ui.go
+++ b/ui.go
@@ -2485,6 +2485,20 @@ func makeSettingsWindow() {
 	}
 	center.AddItem(bubbleOpSlider)
 
+	bubbleLifeSlider, bubbleLifeEvents := eui.NewSlider()
+	bubbleLifeSlider.Label = "Bubble Life (s/word)"
+	bubbleLifeSlider.MinValue = 0.5
+	bubbleLifeSlider.MaxValue = 5
+	bubbleLifeSlider.Value = float32(gs.BubbleLife)
+	bubbleLifeSlider.Size = eui.Point{X: centerW - 10, Y: 24}
+	bubbleLifeEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.BubbleLife = float64(ev.Value)
+			settingsDirty = true
+		}
+	}
+	center.AddItem(bubbleLifeSlider)
+
 	label, _ = eui.NewText()
 	label.Text = "\nQuality Options:"
 	label.FontSize = 15


### PR DESCRIPTION
## Summary
- add slider to configure chat bubble lifetime per word
- base bubble duration on message word count

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7d64eb6c832a8eb8760d62415653