### PR TITLE
Fix plugin View button opening

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -462,6 +462,7 @@ func showPluginInfo(owner string) {
 	}
 
 	win.AddWindow(false)
+	win.MarkOpen()
 }
 
 func makeMixerWindow() {


### PR DESCRIPTION
## Summary
- Ensure the View button in the Plugins window opens the plugin info window

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9217a58c832a86c8a965593bce27