### PR TITLE
Use Noto Sans Mono in text viewers

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -15,7 +15,7 @@ func updateChatWindow() {
 	scrollit := chatList.ScrollAtBottom()
 
 	msgs := getChatMessages()
-	updateTextWindow(chatWin, chatList, nil, msgs, gs.ChatFontSize, "")
+	updateTextWindow(chatWin, chatList, nil, msgs, gs.ChatFontSize, "", nil)
 	if chatList != nil {
 		// Auto-scroll list to bottom on new messages
 		if scrollit {

--- a/console_ui.go
+++ b/console_ui.go
@@ -19,7 +19,7 @@ func updateConsoleWindow() {
 	scrollit := messagesFlow.ScrollAtBottom()
 
 	msgs := getConsoleMessages()
-	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg)
+	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg, nil)
 	if messagesFlow != nil {
 		// Scroll to bottom on new text; clamp occurs on Refresh.
 		if scrollit {

--- a/font.go
+++ b/font.go
@@ -21,7 +21,14 @@ var notoSansItalic []byte
 //go:embed data/font/NotoSans-BoldItalic.ttf
 var notoSansBoldItalic []byte
 
-var mainFont, mainFontBold, mainFontItalic, mainFontBoldItalic, bubbleFont text.Face
+//go:embed data/font/NotoSansMono-Regular.ttf
+var notoSansMonoRegular []byte
+
+//go:embed data/font/NotoSansMono-Bold.ttf
+var notoSansMonoBold []byte
+
+var mainFont, mainFontBold, mainFontItalic, mainFontBoldItalic, monoFont, monoFontBold, bubbleFont text.Face
+var monoFaceSource *text.GoTextFaceSource
 var fontGen uint32
 
 func initFont() {
@@ -60,6 +67,25 @@ func initFont() {
 	}
 	mainFontBoldItalic = &text.GoTextFace{
 		Source: boldItalic,
+		Size:   gs.MainFontSize * gs.GameScale,
+	}
+
+	monoRegular, err := text.NewGoTextFaceSource(bytes.NewReader(notoSansMonoRegular))
+	if err != nil {
+		log.Fatalf("failed to parse font: %v", err)
+	}
+	monoFaceSource = monoRegular
+	monoFont = &text.GoTextFace{
+		Source: monoRegular,
+		Size:   gs.MainFontSize * gs.GameScale,
+	}
+
+	monoBold, err := text.NewGoTextFaceSource(bytes.NewReader(notoSansMonoBold))
+	if err != nil {
+		log.Fatalf("failed to parse font: %v", err)
+	}
+	monoFontBold = &text.GoTextFace{
+		Source: monoBold,
 		Size:   gs.MainFontSize * gs.GameScale,
 	}
 

--- a/help_ui.go
+++ b/help_ui.go
@@ -23,20 +23,20 @@ func initHelpUI() {
 	helpWin, helpList, _ = makeTextWindow("Help", eui.HZoneCenter, eui.VZoneMiddleTop, false)
 	helpWin.AutoSize = true
 	helpLines = strings.Split(strings.ReplaceAll(helpText, "\r\n", "\n"), "\n")
-	helpWin.OnResize = func() { updateTextWindow(helpWin, helpList, nil, helpLines, 15, "") }
+	helpWin.OnResize = func() { updateTextWindow(helpWin, helpList, nil, helpLines, 15, "", monoFaceSource) }
 }
 
 func openHelpWindow(anchor *eui.ItemData) {
 	if helpWin == nil {
 		return
 	}
-	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "")
+	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "", monoFaceSource)
 	if anchor != nil {
 		helpWin.MarkOpenNear(anchor)
 	} else {
 		helpWin.MarkOpen()
 	}
-	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "")
+	updateTextWindow(helpWin, helpList, nil, helpLines, 15, "", monoFaceSource)
 	helpWin.Refresh()
 }
 

--- a/text_window.go
+++ b/text_window.go
@@ -53,7 +53,8 @@ func newTextWindow(name string, hz eui.HZone, vz eui.VZone, hasInput bool, updat
 }
 
 // updateTextWindow refreshes a text window's content and optional input message.
-func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []string, fontSize float64, inputMsg string) {
+// If faceSrc is nil the default font source is used.
+func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []string, fontSize float64, inputMsg string, faceSrc *text.GoTextFaceSource) {
 	if list == nil || win == nil {
 		return
 	}
@@ -81,7 +82,9 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	ui := eui.UIScale()
 	facePx := float64(float32(fontSize) * ui)
 	var goFace *text.GoTextFace
-	if src := eui.FontSource(); src != nil {
+	if faceSrc != nil {
+		goFace = &text.GoTextFace{Source: faceSrc, Size: facePx}
+	} else if src := eui.FontSource(); src != nil {
 		goFace = &text.GoTextFace{Source: src, Size: facePx}
 	} else {
 		goFace = &text.GoTextFace{Size: facePx}
@@ -108,12 +111,14 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				list.Contents[i].Text = wrapped
 				list.Contents[i].FontSize = float32(fontSize)
 			}
+			list.Contents[i].Face = face
 			list.Contents[i].Size.Y = rowUnits * float32(linesN)
 			list.Contents[i].Size.X = clientWAvail
 		} else {
 			t, _ := eui.NewText()
 			t.Text = wrapped
 			t.FontSize = float32(fontSize)
+			t.Face = face
 			t.Size = eui.Point{X: clientWAvail, Y: rowUnits * float32(linesN)}
 			// Append to maintain ordering with the msgs index
 			list.AddItem(t)
@@ -150,6 +155,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			t, _ := eui.NewText()
 			t.Text = wrappedIn
 			t.FontSize = float32(fontSize)
+			t.Face = face
 			t.Size = eui.Point{X: clientWAvail, Y: inputContentH}
 			t.Filled = true
 			input.AddItem(t)
@@ -158,6 +164,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 				input.Contents[0].Text = wrappedIn
 				input.Contents[0].FontSize = float32(fontSize)
 			}
+			input.Contents[0].Face = face
 			input.Contents[0].Size.X = clientWAvail
 			input.Contents[0].Size.Y = inputContentH
 		}

--- a/ui.go
+++ b/ui.go
@@ -461,6 +461,7 @@ func showPluginInfo(owner string) {
 		t.FontSize = 12
 		t.Scrollable = true
 		t.Filled = true
+		t.Face = &text.GoTextFace{Source: monoFaceSource, Size: float64(t.FontSize*eui.UIScale() + 2)}
 		flow.AddItem(t)
 
 		saveBtn, saveEvents := eui.NewButton()
@@ -1787,7 +1788,7 @@ func updateChangelogWindow() {
 	lines := strings.Split(changelog, "\n")
 	header := fmt.Sprintf("goThoom test %d", appVersion)
 	lines = append([]string{header, ""}, lines...)
-	updateTextWindow(changelogWin, changelogList, nil, lines, 14, "")
+	updateTextWindow(changelogWin, changelogList, nil, lines, 14, "", monoFaceSource)
 	if changelogPrevBtn != nil {
 		changelogPrevBtn.Disabled = changelogVersionIdx <= 0
 		changelogPrevBtn.Dirty = true


### PR DESCRIPTION
## Summary
- load Noto Sans Mono fonts alongside existing Sans variants
- allow text windows to use a custom font
- apply monospaced font to plugin source, Help, and Changelog viewers

## Testing
- `go test ./...` *(fails: Package 'alsa' not found)*
- `go build ./...` *(fails: X11/GTK dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9cb798cc832a84060502877ffa67