### PR TITLE
feat: auto refresh plugins with reload option

### DIFF
--- a/game.go
+++ b/game.go
@@ -540,6 +540,7 @@ func (g *Game) Update() error {
 	})
 
 	eui.Update() //We really need this to return eaten clicks
+	checkPluginMods()
 	updateNotifications()
 	updateThinkMessages()
 

--- a/ui.go
+++ b/ui.go
@@ -387,6 +387,22 @@ func refreshPluginsWindow() {
 		}
 		row.AddItem(viewBtn)
 
+		reloadBtn, rh := eui.NewButton()
+		reloadBtn.Text = "Reload"
+		reloadBtn.Size = eui.Point{X: 48, Y: 24}
+		rh.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventClick {
+				pluginMu.RLock()
+				enabled := !pluginDisabled[owner]
+				pluginMu.RUnlock()
+				disablePlugin(owner, "reloaded")
+				if enabled {
+					enablePlugin(owner)
+				}
+			}
+		}
+		row.AddItem(reloadBtn)
+
 		pluginsList.AddItem(row)
 	}
 	if pluginsWin != nil {


### PR DESCRIPTION
## Summary
- watch plugin directories and auto-refresh plugin list when files change
- add Reload button for each plugin to restart from disk
- integrate plugin reload check into main game loop

## Testing
- `go vet ./...` *(fails: unknown field HideWindow in syscall.SysProcAttr)*
- `go build ./...` *(fails: unknown field HideWindow in syscall.SysProcAttr)*

------
https://chatgpt.com/codex/tasks/task_e_68accc287b10832aaae13e40b357b8ea