### PR TITLE
Refresh download dialog for music and TTS

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -628,6 +628,10 @@ func makeMixerWindow() {
 						status = s
 						if status.NeedSoundfont {
 							disableMusic()
+							if downloadWin != nil {
+								downloadWin.Close()
+								downloadWin = nil
+							}
 							makeDownloadsWindow()
 							if downloadWin != nil {
 								downloadWin.MarkOpen()
@@ -662,6 +666,10 @@ func makeMixerWindow() {
 						status = s
 						if status.NeedPiper || status.NeedPiperFem || status.NeedPiperMale {
 							disableTTS()
+							if downloadWin != nil {
+								downloadWin.Close()
+								downloadWin = nil
+							}
 							makeDownloadsWindow()
 							if downloadWin != nil {
 								downloadWin.MarkOpen()


### PR DESCRIPTION
## Summary
- ensure enabling music or TTS recreates the downloads window so it updates

## Testing
- `go vet ./...` *(fails: undefined references to context and glfw)*

------
https://chatgpt.com/codex/tasks/task_e_68acd63a7bac832aa1fdacd813dd6293