### PR TITLE
Fix window position updates during resize

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -168,10 +168,8 @@ func Update() error {
 				case PART_TOP:
 					posCh.X = 0
 					sizeCh.X = 0
-					if !win.setSize(pointSub(win.Size, sizeCh)) {
-						if win.zone == nil {
-							win.Position = pointAdd(win.Position, posCh)
-						}
+					if win.setSize(pointSub(win.Size, sizeCh)) && win.zone == nil {
+						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_BOTTOM:
 					sizeCh.X = 0
@@ -179,27 +177,21 @@ func Update() error {
 				case PART_LEFT:
 					posCh.Y = 0
 					sizeCh.Y = 0
-					if !win.setSize(pointSub(win.Size, sizeCh)) {
-						if win.zone == nil {
-							win.Position = pointAdd(win.Position, posCh)
-						}
+					if win.setSize(pointSub(win.Size, sizeCh)) && win.zone == nil {
+						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_RIGHT:
 					sizeCh.Y = 0
 					win.setSize(pointAdd(win.Size, sizeCh))
 				case PART_TOP_LEFT:
-					if !win.setSize(pointSub(win.Size, sizeCh)) {
-						if win.zone == nil {
-							win.Position = pointAdd(win.Position, posCh)
-						}
+					if win.setSize(pointSub(win.Size, sizeCh)) && win.zone == nil {
+						win.Position = pointAdd(win.Position, posCh)
 					}
 				case PART_TOP_RIGHT:
 					tx := win.Size.X + sizeCh.X
 					ty := win.Size.Y - sizeCh.Y
-					if !win.setSize(point{X: tx, Y: ty}) {
-						if win.zone == nil {
-							win.Position.Y += posCh.Y
-						}
+					if win.setSize(point{X: tx, Y: ty}) && win.zone == nil {
+						win.Position.Y += posCh.Y
 					}
 				case PART_BOTTOM_RIGHT:
 					tx := win.Size.X + sizeCh.X
@@ -208,10 +200,8 @@ func Update() error {
 				case PART_BOTTOM_LEFT:
 					tx := win.Size.X - sizeCh.X
 					ty := win.Size.Y + sizeCh.Y
-					if !win.setSize(point{X: tx, Y: ty}) {
-						if win.zone == nil {
-							win.Position.X += posCh.X
-						}
+					if win.setSize(point{X: tx, Y: ty}) && win.zone == nil {
+						win.Position.X += posCh.X
 					}
 				case PART_SCROLL_V:
 					if dragFlow != nil {


### PR DESCRIPTION
## Summary
- ensure window position updates after successful top/left edge and corner resizes when not zoned
- cleanly handle position updates for corner resizes

## Testing
- `go vet ./...` *(fails: Package alsa and X11/GTK development files not found)*
- `go test ./eui` *(fails: X11/extensions/Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb9cf148832a9a86c88f9f26783e