### PR TITLE
Restrict macro expansion to whole words

### DIFF
--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -21,7 +21,7 @@ var (
 // pluginAddMacro registers a single macro for the plugin identified by owner.
 // Typing short text in the chat box will expand into the full string before
 // being sent.  For example, adding ("pp", "/ponder ") means that typing
-// "pphello" becomes "/ponder hello".
+// "pp" or "pp hello" becomes "/ponder " or "/ponder hello" respectively.
 func pluginAddMacro(owner, short, full string) {
 	short = strings.ToLower(short)
 	macroMu.Lock()
@@ -39,7 +39,12 @@ func pluginAddMacro(owner, short, full string) {
 			lower := strings.ToLower(txt)
 			for k, v := range local {
 				if strings.HasPrefix(lower, k) {
-					return v + txt[len(k):]
+					if len(lower) == len(k) {
+						return v
+					}
+					if len(lower) > len(k) && lower[len(k)] == ' ' {
+						return v + txt[len(k)+1:]
+					}
 				}
 			}
 			return txt

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -16,12 +16,20 @@ func TestPluginAddMacroExpandsInput(t *testing.T) {
 
 	pluginAddMacro("tester", "pp", "/ponder ")
 
-	if got, want := runInputHandlers("pphello"), "/ponder hello"; got != want {
-		t.Fatalf("lowercase macro failed: got %q, want %q", got, want)
+	if got, want := runInputHandlers("pp"), "/ponder "; got != want {
+		t.Fatalf("bare macro failed: got %q, want %q", got, want)
 	}
 
-	if got, want := runInputHandlers("PPHello"), "/ponder Hello"; got != want {
+	if got, want := runInputHandlers("pp hello"), "/ponder hello"; got != want {
+		t.Fatalf("lowercase macro with space failed: got %q, want %q", got, want)
+	}
+
+	if got, want := runInputHandlers("PP Hello"), "/ponder Hello"; got != want {
 		t.Fatalf("uppercase macro failed: got %q, want %q", got, want)
+	}
+
+	if got, want := runInputHandlers("pphi"), "pphi"; got != want {
+		t.Fatalf("macro should not expand within word: got %q, want %q", got, want)
 	}
 }
 
@@ -34,10 +42,10 @@ func TestPluginAddMacros(t *testing.T) {
 
 	pluginAddMacros("bulk", map[string]string{"pp": "/ponder ", "hi": "/hello "})
 
-	if got, want := runInputHandlers("ppthere"), "/ponder there"; got != want {
+	if got, want := runInputHandlers("pp there"), "/ponder there"; got != want {
 		t.Fatalf("pp macro failed: got %q, want %q", got, want)
 	}
-	if got, want := runInputHandlers("hiyou"), "/hello you"; got != want {
+	if got, want := runInputHandlers("hi you"), "/hello you"; got != want {
 		t.Fatalf("hi macro failed: got %q, want %q", got, want)
 	}
 }
@@ -96,13 +104,13 @@ func TestPluginRemoveMacrosOnDisable(t *testing.T) {
 
 	owner := "plug"
 	pluginAddMacro(owner, "pp", "/ponder ")
-	if got, want := runInputHandlers("pphello"), "/ponder hello"; got != want {
+	if got, want := runInputHandlers("pp hello"), "/ponder hello"; got != want {
 		t.Fatalf("macro not added: got %q, want %q", got, want)
 	}
 
 	disablePlugin(owner, "testing")
 
-	if got, want := runInputHandlers("pphello"), "pphello"; got != want {
+	if got, want := runInputHandlers("pp hello"), "pp hello"; got != want {
 		t.Fatalf("macro not removed: got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Expand plugin macros only when followed by space or end-of-line
- Test macro behavior with trailing spaces and ensure no expansion within words

## Testing
- `go test ./...` *(fails: Package alsa was not found and X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2d5989f4832a9f6935483697c086