### PR TITLE
Limit plugin hotkey list output to 15 lines

### DIFF
--- a/example_plugins/example_ponder.go
+++ b/example_plugins/example_ponder.go
@@ -113,11 +113,13 @@ func handleRad(args string) {
 		}
 		gt.Console("item not found")
 	case "hotkeys":
-		// List hotkeys that come from plugins.
+		// List hotkeys that come from plugins, capped at 15 lines.
+		count := 0
 		for _, hk := range gt.Hotkeys() {
 			if hk.Disabled {
 				continue
 			}
+		outer:
 			for _, cmd := range hk.Commands {
 				if cmd.Plugin == "" {
 					continue
@@ -127,6 +129,13 @@ func handleRad(args string) {
 				} else if cmd.Function != "" {
 					gt.Console(fmt.Sprintf("%s -> func %s", hk.Combo, cmd.Function))
 				}
+				count++
+				if count >= 15 {
+					break outer
+				}
+			}
+			if count >= 15 {
+				break
 			}
 		}
 	case "rmhotkey":


### PR DESCRIPTION
## Summary
- cap the example plugin's hotkey listing to 15 lines to avoid flooding the console

## Testing
- `go vet -tags=plugin ./example_plugins/...` *(fails: PluginName redeclared in example_plugins/chain_swap.go:11:5)*
- `go test ./...` *(fails: X11/ALSA/GTK development libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac860998c0832aa6d6181c64692939