### PR TITLE
Clear plugin macros when plugins unload

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -432,6 +432,7 @@ func disablePlugin(owner, reason string) {
 	for _, hk := range pluginHotkeys(owner) {
 		pluginRemoveHotkey(owner, hk.Combo)
 	}
+	pluginRemoveMacros(owner)
 	pluginMu.Lock()
 	for cmd, o := range pluginCommandOwners {
 		if o == owner {

--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -56,6 +56,15 @@ func pluginAddMacros(owner string, macros map[string]string) {
 	}
 }
 
+// pluginRemoveMacros deletes all macros registered by the specified plugin.
+// It is typically called when a plugin is disabled or unloaded so that any
+// previously registered macro prefixes no longer expand.
+func pluginRemoveMacros(owner string) {
+	macroMu.Lock()
+	delete(macroMaps, owner)
+	macroMu.Unlock()
+}
+
 // pluginAutoReply watches chat messages and runs a command when a message
 // begins with trigger.  Comparison is case-insensitive.  It is handy for simple
 // automatic responses.

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -74,3 +74,35 @@ func TestPluginAutoReplyRunsCommand(t *testing.T) {
 		t.Fatalf("pending command %q, want %q", pendingCommand, "/wave")
 	}
 }
+
+// Test that disabling a plugin removes any macros it registered.
+func TestPluginRemoveMacrosOnDisable(t *testing.T) {
+	// Reset shared state.
+	macroMu = sync.RWMutex{}
+	macroMaps = map[string]map[string]string{}
+	inputHandlersMu = sync.RWMutex{}
+	inputHandlers = nil
+	pluginMu = sync.RWMutex{}
+	pluginDisabled = map[string]bool{}
+	pluginDisplayNames = map[string]string{}
+	pluginTerminators = map[string]func(){}
+	pluginCommandOwners = map[string]string{}
+	pluginCommands = map[string]PluginCommandHandler{}
+	pluginSendHistory = map[string][]time.Time{}
+	hotkeysMu = sync.RWMutex{}
+	hotkeys = nil
+	pluginHotkeyEnabled = map[string]map[string]bool{}
+	consoleLog = messageLog{max: maxMessages}
+
+	owner := "plug"
+	pluginAddMacro(owner, "pp", "/ponder ")
+	if got, want := runInputHandlers("pphello"), "/ponder hello"; got != want {
+		t.Fatalf("macro not added: got %q, want %q", got, want)
+	}
+
+	disablePlugin(owner, "testing")
+
+	if got, want := runInputHandlers("pphello"), "pphello"; got != want {
+		t.Fatalf("macro not removed: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- clear a plugin's macros whenever it is disabled or reloaded
- add helper to drop macro registrations
- verify macros vanish after disabling a plugin

## Testing
- `EBITENGINE_HEADLESS=1 go test -run TestPluginRemoveMacrosOnDisable -count=1` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb56371c832aa91fccfee011115b