### PR TITLE
Delay window restore until layout

### DIFF
--- a/game.go
+++ b/game.go
@@ -1888,6 +1888,10 @@ func equippedItemPicts() (uint16, uint16) {
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 	scaledW, scaledH := eui.Layout(outsideWidth, outsideHeight)
 
+	if uiReady && !windowsRestored {
+		restoreWindowsAfterScale()
+	}
+
 	if outsideWidth > 512 && outsideHeight > 384 {
 		if gs.WindowWidth != outsideWidth || gs.WindowHeight != outsideHeight {
 			gs.WindowWidth = outsideWidth
@@ -1972,7 +1976,6 @@ func makeGameWindow() {
 		gameWin.SetZone(eui.HZoneCenter, eui.VZoneTop)
 	}
 	gameWin.Size = eui.Point{X: 8000, Y: 8000}
-	gameWin.MarkOpen()
 	gameWin.OnResize = func() { onGameWindowResize() }
 	// Titlebar maximize button controlled by settings (now default on)
 	gameWin.Maximizable = true

--- a/settings.go
+++ b/settings.go
@@ -29,6 +29,11 @@ var gs settings = gsdef
 // settingsLoaded reports whether settings were successfully loaded from disk.
 var settingsLoaded bool
 
+// windowsRestored tracks whether window positions have been restored for the
+// current UI scale. Initialization defers restoration until the first layout
+// provides a final screen size.
+var windowsRestored bool
+
 var gsdef settings = settings{
 	Version: SETTINGS_VERSION,
 
@@ -514,6 +519,17 @@ func restoreWindowSettings() {
 	if hudWin != nil {
 		hudWin.MarkOpen()
 	}
+	windowsRestored = true
+}
+
+// restoreWindowsAfterScale ensures window geometry is applied only after the UI
+// scale and HiDPI settings have been established. It restores saved window
+// positions a single time per scale change.
+func restoreWindowsAfterScale() {
+	if windowsRestored {
+		return
+	}
+	restoreWindowSettings()
 }
 
 type qualityPreset struct {

--- a/ui.go
+++ b/ui.go
@@ -190,8 +190,6 @@ func initUI() {
 	loadPlayersPersist()
 	backfillCharactersFromPlayers()
 
-	restoreWindowSettings()
-
 	if status.NeedImages || status.NeedSounds {
 		downloadWin.MarkOpen()
 	} else if clmov == "" && pcapPath == "" && !fake {
@@ -696,7 +694,6 @@ func makeToolbar() {
 
 	hudWin.AddItem(flow)
 	hudWin.AddWindow(false)
-	hudWin.MarkOpen()
 	updateHandsWindow()
 }
 


### PR DESCRIPTION
## Summary
- Add windowsRestored flag and restoreWindowsAfterScale helper to delay applying saved window geometry
- Remove early window openings in game and toolbar constructors
- Restore windows only after first layout once scaling is known

## Testing
- `go vet ./...` *(fails: Package alsa was not found; Xrandr.h: No such file or directory; gtk+-3.0 package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc7573914832ab3dbcac9e55ba3d1