### PR TITLE
Handle Windows piper path and hide command window

### DIFF
--- a/prepare_piper_test.go
+++ b/prepare_piper_test.go
@@ -18,7 +18,11 @@ func TestPreparePiperVoiceArchive(t *testing.T) {
 		t.Fatal(err)
 	}
 	// create dummy piper binary inside nested directory to skip download
-	binPath := filepath.Join(binDir, "piper", "piper")
+	binName := "piper"
+	if runtime.GOOS == "windows" {
+		binName = "piper.exe"
+	}
+	binPath := filepath.Join(binDir, "piper", binName)
 	if err := os.WriteFile(binPath, []byte(""), 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- search both `bin/piper/<binary>` and `bin/piper/piper` to locate the piper executable on Windows
- hide the Windows command window when invoking piper
- improve piper presence check to account for nested paths

## Testing
- `go test ./...` *(fails: Package alsa was not found; Xrandr.h not found; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9eb9970832aa8c31c2090e29be3