### PR TITLE
Ensure command number increments with every packet

### DIFF
--- a/network.go
+++ b/network.go
@@ -158,8 +158,8 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool) 
 		whoLastCommandFrame = ackFrame
 		pendingCommand = ""
 		nextCommand()
-		commandNum++
 	}
+	commandNum++
 	logDebug("player input ack=%d resend=%d cmd=%d mouse=%d,%d flags=%#x", ackFrame, resendFrame, packetCommand, mouseX, mouseY, flags)
 	latencyMu.Lock()
 	lastInputSent = time.Now()

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// bufConn is a simple in-memory net.Conn implementation that collects writes.
+type bufConn struct{ bytes.Buffer }
+
+func (c *bufConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (c *bufConn) Write(b []byte) (int, error)        { return c.Buffer.Write(b) }
+func (c *bufConn) Close() error                       { return nil }
+func (c *bufConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (c *bufConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (c *bufConn) SetDeadline(t time.Time) error      { return nil }
+func (c *bufConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *bufConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "dummy" }
+func (dummyAddr) String() string  { return "dummy" }
+
+// extractCommand reads the command number from a packet written to bufConn.
+func extractCommand(t *testing.T, buf *bufConn) uint32 {
+	data := buf.Bytes()
+	if len(data) < 22 { // size (2) + header (20)
+		t.Fatalf("packet too small: %d bytes", len(data))
+	}
+	size := int(binary.BigEndian.Uint16(data[:2]))
+	if len(data) < 2+size {
+		t.Fatalf("incomplete packet: got %d want %d", len(data)-2, size)
+	}
+	pkt := data[2 : 2+size]
+	return binary.BigEndian.Uint32(pkt[16:20])
+}
+
+func TestSendPlayerInputCommandNumIncrements(t *testing.T) {
+	// Preserve globals used by sendPlayerInput.
+	oldCommandNum := commandNum
+	oldPending := pendingCommand
+	defer func() {
+		commandNum = oldCommandNum
+		pendingCommand = oldPending
+	}()
+
+	commandNum = 1
+	pendingCommand = ""
+
+	conn := &bufConn{}
+	if err := sendPlayerInput(conn, 0, 0, false); err != nil {
+		t.Fatalf("sendPlayerInput: %v", err)
+	}
+	if got, want := commandNum, uint32(2); got != want {
+		t.Fatalf("commandNum=%d, want %d", got, want)
+	}
+	if cmd := extractCommand(t, conn); cmd != 1 {
+		t.Fatalf("packet command=%d, want 1", cmd)
+	}
+
+	conn2 := &bufConn{}
+	if err := sendPlayerInput(conn2, 0, 0, false); err != nil {
+		t.Fatalf("sendPlayerInput: %v", err)
+	}
+	if got, want := commandNum, uint32(3); got != want {
+		t.Fatalf("commandNum=%d, want %d", got, want)
+	}
+	if cmd := extractCommand(t, conn2); cmd != 2 {
+		t.Fatalf("packet command=%d, want 2", cmd)
+	}
+}
+
+func TestSendPlayerInputCommandNumIncrementsWithCommand(t *testing.T) {
+	oldCommandNum := commandNum
+	oldPending := pendingCommand
+	defer func() {
+		commandNum = oldCommandNum
+		pendingCommand = oldPending
+	}()
+
+	commandNum = 10
+	pendingCommand = "/test"
+
+	conn := &bufConn{}
+	if err := sendPlayerInput(conn, 0, 0, false); err != nil {
+		t.Fatalf("sendPlayerInput: %v", err)
+	}
+	if got, want := commandNum, uint32(11); got != want {
+		t.Fatalf("commandNum=%d, want %d", got, want)
+	}
+	if cmd := extractCommand(t, conn); cmd != 10 {
+		t.Fatalf("packet command=%d, want 10", cmd)
+	}
+}


### PR DESCRIPTION
## Summary
- increment `commandNum` for every player input packet
- add tests verifying command sequence numbers increase per send

## Testing
- `go vet ./...`
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aea3a85438832a89f5382f2c33e304