### PR TITLE
Add Numpad Poser plugin for pose hotkeys

### DIFF
--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -174,6 +174,18 @@ Reply to the last exile who thinks to you.
 Automatically whisper "yes" when a boat ferryman offers a ride.
 1. When the ferryman says "My fine boats", the plugin replies for you.
 
+### Numpad Poser (`numpad_poser.go`)
+Use the numeric keypad to strike poses quickly.
+- `Numpad1` → `/pose leanleft`
+- `Numpad2` → `/pose akimbo`
+- `Numpad3` → `/pose leanright`
+- `Numpad4` → `/pose kneel`
+- `Numpad5` → `/pose sit`
+- `Numpad6` → `/pose angry`
+- `Numpad7` → `/pose lie`
+- `Numpad8` → `/pose seated`
+- `Numpad9` → `/pose celebrate`
+
 Notes
 -----
 - This directory is created automatically the first time the game runs.

--- a/example_plugins/numpad_poser.go
+++ b/example_plugins/numpad_poser.go
@@ -1,0 +1,19 @@
+//go:build plugin
+
+package main
+
+import "gt"
+
+var PluginName = "Numpad Poser"
+
+func Init() {
+	gt.AddHotkey("Numpad1", "/pose leanleft")
+	gt.AddHotkey("Numpad2", "/pose akimbo")
+	gt.AddHotkey("Numpad3", "/pose leanright")
+	gt.AddHotkey("Numpad4", "/pose kneel")
+	gt.AddHotkey("Numpad5", "/pose sit")
+	gt.AddHotkey("Numpad6", "/pose angry")
+	gt.AddHotkey("Numpad7", "/pose lie")
+	gt.AddHotkey("Numpad8", "/pose seated")
+	gt.AddHotkey("Numpad9", "/pose celebrate")
+}

--- a/plugin.go
+++ b/plugin.go
@@ -90,7 +90,7 @@ func exportsForPlugin(owner string) interp.Exports {
 	return ex
 }
 
-//go:embed example_plugins/example_ponder.go example_plugins/default_macros.go example_plugins/README.txt example_plugins/chain_swap.go example_plugins/healer_selfheal.go example_plugins/coin_lord.go example_plugins/sharecads.go example_plugins/kudzu.go example_plugins/bard.go example_plugins/dance.go
+//go:embed example_plugins/example_ponder.go example_plugins/default_macros.go example_plugins/README.txt example_plugins/chain_swap.go example_plugins/healer_selfheal.go example_plugins/coin_lord.go example_plugins/sharecads.go example_plugins/kudzu.go example_plugins/bard.go example_plugins/dance.go example_plugins/numpad_poser.go
 var pluginExamples embed.FS
 
 func userPluginsDir() string {
@@ -130,6 +130,7 @@ func ensureDefaultPlugins() {
 		"plugins/kudzu.go",
 		"plugins/bard.go",
 		"plugins/dance.go",
+		"plugins/numpad_poser.go",
 	}
 	for _, src := range files {
 		data, err := pluginExamples.ReadFile(src)


### PR DESCRIPTION
## Summary
- add Numpad Poser example plugin mapping numeric keypad keys to /pose commands
- embed plugin and documentation in default plugin set

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW display environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e103430832ab9a14600c50c18a8