### PR TITLE
Refresh voice dropdown and support flat voice files

### DIFF
--- a/chat_tts.go
+++ b/chat_tts.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2/audio"
@@ -257,6 +256,11 @@ func preparePiper(dataDir string) (string, string, string, error) {
 	model := filepath.Join(voicesDir, voice, voice+".onnx")
 	cfg := filepath.Join(voicesDir, voice, voice+".onnx.json")
 	if _, err := os.Stat(model); err != nil {
+		// Try voice files directly in voicesDir
+		model = filepath.Join(voicesDir, voice+".onnx")
+		cfg = filepath.Join(voicesDir, voice+".onnx.json")
+	}
+	if _, err := os.Stat(model); err != nil {
 		return "", "", "", fmt.Errorf("missing piper voice model: %w", err)
 	}
 	if _, err := os.Stat(cfg); err != nil {
@@ -271,21 +275,31 @@ func listPiperVoices() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	voices := []string{}
+	voiceSet := map[string]struct{}{}
 	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
 		name := e.Name()
-		model := filepath.Join(voicesDir, name, name+".onnx")
-		cfg := filepath.Join(voicesDir, name, name+".onnx.json")
-		if _, err := os.Stat(model); err != nil {
-			continue
+		if e.IsDir() {
+			model := filepath.Join(voicesDir, name, name+".onnx")
+			cfg := filepath.Join(voicesDir, name, name+".onnx.json")
+			if _, err := os.Stat(model); err != nil {
+				continue
+			}
+			if _, err := os.Stat(cfg); err != nil {
+				continue
+			}
+			voiceSet[name] = struct{}{}
+		} else if strings.HasSuffix(name, ".onnx") {
+			base := strings.TrimSuffix(name, ".onnx")
+			cfg := filepath.Join(voicesDir, base+".onnx.json")
+			if _, err := os.Stat(cfg); err != nil {
+				continue
+			}
+			voiceSet[base] = struct{}{}
 		}
-		if _, err := os.Stat(cfg); err != nil {
-			continue
-		}
-		voices = append(voices, name)
+	}
+	voices := make([]string, 0, len(voiceSet))
+	for v := range voiceSet {
+		voices = append(voices, v)
 	}
 	sort.Strings(voices)
 	return voices, nil
@@ -456,7 +470,9 @@ func synthesizeWithPiper(text string) ([]byte, error) {
 		cmd.Dir = dir
 		cmd.Stdin = strings.NewReader(text)
 		cmd.Stderr = &stderr
-		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		if attr := piperSysProcAttr(); attr != nil {
+			cmd.SysProcAttr = attr
+		}
 		if err := cmd.Run(); err != nil {
 			if os.IsPermission(err) {
 				if info, statErr := os.Stat(piperPath); statErr == nil {
@@ -479,8 +495,8 @@ func synthesizeWithPiper(text string) ([]byte, error) {
 	cmd.Stdin = strings.NewReader(text)
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	if runtime.GOOS == "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	if attr := piperSysProcAttr(); attr != nil {
+		cmd.SysProcAttr = attr
 	}
 	if err := cmd.Run(); err != nil {
 		if os.IsPermission(err) {

--- a/chat_tts_other.go
+++ b/chat_tts_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+func piperSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/chat_tts_test.go
+++ b/chat_tts_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestListPiperVoicesRootFiles(t *testing.T) {
+	dir := t.TempDir()
+	orig := dataDirPath
+	dataDirPath = dir
+	defer func() { dataDirPath = orig }()
+
+	voicesDir := filepath.Join(dir, "piper", "voices")
+	if err := os.MkdirAll(voicesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// voice stored directly in voices directory
+	if err := os.WriteFile(filepath.Join(voicesDir, "rootvoice.onnx"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(voicesDir, "rootvoice.onnx.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// voice stored inside a matching subdirectory
+	sub := filepath.Join(voicesDir, "dirvoice")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "dirvoice.onnx"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "dirvoice.onnx.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	voices, err := listPiperVoices()
+	if err != nil {
+		t.Fatalf("listPiperVoices: %v", err)
+	}
+	want := []string{"dirvoice", "rootvoice"}
+	if !reflect.DeepEqual(voices, want) {
+		t.Fatalf("voices = %v, want %v", voices, want)
+	}
+}

--- a/chat_tts_windows.go
+++ b/chat_tts_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+func piperSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{HideWindow: true}
+}

--- a/ui.go
+++ b/ui.go
@@ -2112,6 +2112,28 @@ func makeSettingsWindow() {
 			}
 		}
 	}
+	voiceDD.Action = func() {
+		if !voiceDD.Open {
+			return
+		}
+		if voices, err := listPiperVoices(); err == nil {
+			voiceDD.Options = voices
+			sel := 0
+			for i, v := range voices {
+				if v == gs.ChatTTSVoice {
+					sel = i
+					break
+				}
+			}
+			voiceDD.Selected = sel
+			if gs.ChatTTSVoice != voices[sel] {
+				SettingsLock.Lock()
+				gs.ChatTTSVoice = voices[sel]
+				SettingsLock.Unlock()
+				settingsDirty = true
+			}
+		}
+	}
 	voiceDD.Size = eui.Point{X: leftW, Y: 24}
 	voiceEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventDropdownSelected {


### PR DESCRIPTION
## Summary
- allow Piper voices to be stored directly in the voices folder without a subdirectory
- repopulate TTS voice options from disk whenever the dropdown is opened
- add tests for listing voices in both flat and nested layouts

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68accbf178a0832a8480cc4cf386334a