### PR TITLE
fix plugin stdlib map

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -190,13 +190,13 @@ var pluginAllowedPkgs = []string{
 	"fmt/fmt",
 	"math/big/big",
 	"math/math",
-	"math/rand",
+	"math/rand/rand",
 	"regexp/regexp",
 	"sort/sort",
 	"strconv/strconv",
 	"strings/strings",
 	"time/time",
-	"unicode/utf8",
+	"unicode/utf8/utf8",
 }
 
 func restrictedStdlib() interp.Exports {


### PR DESCRIPTION
## Summary
- fix plugin stdlib map

## Testing
- `go build -v ./...`
- `go run /tmp/test_plugin_eval.go`

------
https://chatgpt.com/codex/tasks/task_e_68ad044c2764832aa4dec0e7c3009c00