### PR TITLE
Use rcodesign for ad-hoc mac signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ export MAC_ENTITLEMENTS=scripts/goThoom.entitlements  # override for custom enti
 scripts/build_binaries.sh
 ```
 
+The script uses [rcodesign](https://gregoryszorc.com/projects/apple-codesign/) to ad-hoc sign macOS `.app` bundles when available. Install it on Linux with:
+
+```bash
+curl -L -o rcodesign.tar.gz https://gregoryszorc.com/projects/apple-codesign/releases/latest/linux-x86_64.tar.gz
+tar -xf rcodesign.tar.gz && sudo mv rcodesign /usr/local/bin/
+```
+
 This helper uses [`go-winres`](https://github.com/tc-hib/go-winres) to embed
 `goThoom.png` as the Windows executable icon. To build manually with the icon:
 

--- a/scripts/build_binaries.sh
+++ b/scripts/build_binaries.sh
@@ -263,7 +263,11 @@ for platform in "${platforms[@]}"; do
 </plist>
 EOF
 
-    if command -v codesign >/dev/null 2>&1; then
+    if command -v rcodesign >/dev/null 2>&1; then
+      echo "Ad-hoc signing ${APP_NAME}.app with rcodesign..."
+      rcodesign sign "$APP_DIR" || echo "rcodesign sign failed, continuing" >&2
+      rcodesign verify --verbose "$APP_DIR" || echo "rcodesign verify failed, continuing" >&2
+    elif command -v codesign >/dev/null 2>&1; then
       echo "Codesigning ${APP_NAME}.app..."
       MAC_ENTITLEMENTS="${MAC_ENTITLEMENTS:-${SCRIPT_DIR}/goThoom.entitlements}"
       if [ -f "$MAC_ENTITLEMENTS" ]; then
@@ -272,7 +276,7 @@ EOF
         codesign --force --deep --sign "${MAC_SIGN_IDENTITY:--}" "$APP_DIR" || echo "codesign failed, continuing" >&2
       fi
     else
-      echo "codesign tool not found; skipping macOS signing." >&2
+      echo "rcodesign/codesign not found; skipping macOS signing." >&2
     fi
     rm "${OUTPUT_DIR}/${BIN_NAME}"
   fi


### PR DESCRIPTION
## Summary
- sign macOS `.app` bundles using rcodesign when available
- document rcodesign ad-hoc signing in build instructions

## Testing
- `shellcheck scripts/build_binaries.sh`
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; Xrandr.h missing; gtk+-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68addbf41dc8832a9265810e92f0011a