### PR TITLE
Run plugins asynchronously

### DIFF
--- a/player.go
+++ b/player.go
@@ -132,6 +132,6 @@ func notifyPlayerHandlers(p Player) {
 	handlers := append([]func(Player){}, playerHandlers...)
 	playerHandlersMu.RUnlock()
 	for _, fn := range handlers {
-		fn(p)
+		go fn(p)
 	}
 }

--- a/plugin.go
+++ b/plugin.go
@@ -367,7 +367,7 @@ func loadPluginSource(owner, name, path string, src []byte, restricted interp.Ex
 	}
 	if v, err := i.Eval("Init"); err == nil {
 		if fn, ok := v.Interface().(func()); ok {
-			fn()
+			go fn()
 		}
 	}
 	log.Printf("loaded plugin %s", path)
@@ -427,7 +427,7 @@ func disablePlugin(owner, reason string) {
 	delete(pluginTerminators, owner)
 	pluginMu.Unlock()
 	if term != nil {
-		term()
+		go term()
 	}
 	for _, hk := range pluginHotkeys(owner) {
 		pluginRemoveHotkey(owner, hk.Combo)


### PR DESCRIPTION
## Summary
- Launch plugin `Init` and `Terminate` functions in separate goroutines
- Execute player event handlers concurrently to avoid blocking game updates

## Testing
- `gofmt -w plugin.go player.go`
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1ce3c418832a92fbf8433fbd8340