### PR TITLE
Avoid grouping distinct inventory items

### DIFF
--- a/inventory_group_test.go
+++ b/inventory_group_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestInventorySeparateNames(t *testing.T) {
+	resetInventory()
+	addInventoryItem(100, -1, "First", false)
+	addInventoryItem(100, -1, "Second", false)
+	items := getInventory()
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestToggleInventoryEquipAt(t *testing.T) {
+	resetInventory()
+	addInventoryItem(100, 0, "Ring A", false)
+	addInventoryItem(100, 1, "Ring B", false)
+	toggleInventoryEquipAt(100, 1)
+	items := getInventory()
+	if !items[1].Equipped {
+		t.Fatalf("expected second item equipped")
+	}
+}


### PR DESCRIPTION
## Summary
- prevent inventory grouping when items share an ID but differ by name or index
- allow equipping a specific indexed item from the inventory window
- test that items with unique names stay separate and equipping by index works

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb9421f8832aa7c5cdbdd21d12fc