### PR TITLE
fix: correct window input offset

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -228,9 +228,10 @@ func (win *windowData) Draw(screen *ebiten.Image, dropdowns *[]openDropdown) {
 			win.Render.Clear()
 		}
 		origPos := win.Position
+		basePos := win.getPosition()
 		win.Position = point{}
 		win.drawBG(win.Render)
-		win.drawItems(win.Render, origPos, dropdowns)
+		win.drawItems(win.Render, basePos, dropdowns)
 		win.drawScrollbars(win.Render)
 		titleArea := win.Render.SubImage(win.getTitleRect().getRectangle()).(*ebiten.Image)
 		win.drawWinTitle(titleArea)


### PR DESCRIPTION
## Summary
- ensure cached window renders use screen-space base so DrawRect aligns with window position

## Testing
- `go vet ./...` *(fails: Package 'alsa' not found; X11 Xrandr missing)*
- `go test ./...` *(fails: Package 'alsa' not found; X11 Xrandr missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4c569ec8832a8d171d6dfdbc82e8