### PR TITLE
Restore window settings after UI init

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -196,6 +196,9 @@ func initUI() {
 		loginWin.MarkOpen()
 	}
 	uiReady = true
+	if !windowsRestored {
+		restoreWindowSettings()
+	}
 }
 
 func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData {


### PR DESCRIPTION
## Summary
- Restore window layout from settings immediately after UI initialization, ensuring windows reopen per saved defaults

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adebeec9f8832abe5ca494bbadfd7e