### PR TITLE
Fix mouse coordinate scaling

### DIFF
--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -20,14 +20,22 @@ const touchScrollScale = 0.05
 
 // PointerPosition returns the current pointer position in screen pixels.
 // If a touch is active, the first touch is used; otherwise the mouse cursor
-// position is returned. The coordinates already match the UI's scaled
-// coordinate space.
+// position is returned. The coordinates are adjusted for the last device scale
+// factor so they match the UI's scaled coordinate space.
 func PointerPosition() (int, int) {
 	ids := ebiten.AppendTouchIDs(nil)
+	var x, y int
 	if len(ids) > 0 {
-		return ebiten.TouchPosition(ids[0])
+		x, y = ebiten.TouchPosition(ids[0])
+	} else {
+		x, y = ebiten.CursorPosition()
 	}
-	return ebiten.CursorPosition()
+
+	if lastDeviceScale != 1.0 {
+		x = int(float64(x) * lastDeviceScale)
+		y = int(float64(y) * lastDeviceScale)
+	}
+	return x, y
 }
 
 // pointerWheel returns the wheel delta for mouse or two-finger touch scrolling.


### PR DESCRIPTION
## Summary
- adjust pointer position with lastDeviceScale so mouse coords match UI scale on HiDPI displays

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2b6ee3c8832a971aa91e4e560dfd