### PR TITLE
Use window scale when computing zone positions

### DIFF
--- a/eui/zones.go
+++ b/eui/zones.go
@@ -60,11 +60,12 @@ func (win *windowData) updateZonePosition() {
 	cx := hZoneCoord(win.zone.h, screenWidth)
 	cy := vZoneCoord(win.zone.v, screenHeight)
 	size := win.GetSize()
-	win.Position.X = (cx - size.X/2) / uiScale
-	win.Position.Y = (cy - size.Y/2) / uiScale
+	s := win.scale()
+	win.Position.X = (cx - size.X/2) / s
+	win.Position.Y = (cy - size.Y/2) / s
 
-	maxX := (float32(screenWidth) - size.X) / uiScale
-	maxY := (float32(screenHeight) - size.Y) / uiScale
+	maxX := (float32(screenWidth) - size.X) / s
+	maxY := (float32(screenHeight) - size.Y) / s
 	if maxX < 0 {
 		maxX = 0
 	}


### PR DESCRIPTION
## Summary
- ensure updateZonePosition uses each window's scale instead of global uiScale so NoScale windows stay fixed when changing UIScale

## Testing
- `go vet ./...`
- `go test ./...` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adf23f1714832aae36f97a37c828f0