### PR TITLE
Add macro helpers and auto replies

### DIFF
--- a/data/plugins/README.txt
+++ b/data/plugins/README.txt
@@ -67,6 +67,9 @@ Common API calls:
   runs locally.
 - `gt.RunCommand(cmd)` – send a command to the server immediately.
 - `gt.EnqueueCommand(cmd)` – queue a command to send on the next tick.
+- `gt.AddMacro(short, full)` – expand a short prefix into a full command.
+- `gt.AddMacros(map[string]string)` – register many macros at once.
+- `gt.AutoReply(trigger, cmd)` – run a command when chat starts with trigger.
 - `gt.RegisterInputHandler(func(text string) string)` – inspect or change chat
   text before it is sent.
 - `gt.RegisterChatHandler(func(msg string))` – react to every chat message.
@@ -87,6 +90,9 @@ Common API calls:
 - `gt.LastClick()` – info about the most recent click.
 - `gt.FrameNumber()` – current frame count.
 - `gt.SetInputText(txt)` and `gt.InputText()` – set or read the chat input box.
+- Simple text helpers: `gt.Lower`, `gt.Upper`, `gt.IgnoreCase`, `gt.StartsWith`,
+  `gt.EndsWith`, `gt.Includes`, `gt.Trim`, `gt.TrimStart`, `gt.TrimEnd`,
+  `gt.Words`, `gt.Join`.
 
 Plugin Tutorials
 ----------------
@@ -104,10 +110,10 @@ It also adds hotkeys:
 - `Ctrl-N` shows a notification.
 
 ### Default Macros (`default_macros.go`)
-Replaces short text in the chat box with full commands.
+Replaces short text in the chat box with full commands using `gt.AddMacros`.
 1. Type `??` followed by text to open `/help`.
 2. Try typing `pphello` and it becomes `/ponder hello`.
-Edit the `macroMap` in the file to add your own shortcuts.
+Edit the `Init` function to add your own shortcuts with `gt.AddMacro`.
 
 ### Healer Self-Heal (`healer_selfheal.go`)
 Right-click yourself to cast a self-heal.

--- a/data/plugins/default_macros.go
+++ b/data/plugins/default_macros.go
@@ -2,48 +2,30 @@
 
 package main
 
-import (
-	"gt"
-	"strings"
-	"time"
-)
+import "gt"
 
 var PluginName = "Default Macros"
 
