### PR TITLE
Store plugin input handlers per owner

### DIFF
--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -32,7 +32,7 @@ func pluginAddMacro(owner, short, full string) {
 		// Install an input handler the first time this plugin adds a
 		// macro.  It runs whenever the user submits chat text and
 		// replaces any macro prefixes.
-		pluginRegisterInputHandler(func(txt string) string {
+		pluginRegisterInputHandler(owner, func(txt string) string {
 			macroMu.RLock()
 			local := macroMaps[owner]
 			macroMu.RUnlock()

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -12,7 +12,7 @@ func TestPluginAddMacroExpandsInput(t *testing.T) {
 	macroMu = sync.RWMutex{}
 	macroMaps = map[string]map[string]string{}
 	inputHandlersMu = sync.RWMutex{}
-	inputHandlers = nil
+	pluginInputHandlers = map[string][]func(string) string{}
 
 	pluginAddMacro("tester", "pp", "/ponder ")
 
@@ -38,7 +38,7 @@ func TestPluginAddMacros(t *testing.T) {
 	macroMu = sync.RWMutex{}
 	macroMaps = map[string]map[string]string{}
 	inputHandlersMu = sync.RWMutex{}
-	inputHandlers = nil
+	pluginInputHandlers = map[string][]func(string) string{}
 
 	pluginAddMacros("bulk", map[string]string{"pp": "/ponder ", "hi": "/hello "})
 
@@ -55,7 +55,7 @@ func TestPluginAutoReplyRunsCommand(t *testing.T) {
 	macroMu = sync.RWMutex{}
 	macroMaps = map[string]map[string]string{}
 	inputHandlersMu = sync.RWMutex{}
-	inputHandlers = nil
+	pluginInputHandlers = map[string][]func(string) string{}
 	chatHandlersMu = sync.RWMutex{}
 	pluginChatHandlers = map[string][]func(string){}
 	consoleLog = messageLog{max: maxMessages}
@@ -89,7 +89,7 @@ func TestPluginRemoveMacrosOnDisable(t *testing.T) {
 	macroMu = sync.RWMutex{}
 	macroMaps = map[string]map[string]string{}
 	inputHandlersMu = sync.RWMutex{}
-	inputHandlers = nil
+	pluginInputHandlers = map[string][]func(string) string{}
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
 	pluginDisplayNames = map[string]string{}


### PR DESCRIPTION
## Summary
- Store input handlers in a per-owner map guarded by `inputHandlersMu`
- Add `RegisterInputHandler` to plugin exports via owner-aware closure
- Clean up a plugin's input handlers when disabling and expand macro tests

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae303ceb8c832ab58f2085ed46bada