### PR TITLE
Add quick reply and boat auto-yes example plugins

### DIFF
--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -166,6 +166,14 @@ Cycle through a list of weapons with a single key.
 1. Edit the `cycleItems` list in the file to match your weapons.
 2. Press `F3` or type `/cycleweapon` to equip the next item in the list.
 
+### Quick Reply (`quick_reply.go`)
+Reply to the last exile who thinks to you.
+1. Type `/r <message>` to respond with `/thinkto <name> <message>`.
+
+### Auto Yes Boats (`auto_yes_boats.go`)
+Automatically whisper "yes" when a boat ferryman offers a ride.
+1. When the ferryman says "My fine boats", the plugin replies for you.
+
 Notes
 -----
 - This directory is created automatically the first time the game runs.

--- a/example_plugins/auto_yes_boats.go
+++ b/example_plugins/auto_yes_boats.go
@@ -1,0 +1,17 @@
+//go:build plugin
+
+package main
+
+import "gt"
+
+var PluginName = "Auto Yes Boats"
+
+func Init() {
+	nameLower := gt.Lower(gt.PlayerName())
+	gt.RegisterChatHandler(func(msg string) {
+		lower := gt.Lower(msg)
+		if gt.Includes(lower, "my fine boats") && gt.Includes(lower, nameLower) {
+			gt.RunCommand("/whisper yes")
+		}
+	})
+}

--- a/example_plugins/quick_reply.go
+++ b/example_plugins/quick_reply.go
@@ -1,0 +1,26 @@
+//go:build plugin
+
+package main
+
+import "gt"
+
+var PluginName = "Quick Reply"
+
+var lastThinker string
+
+func Init() {
+	gt.RegisterChatHandler(func(msg string) {
+		lower := gt.Lower(msg)
+		if gt.Includes(lower, "thinks to you") {
+			words := gt.Words(msg)
+			if len(words) > 0 {
+				lastThinker = words[0]
+			}
+		}
+	})
+	gt.RegisterCommand("r", func(args string) {
+		if lastThinker != "" {
+			gt.RunCommand("/thinkto " + lastThinker + " " + args)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add quick reply plugin for `/r` responses to last thinker
- add auto yes boats plugin to confirm ferry offers
- document new plugins in example README

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11 headers missing; Package gtk+-3.0 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8af98e00832a88b820a7540c540f