### PR TITLE
Skip karma alerts from blocked players

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -194,6 +194,21 @@ func decodeBEPP(data []byte) string {
 		// Back-end command: handle internally using raw (unstripped) data.
 		parseBackend(raw)
 		return ""
+	case "kr":
+		// Karma received: suppress notifications from blocked or ignored players.
+		name := utfFold(firstTagContent(raw, 'p', 'n'))
+		if name != "" {
+			playersMu.RLock()
+			p, ok := players[name]
+			blocked := ok && (p.Blocked || p.Ignored)
+			playersMu.RUnlock()
+			if blocked {
+				return ""
+			}
+		}
+		if text != "" {
+			return text
+		}
 	case "yk", "iv", "hp", "cf", "pn", "ka", "tl":
 		// Known simple pass-through prefixes (e.g., iv: item/verb,
 		// ka: karma, tl: text log only)

--- a/karma_bepp_test.go
+++ b/karma_bepp_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestDecodeKarmaBlockedIgnored(t *testing.T) {
+	raw := bepp("kr", append(pnTag("Bob"), []byte(" gives you good karma")...))
+
+	// Sanity check: unblocked message should be returned.
+	players = make(map[string]*Player)
+	if got := decodeBEPP(raw); got == "" {
+		t.Fatalf("decodeBEPP returned empty for unblocked message")
+	}
+
+	cases := []struct {
+		name string
+		p    *Player
+	}{
+		{"blocked", &Player{Name: "Bob", Blocked: true}},
+		{"ignored", &Player{Name: "Bob", Ignored: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			players = map[string]*Player{"Bob": tc.p}
+			if got := decodeBEPP(raw); got != "" {
+				t.Fatalf("decodeBEPP returned %q, want empty", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- ignore karma received messages from blocked or ignored players
- test that karma messages from blocked/ignored players are discarded

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8daaa620832ab2e7e36fb76d8b85