### PR TITLE
Resettable chat TTS worker

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -2126,7 +2126,7 @@ func makeSettingsWindow() {
 				}
 				updateSoundVolume()
 			}
-			go playChatTTS(ttsTestPhrase)
+			go playChatTTS(chatTTSCtx, ttsTestPhrase)
 		}
 	}
 	left.AddItem(ttsTestBtn)

--- a/update.go
+++ b/update.go
@@ -683,7 +683,7 @@ func downloadDataFiles(clientVer int, status dataFilesStatus, getSoundfont, getP
 			piperPath, piperModel, piperConfig = path, model, cfg
 			gs.ChatTTS = true
 			settingsDirty = true
-			go playChatTTS(ttsTestPhrase)
+			go playChatTTS(chatTTSCtx, ttsTestPhrase)
 		} else {
 			logError("prepare piper: %v", err)
 		}


### PR DESCRIPTION
## Summary
- add cancellable context to chat TTS worker and reset it on stop/disable
- respect cancel signals in playChatTTS
- ensure TTS test calls include context and add regression test for disable behaviour

## Testing
- `go test -run ChatTTS` *(fails: glfw: X11: The DISPLAY environment variable is missing)*
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68ae14aab630832aa60a796de0f21a4c