### PR TITLE
Use macOS container path for data

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -17,15 +17,21 @@ type assetStats struct {
 
 const statsFile = "stats.json"
 
-// dataDirPath holds the absolute path to the "data" directory containing game
-// assets. The path is resolved relative to the executable so assets are placed
-// alongside the binary regardless of the current working directory.
+// dataDirPath holds the absolute path to the directory containing game assets.
+// On macOS the path resolves to the app's container directory so the client can
+// operate inside the sandbox. On other platforms the path is resolved relative
+// to the executable so assets are placed alongside the binary regardless of the
+// current working directory.
 var dataDirPath = func() string {
 	if runtime.GOOS == "darwin" {
 		if home, err := os.UserHomeDir(); err == nil {
-			p := filepath.Join(home, "Library", "Application Support", "goThoom")
-			_ = os.MkdirAll(p, 0o755)
-			return p
+			if filepath.Base(home) == "Data" && filepath.Base(filepath.Dir(home)) == "com.goThoom.client" {
+				home = filepath.Dir(home)
+			} else {
+				home = filepath.Join(home, "Library", "Containers", "com.goThoom.client")
+			}
+			_ = os.MkdirAll(home, 0o755)
+			return home
 		}
 	}
 	if exe, err := os.Executable(); err == nil {


### PR DESCRIPTION
## Summary
- resolve `dataDirPath` to the app container on macOS so the client operates inside the sandbox
- keep existing behavior for other platforms

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adc7ad432c832a8d28ef4c8015ce00