### PR TITLE
Handle chat window toggle when console and chat are combined

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -3768,8 +3768,13 @@ func makeWindowsWindow() {
 	chatBoxEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			if ev.Checked {
-				chatWin.MarkOpenNear(ev.Item)
-			} else {
+				if chatWin == nil {
+					_ = makeChatWindow()
+				}
+				if chatWin != nil {
+					chatWin.MarkOpenNear(ev.Item)
+				}
+			} else if chatWin != nil {
 				chatWin.Close()
 			}
 		}


### PR DESCRIPTION
## Summary
- avoid nil deref by creating the chat window before opening
- skip closing actions when chat window is absent

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; fatal error: X11/extensions/Xrandr.h: No such file or directory; Package 'gtk+-3.0', required by 'virtual:world', not found)*
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; Package 'gtk+-3.0', required by 'virtual:world', not found; fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acca0043c4832a96f57ca3b0690b6e