### PR TITLE
Enable TTS when testing voice

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -2190,6 +2190,17 @@ func makeSettingsWindow() {
 	ttsTestBtn.Size = eui.Point{X: leftW, Y: 24}
 	ttsTestBtnEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
+			if !gs.ChatTTS {
+				gs.ChatTTS = true
+				settingsDirty = true
+				if ttsMixCB != nil {
+					ttsMixCB.Checked = true
+				}
+				if ttsMixSlider != nil {
+					ttsMixSlider.Disabled = false
+				}
+				updateSoundVolume()
+			}
 			go playChatTTS(ttsTestPhrase)
 		}
 	}


### PR DESCRIPTION
## Summary
- automatically enable TTS when the "Test TTS" button is pressed so the sample can play immediately

## Testing
- `go vet ui.go` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory; Package 'gtk+-3.0', required by 'virtual:world', not found)*
- `go test ./...` *(fails: Package alsa not found; fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acd9a1dd68832a96a8384443400900