### PR TITLE
Ensure plugins window is current when opened

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -232,6 +232,7 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	plugBtn.FontSize = toolFontSize
 	plugEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
+			refreshPluginsWindow()
 			pluginsWin.ToggleNear(ev.Item)
 		}
 	}


### PR DESCRIPTION
## Summary
- refresh the plugins window list before toggling it open

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68acd5afa1c8832ab7b91812f4e7aa69