### PR TITLE
Split Windows SysProcAttr into platform-specific files

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2/audio"
@@ -456,7 +455,7 @@ func synthesizeWithPiper(text string) ([]byte, error) {
 		cmd.Dir = dir
 		cmd.Stdin = strings.NewReader(text)
 		cmd.Stderr = &stderr
-		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		cmd.SysProcAttr = windowsSysProcAttr()
 		if err := cmd.Run(); err != nil {
 			if os.IsPermission(err) {
 				if info, statErr := os.Stat(piperPath); statErr == nil {
@@ -480,7 +479,7 @@ func synthesizeWithPiper(text string) ([]byte, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	if runtime.GOOS == "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		cmd.SysProcAttr = windowsSysProcAttr()
 	}
 	if err := cmd.Run(); err != nil {
 		if os.IsPermission(err) {

--- a/sysproc_nonwindows.go
+++ b/sysproc_nonwindows.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import "syscall"
+
+func windowsSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/sysproc_windows.go
+++ b/sysproc_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package main
+
+import "syscall"
+
+func windowsSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{HideWindow: true}
+}


### PR DESCRIPTION
## Summary
- isolate SysProcAttr configuration behind a windows-only helper
- provide no-op SysProcAttr stub for non-Windows builds

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW library requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68accba8cb9c832abe9f4d5e933c0878