### PR TITLE
Play sound for think messages

### DIFF
--- a/think_messages.go
+++ b/think_messages.go
@@ -9,6 +9,9 @@ import (
 	"gothoom/eui"
 )
 
+// sndThinkTo matches the original client's notification sound for think messages.
+const sndThinkTo = 58
+
 type thinkMessage struct {
 	item   *eui.ItemData
 	expiry time.Time
@@ -22,6 +25,7 @@ func showThinkMessage(msg string) {
 	if gameWin == nil {
 		return
 	}
+	playSound([]uint16{sndThinkTo})
 	btn, events := eui.NewButton()
 	btn.Text = msg
 	btn.FontSize = float32(gs.ChatFontSize)


### PR DESCRIPTION
## Summary
- Play think notification sound when receiving a think message.
- Reference old mac client to match sound ID 58.

## Testing
- `go test ./...` *(fails: command hung; terminated)*
- `go vet ./...` *(fails: command hung; terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68aed5481154832aaee60abdb1bc05ad