### PR TITLE
feat: add plugin goroutine watchdog

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -197,6 +198,24 @@ var pluginAllowedPkgs = []string{
 	"strings/strings",
 	"time/time",
 	"unicode/utf8/utf8",
+}
+
+const pluginGoroutineLimit = 1000
+
+func init() {
+	go pluginGoroutineWatchdog()
+}
+
+func pluginGoroutineWatchdog() {
+	for {
+		if runtime.NumGoroutine() > pluginGoroutineLimit {
+			log.Printf("[plugin] goroutine limit exceeded; stopping all plugins")
+			consoleMessage("[plugin] goroutine limit exceeded; stopping plugins")
+			stopAllPlugins()
+			return
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 func restrictedStdlib() interp.Exports {


### PR DESCRIPTION
## Summary
- watch goroutine count and disable all plugins if it exceeds a safety limit

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c1f0bb4832ab0ad8d8d61cbba02