### PR TITLE
Do not group clothing items in inventory

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -62,11 +62,14 @@ func updateInventoryWindow() {
 	}
 
 	// Build a unique list of items while counting duplicates and tracking
-	// whether any instance of a given key is equipped. Items are grouped by
-	// ID and name so identical items appear once with a quantity.
+	// whether any instance of a given key is equipped. Non-clothing items are
+	// grouped by ID and name so identical items appear once with a quantity,
+	// while clothing items are listed individually to allow swapping similar
+	// pieces (e.g. different pairs of shoes).
 	type invGroupKey struct {
 		id   uint16
 		name string
+		idx  int
 	}
 	items := getInventory()
 	counts := make(map[invGroupKey]int)
@@ -74,7 +77,17 @@ func updateInventoryWindow() {
 	anyEquipped := make(map[invGroupKey]bool)
 	order := make([]invGroupKey, 0, len(items))
 	for _, it := range items {
+		slot := -1
+		if clImages != nil {
+			slot = clImages.ItemSlot(uint32(it.ID))
+		}
+		isClothing := slot >= kItemSlotForehead && slot <= kItemSlotHead &&
+			slot != kItemSlotRightHand && slot != kItemSlotLeftHand &&
+			slot != kItemSlotBothHands
 		key := invGroupKey{id: it.ID, name: it.Name}
+		if isClothing {
+			key.idx = it.Index
+		}
 		if _, seen := counts[key]; !seen {
 			order = append(order, key)
 			first[key] = it


### PR DESCRIPTION
## Summary
- Treat clothing items as unique entries instead of grouping them so multiple similar pieces (like shoes) can be swapped.

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; X11/extensions/Xrandr.h: No such file or directory; Package 'gtk+-3.0', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed5948cf0832a857542c0610d466f