### PR TITLE
Add macOS app icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ data/global-hotkeys.json
 data/piper
 data/plugins
 example_plugins.zip
+*.icns

--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -222,9 +222,12 @@ for platform in "${platforms[@]}"; do
 
     echo "Creating ${APP_NAME}.app bundle..."
     rm -rf "$APP_DIR"
-    mkdir -p "$APP_DIR/Contents/MacOS"
-    cp "${OUTPUT_DIR}/${BIN_NAME}" "$APP_DIR/Contents/MacOS/${APP_NAME}"
-    cat <<'EOF' >"$APP_DIR/Contents/Info.plist"
+      mkdir -p "$APP_DIR/Contents/MacOS"
+      cp "${OUTPUT_DIR}/${BIN_NAME}" "$APP_DIR/Contents/MacOS/${APP_NAME}"
+      mkdir -p "$APP_DIR/Contents/Resources"
+      ensure_cmd convert imagemagick
+      convert "$SCRIPT_DIR/../goThoom.png" -define icon:auto-resize=16,32,64,128,256,512 "$APP_DIR/Contents/Resources/goThoom.icns"
+      cat <<'EOF' >"$APP_DIR/Contents/Info.plist"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -239,11 +242,13 @@ for platform in "${platforms[@]}"; do
   <string>APPL</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0</string>
-   <key>com.apple.security.app-sandbox</key>
-   <true/>
-</dict>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleIconFile</key>
+    <string>goThoom.icns</string>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+  </dict>
 </plist>
 EOF
 


### PR DESCRIPTION
## Summary
- generate goThoom.icns from goThoom.png at build time
- ignore `.icns` files to avoid committing binaries

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adcd44b23c832a81b6aeb4ebb2cb9d