### PR TITLE
Scale pointer with UI

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -37,7 +37,7 @@ func Update() error {
 	prevHovered := hoveredItem
 	hoveredItem = nil
 
-	mx, my := pointerPosition()
+	mx, my := PointerPosition()
 	mpos := point{X: float32(mx), Y: float32(my)}
 
 	click := pointerJustPressed()

--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -18,14 +18,24 @@ var (
 
 const touchScrollScale = 0.05
 
-// pointerPosition returns the current pointer position.
-// If a touch is active, the first touch is used. Otherwise the mouse cursor position is returned.
-func pointerPosition() (int, int) {
+// PointerPosition returns the current pointer position in UI coordinate space.
+// If a touch is active, the first touch is used. Otherwise the mouse cursor
+// position is returned. The result is adjusted by the current UI scale so
+// callers operate in the same coordinate system as the UI layout.
+func PointerPosition() (int, int) {
 	ids := ebiten.AppendTouchIDs(nil)
+	var x, y int
 	if len(ids) > 0 {
-		return ebiten.TouchPosition(ids[0])
+		x, y = ebiten.TouchPosition(ids[0])
+	} else {
+		x, y = ebiten.CursorPosition()
 	}
-	return ebiten.CursorPosition()
+	s := UIScale()
+	if s != 0 {
+		x = int(float32(x) / s)
+		y = int(float32(y) / s)
+	}
+	return x, y
 }
 
 // pointerWheel returns the wheel delta for mouse or two-finger touch scrolling.

--- a/game.go
+++ b/game.go
@@ -544,7 +544,7 @@ func (g *Game) Update() error {
 	updateNotifications()
 	updateThinkMessages()
 
-	mx, my := ebiten.CursorPosition()
+	mx, my := eui.PointerPosition()
 	origX, origY, worldScale := worldDrawInfo()
 	hx := int16(float64(mx-origX)/worldScale - float64(fieldCenterX))
 	hy := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
@@ -760,7 +760,7 @@ func (g *Game) Update() error {
 		}
 	}
 
-	mx, my = ebiten.CursorPosition()
+	mx, my = eui.PointerPosition()
 	// Map mouse to world coordinates accounting for current draw scale/offset.
 	origX, origY, worldScale = worldDrawInfo()
 	baseX := int16(float64(mx-origX)/worldScale - float64(fieldCenterX))


### PR DESCRIPTION
## Summary
- scale pointer coordinates by UIScale instead of device scale
- route game cursor reads through eui.PointerPosition for consistent space

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad19b08bcc832a98bbc759945ac6c3