### PR TITLE
Auto-enable TTS after piper download

### DIFF
--- a/update.go
+++ b/update.go
@@ -681,6 +681,9 @@ func downloadDataFiles(clientVer int, status dataFilesStatus, getSoundfont, getP
 	if getPiper || getFem || getMale {
 		if path, model, cfg, err := preparePiper(dataDirPath); err == nil {
 			piperPath, piperModel, piperConfig = path, model, cfg
+			gs.ChatTTS = true
+			settingsDirty = true
+			go playChatTTS(ttsTestPhrase)
 		} else {
 			logError("prepare piper: %v", err)
 		}


### PR DESCRIPTION
## Summary
- Enable ChatTTS after downloading piper assets
- Trigger a test TTS playback to verify functionality

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acd66fe2b0832aa08dd09035339136