### PR TITLE
Check required assets when enabling audio features

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -604,14 +604,25 @@ func makeMixerWindow() {
 		},
 		func(ev eui.UIEvent) {
 			if ev.Type == eui.EventCheckboxChanged {
-				gs.Music = ev.Checked
-				musicMixSlider.Disabled = !ev.Checked
-				if !ev.Checked {
-					stopAllMusic()
-					clearTuneQueue()
+				if ev.Checked {
+					gs.Music = true
+					musicMixSlider.Disabled = false
+					if s, err := checkDataFiles(clientVersion); err == nil {
+						status = s
+						if status.NeedSoundfont {
+							disableMusic()
+							makeDownloadsWindow()
+							if downloadWin != nil {
+								downloadWin.MarkOpen()
+							}
+							return
+						}
+					}
+					settingsDirty = true
+					updateSoundVolume()
+				} else {
+					disableMusic()
 				}
-				settingsDirty = true
-				updateSoundVolume()
 			}
 		})
 
@@ -627,13 +638,25 @@ func makeMixerWindow() {
 		},
 		func(ev eui.UIEvent) {
 			if ev.Type == eui.EventCheckboxChanged {
-				gs.ChatTTS = ev.Checked
-				ttsMixSlider.Disabled = !ev.Checked
-				if !ev.Checked {
-					stopAllTTS()
+				if ev.Checked {
+					gs.ChatTTS = true
+					ttsMixSlider.Disabled = false
+					if s, err := checkDataFiles(clientVersion); err == nil {
+						status = s
+						if status.NeedPiper || status.NeedPiperFem || status.NeedPiperMale {
+							disableTTS()
+							makeDownloadsWindow()
+							if downloadWin != nil {
+								downloadWin.MarkOpen()
+							}
+							return
+						}
+					}
+					settingsDirty = true
+					updateSoundVolume()
+				} else {
+					disableTTS()
 				}
-				settingsDirty = true
-				updateSoundVolume()
 			}
 		})
 


### PR DESCRIPTION
## Summary
- Verify soundfont availability when enabling music and open the download dialog if missing
- Verify Piper TTS assets when enabling chat TTS and open the download dialog if required

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9de2406c832aab70fce0e60d0415