### PR TITLE
Track players' fall times

### DIFF
--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -116,6 +116,7 @@ type Player struct {
 	Ignored    bool
 	Dead       bool
 	FellWhere  string
+	FellTime   time.Time
 	KillerName string
 	Bard       bool
 	LastSeen   time.Time

--- a/player.go
+++ b/player.go
@@ -26,6 +26,7 @@ type Player struct {
 	Ignored     bool // true if player is fully ignored
 	Dead        bool // parsed from obit messages (future)
 	FellWhere   string
+	FellTime    time.Time
 	KillerName  string
 	Bard        bool // true if player is in the Bards' Guild
 	// Presence tracking

--- a/players_persist.go
+++ b/players_persist.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 )
 
 type persistPlayers struct {
@@ -26,6 +27,7 @@ type persistPlayer struct {
 	Bard        bool   `json:"bard,omitempty"`
 	ColorsHex   string `json:"colors,omitempty"` // hex of [count][colors...]
 	FellWhere   string `json:"fell_where,omitempty"`
+	FellTime    int64  `json:"fell_time,omitempty"`
 	KillerName  string `json:"killer,omitempty"`
 }
 
@@ -79,6 +81,11 @@ func loadPlayersPersist() {
 		pr.Ignored = p.Ignored
 		pr.Bard = p.Bard
 		pr.FellWhere = p.FellWhere
+		if p.FellTime != 0 {
+			pr.FellTime = time.Unix(p.FellTime, 0)
+		} else {
+			pr.FellTime = time.Time{}
+		}
 		pr.KillerName = p.KillerName
 		playersMu.Unlock()
 	}
@@ -116,6 +123,10 @@ func savePlayersPersist() {
 			}
 			hex = encodeHex(buf)
 		}
+		var ft int64
+		if !p.FellTime.IsZero() {
+			ft = p.FellTime.Unix()
+		}
 		list = append(list, persistPlayer{
 			Name:        p.Name,
 			Gender:      p.Gender,
@@ -131,6 +142,7 @@ func savePlayersPersist() {
 			Bard:        p.Bard,
 			ColorsHex:   hex,
 			FellWhere:   p.FellWhere,
+			FellTime:    ft,
 			KillerName:  p.KillerName,
 		})
 	}

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -283,6 +283,7 @@ func parseFallenText(raw []byte, s string) bool {
 		p.Dead = true
 		p.KillerName = killer
 		p.FellWhere = where
+		p.FellTime = time.Now()
 		playerCopy := *p
 		playersMu.Unlock()
 		playersDirty = true
@@ -308,6 +309,7 @@ func parseFallenText(raw []byte, s string) bool {
 			p.Dead = false
 			p.FellWhere = ""
 			p.KillerName = ""
+			p.FellTime = time.Time{}
 			playerCopy := *p
 			playersMu.Unlock()
 			playersDirty = true


### PR DESCRIPTION
## Summary
- record when a player falls and clear the timestamp when they recover
- persist each player's fall time to disk and expose it to plugins

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68adf0cf73d0832a84b79a10bb9a707b