### PR TITLE
Make plugin viewer editable with save option

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -454,11 +454,34 @@ func showPluginInfo(owner string) {
 		header, _ := eui.NewText()
 		header.Text = "Source:"
 		flow.AddItem(header)
+
 		t, _ := eui.NewText()
 		t.Text = src
 		t.Size = eui.Point{X: 600, Y: 400}
 		t.FontSize = 12
+		t.Scrollable = true
+		t.Filled = true
 		flow.AddItem(t)
+
+		saveBtn, saveEvents := eui.NewButton()
+		saveBtn.Text = "Save"
+		saveBtn.Size = eui.Point{X: 48, Y: 24}
+		saveEvents.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventClick {
+				pluginMu.RLock()
+				path := pluginPaths[owner]
+				pluginMu.RUnlock()
+				if path == "" {
+					return
+				}
+				if err := os.WriteFile(path, []byte(t.Text), 0o644); err != nil {
+					consoleMessage("[plugin] save error: " + err.Error())
+				} else {
+					consoleMessage("[plugin] saved " + path)
+				}
+			}
+		}
+		flow.AddItem(saveBtn)
 	}
 
 	win.AddWindow(false)


### PR DESCRIPTION
## Summary
- Allow viewing plugin source in a scrollable, editable area
- Add Save button to persist edited plugin source to its file

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; Xrandr headers not found; Package 'gtk+-3.0', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac94730488832a92900b3d44a525b2