### PR TITLE
Route think, ponder, and action messages to chat and TTS

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -58,13 +58,7 @@ func isSelfChatMessage(msg string) bool {
 		return true
 	}
 	if strings.HasPrefix(m, name+" ") {
-		rest := m[len(name)+1:]
-		verbs := []string{"says", "whispers", "yells", "thinks", "ponders"}
-		for _, v := range verbs {
-			if strings.HasPrefix(rest, v) {
-				return true
-			}
-		}
+		return true
 	}
 	return false
 }

--- a/util.go
+++ b/util.go
@@ -217,7 +217,12 @@ const (
 )
 
 func isChatBubble(t int) bool {
-	return t == kBubbleNormal || t == kBubbleWhisper || t == kBubbleYell
+	switch t {
+	case kBubbleNormal, kBubbleWhisper, kBubbleYell, kBubbleThought, kBubblePonder, kBubbleRealAction, kBubblePlayerAction:
+		return true
+	default:
+		return false
+	}
 }
 
 // bubble languages and codes from Public_cl.h


### PR DESCRIPTION
## Summary
- Treat thought, ponder, and action bubbles as chat so they appear in the chat window and are spoken via TTS
- Simplify self-message detection to suppress TTS for any message beginning with the player name

## Testing
- `go vet ./...`
- `go test ./...` *(fails: `glfw: X11: The DISPLAY environment variable is missing`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7dce0ff4832a9da94760161f2449