### PR TITLE
Move plugin and input options to advanced settings, gate UI scaling

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	musicDebug    bool
 	clientVersion int
 	experimental  bool
+	showUIScale   bool
 )
 
 func main() {
@@ -65,6 +66,7 @@ func main() {
 	flag.BoolVar(&dumpBEPPTags, "dumpBEPPTags", false, "log BEPP tags seen (for empirical analysis)")
 	flag.BoolVar(&musicDebug, "musicDebug", false, "show bard music messages in chat")
 	flag.BoolVar(&experimental, "experimental", false, "enable experimental features like CL_Images/CL_Sounds patching")
+	flag.BoolVar(&showUIScale, "uiscale", false, "show UI scaling options")
 	genPGO := flag.Bool("pgo", false, "create default.pgo using test.clMov at 30 fps for 30s")
 	flag.Parse()
 


### PR DESCRIPTION
## Summary
- Move spammy plugin kill checkbox to advanced settings
- Relocate smart input update and target ping controls from debug window to advanced settings
- Hide UI scaling controls behind new `-uiscale` flag

## Testing
- `go vet ./...` *(fails: Package 'alsa' not found; Xrandr header missing)*
- `go build ./...` *(fails: Package 'alsa' not found; Xrandr header missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae52680498832ab7a587f0800f934c