-var macroMap = map[string]string{
-	"??": "/help ",
-	"aa": "/action ",
-	"gg": "/give ",
-	"ii": "/info ",
-	"kk": "/karma ",
-	"mm": "/money",
-	"nn": "/news",
-	"pp": "/ponder ",
-	"sh": "/share ",
-	"sl": "/sleep",
-	"t":  "/think ",
-	"tt": "/thinkto ",
-	"th": "/thank ",
-	"ui": "/useitem ",
-	"uu": "/use ",
-	"un": "/unshare ",
-	"w":  "/who ",
-	"wh": "/whisper ",
-	"yy": "/yell ",
-}
-
 func Init() {
-	go func() {
-		for {
-			txt := gt.InputText()
-			lower := strings.ToLower(txt)
-			for k, v := range macroMap {
-				if strings.HasPrefix(lower, k) {
-					gt.SetInputText(v + txt[len(k):])
-					break
-				}
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-	}()
+	gt.AddMacros(map[string]string{
+		"??": "/help ",
+		"aa": "/action ",
+		"gg": "/give ",
+		"ii": "/info ",
+		"kk": "/karma ",
+		"mm": "/money",
+		"nn": "/news",
+		"pp": "/ponder ",
+		"sh": "/share ",
+		"sl": "/sleep",
+		"t":  "/think ",
+		"tt": "/thinkto ",
+		"th": "/thank ",
+		"ui": "/useitem ",
+		"uu": "/use ",
+		"un": "/unshare ",
+		"w":  "/who ",
+		"wh": "/whisper ",
+		"yy": "/yell ",
+	})
 }

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -67,6 +67,9 @@ Common API calls:
   runs locally.
 - `gt.RunCommand(cmd)` – send a command to the server immediately.
 - `gt.EnqueueCommand(cmd)` – queue a command to send on the next tick.
+- `gt.AddMacro(short, full)` – expand a short prefix into a full command.
+- `gt.AddMacros(map[string]string)` – register many macros at once.
+- `gt.AutoReply(trigger, cmd)` – run a command when chat starts with trigger.
 - `gt.RegisterInputHandler(func(text string) string)` – inspect or change chat
   text before it is sent.
 - `gt.RegisterChatHandler(func(msg string))` – react to every chat message.
@@ -87,6 +90,9 @@ Common API calls:
 - `gt.LastClick()` – info about the most recent click.
 - `gt.FrameNumber()` – current frame count.
 - `gt.SetInputText(txt)` and `gt.InputText()` – set or read the chat input box.
+- Simple text helpers: `gt.Lower`, `gt.Upper`, `gt.IgnoreCase`, `gt.StartsWith`,
+  `gt.EndsWith`, `gt.Includes`, `gt.Trim`, `gt.TrimStart`, `gt.TrimEnd`,
+  `gt.Words`, `gt.Join`.
 
 Plugin Tutorials
 ----------------
@@ -104,10 +110,10 @@ It also adds hotkeys:
 - `Ctrl-N` shows a notification.
 
 ### Default Macros (`default_macros.go`)
-Replaces short text in the chat box with full commands.
+Replaces short text in the chat box with full commands using `gt.AddMacros`.
 1. Type `??` followed by text to open `/help`.
 2. Try typing `pphello` and it becomes `/ponder hello`.
-Edit the `macroMap` in the file to add your own shortcuts.
+Edit the `Init` function to add your own shortcuts with `gt.AddMacro`.
 
 ### Healer Self-Heal (`healer_selfheal.go`)
 Right-click yourself to cast a self-heal.

--- a/example_plugins/default_macros.go
+++ b/example_plugins/default_macros.go
@@ -2,59 +2,30 @@
 
 package main
 
-import (
-	"gt"      // small API exposed to plugins
-	"strings" // helpers for working with text
-)
+import "gt"
 
-// PluginName shows in the plugin list. It must be unique so the client
-// knows which plugin this is.
 var PluginName = "Default Macros"
 
-// macroMap links short text to longer slash commands. When you type the short
-// version in the chat box the plugin swaps it for the full command.
-var macroMap = map[string]string{
-	// "??" becomes "/help "
-	"??": "/help ",
-	// "aa" becomes "/action "
-	"aa": "/action ",
-	"gg": "/give ",
-	"ii": "/info ",
-	"kk": "/karma ",
-	"mm": "/money",
-	"nn": "/news",
-	"pp": "/ponder ",
-	"sh": "/share ",
-	"sl": "/sleep",
-	// single letter macros work too
-	"t":  "/think ",
-	"tt": "/thinkto ",
-	"th": "/thank ",
-	"ui": "/useitem ",
-	"uu": "/use ",
-	"un": "/unshare ",
-	"w":  "/who ",
-	"wh": "/whisper ",
-	"yy": "/yell ",
-}
-
-// Init runs once when the plugin is loaded by the client.
 func Init() {
-	// Register a small function that runs every time you hit enter in the
-	// chat box. It can change what gets sent to the server.
-	gt.RegisterInputHandler(func(txt string) string {
-		// work with a lowercase copy so matching is easy
-		lower := strings.ToLower(txt)
-		// look through all known macros
-		for short, full := range macroMap {
-			// if the text starts with a macro
-			if strings.HasPrefix(lower, short) {
-				// replace the macro with the full command and
-				// keep the rest of what the user typed
-				return full + txt[len(short):]
-			}
-		}
-		// no macro matched; return the original text untouched
-		return txt
+	gt.AddMacros(map[string]string{
+		"??": "/help ",
+		"aa": "/action ",
+		"gg": "/give ",
+		"ii": "/info ",
+		"kk": "/karma ",
+		"mm": "/money",
+		"nn": "/news",
+		"pp": "/ponder ",
+		"sh": "/share ",
+		"sl": "/sleep",
+		"t":  "/think ",
+		"tt": "/thinkto ",
+		"th": "/thank ",
+		"ui": "/useitem ",
+		"uu": "/use ",
+		"un": "/unshare ",
+		"w":  "/who ",
+		"wh": "/whisper ",
+		"yy": "/yell ",
 	})
 }

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -53,6 +53,48 @@ func RunCommand(cmd string) {}
 // EnqueueCommand queues a command for the next tick without echoing.
 func EnqueueCommand(cmd string) {}
 
+// IgnoreCase reports whether a and b are equal ignoring capitalization.
+func IgnoreCase(a, b string) bool { return false }
+
+// StartsWith reports whether text begins with prefix.
+func StartsWith(text, prefix string) bool { return false }
+
+// EndsWith reports whether text ends with suffix.
+func EndsWith(text, suffix string) bool { return false }
+
+// Includes reports whether text contains substr.
+func Includes(text, substr string) bool { return false }
+
+// Lower returns text in lower case.
+func Lower(text string) string { return "" }
+
+// Upper returns text in upper case.
+func Upper(text string) string { return "" }
+
+// Trim removes spaces at the start and end of text.
+func Trim(text string) string { return "" }
+
+// TrimStart removes prefix from text if present.
+func TrimStart(text, prefix string) string { return "" }
+
+// TrimEnd removes suffix from text if present.
+func TrimEnd(text, suffix string) string { return "" }
+
+// Words splits text into fields separated by spaces.
+func Words(text string) []string { return nil }
+
+// Join concatenates parts with sep between elements.
+func Join(parts []string, sep string) string { return "" }
+
+// AddMacro replaces a short prefix with a full command in the chat box.
+func AddMacro(short, full string) {}
+
+// AddMacros registers multiple macros at once.
+func AddMacros(macros map[string]string) {}
+
+// AutoReply sends a command when a chat message begins with trigger.
+func AutoReply(trigger, command string) {}
+
 // PlayerName returns the current player's name.
 func PlayerName() string { return "" }
 

--- a/plugin.go
+++ b/plugin.go
@@ -53,6 +53,17 @@ var basePluginExports = interp.Exports{
 		"EquippedItems":         reflect.ValueOf(pluginEquippedItems),
 		"HasItem":               reflect.ValueOf(pluginHasItem),
 		"FrameNumber":           reflect.ValueOf(pluginFrameNumber),
+		"IgnoreCase":            reflect.ValueOf(pluginIgnoreCase),
+		"StartsWith":            reflect.ValueOf(pluginStartsWith),
+		"EndsWith":              reflect.ValueOf(pluginEndsWith),
+		"Includes":              reflect.ValueOf(pluginIncludes),
+		"Lower":                 reflect.ValueOf(pluginLower),
+		"Upper":                 reflect.ValueOf(pluginUpper),
+		"Trim":                  reflect.ValueOf(pluginTrim),
+		"TrimStart":             reflect.ValueOf(pluginTrimStart),
+		"TrimEnd":               reflect.ValueOf(pluginTrimEnd),
+		"Words":                 reflect.ValueOf(pluginWords),
+		"Join":                  reflect.ValueOf(pluginJoin),
 	},
 }
 
@@ -69,6 +80,9 @@ func exportsForPlugin(owner string) interp.Exports {
 		m["RegisterCommand"] = reflect.ValueOf(func(name string, handler PluginCommandHandler) {
 			pluginRegisterCommand(owner, name, handler)
 		})
+		m["AddMacro"] = reflect.ValueOf(func(short, full string) { pluginAddMacro(owner, short, full) })
+		m["AddMacros"] = reflect.ValueOf(func(macros map[string]string) { pluginAddMacros(owner, macros) })
+		m["AutoReply"] = reflect.ValueOf(func(trigger, cmd string) { pluginAutoReply(owner, trigger, cmd) })
 		m["RunCommand"] = reflect.ValueOf(func(cmd string) { pluginRunCommand(owner, cmd) })
 		m["EnqueueCommand"] = reflect.ValueOf(func(cmd string) { pluginEnqueueCommand(owner, cmd) })
 		ex[pkg] = m

--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"sync"
+)
+
+var (
+	macroMu   sync.RWMutex
+	macroMaps = map[string]map[string]string{}
+)
+
+func pluginAddMacro(owner, short, full string) {
+	short = strings.ToLower(short)
+	macroMu.Lock()
+	m := macroMaps[owner]
+	if m == nil {
+		m = map[string]string{}
+		macroMaps[owner] = m
+		pluginRegisterInputHandler(func(txt string) string {
+			macroMu.RLock()
+			local := macroMaps[owner]
+			macroMu.RUnlock()
+			lower := strings.ToLower(txt)
+			for k, v := range local {
+				if strings.HasPrefix(lower, k) {
+					return v + txt[len(k):]
+				}
+			}
+			return txt
+		})
+	}
+	m[short] = full
+	macroMu.Unlock()
+}
+
+func pluginAddMacros(owner string, macros map[string]string) {
+	for k, v := range macros {
+		pluginAddMacro(owner, k, v)
+	}
+}
+
+func pluginAutoReply(owner, trigger, cmd string) {
+	trig := strings.ToLower(trigger)
+	pluginRegisterChatHandler(func(msg string) {
+		if strings.HasPrefix(strings.ToLower(msg), trig) {
+			pluginRunCommand(owner, cmd)
+		}
+	})
+}

--- a/plugin_strings.go
+++ b/plugin_strings.go
@@ -1,0 +1,25 @@
+package main
+
+import "strings"
+
+func pluginIgnoreCase(a, b string) bool { return strings.EqualFold(a, b) }
+
+func pluginStartsWith(s, prefix string) bool { return strings.HasPrefix(s, prefix) }
+
+func pluginEndsWith(s, suffix string) bool { return strings.HasSuffix(s, suffix) }
+
+func pluginIncludes(s, substr string) bool { return strings.Contains(s, substr) }
+
+func pluginLower(s string) string { return strings.ToLower(s) }
+
+func pluginUpper(s string) string { return strings.ToUpper(s) }
+
+func pluginTrim(s string) string { return strings.TrimSpace(s) }
+
+func pluginTrimStart(s, prefix string) string { return strings.TrimPrefix(s, prefix) }
+
+func pluginTrimEnd(s, suffix string) string { return strings.TrimSuffix(s, suffix) }
+
+func pluginWords(s string) []string { return strings.Fields(s) }
+
+func pluginJoin(parts []string, sep string) string { return strings.Join(parts, sep) }


### PR DESCRIPTION
## Summary
- expose `AddMacro`, `AddMacros`, and `AutoReply` helpers for plugins
- simplify default macro plugins using `AddMacros`
- document new macro helpers in plugin READMEs

## Testing
- `go vet ./...` *(fails: Package 'alsa' not found; X11 headers missing; Package 'gtk+-3.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84b606d0832a9818c18613632b49