### PR TITLE
Prevent walking when clicking outside window

### DIFF
--- a/game.go
+++ b/game.go
@@ -772,6 +772,16 @@ func (g *Game) Update() error {
 	click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
 	rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
 
+	winW, winH := ebiten.WindowSize()
+	inWindow := mx >= 0 && my >= 0 && mx < winW && my < winH
+	if click && !inWindow {
+		if walkToggled {
+			walkToggled = false
+		}
+		click = false
+		heldTime = 0
+	}
+
 	if click && pointInUI(mx, my) {
 		uiMouseDown = true
 	}


### PR DESCRIPTION
## Summary
- avoid toggling walk when mouse click occurs outside the window

## Testing
- `go vet .`
- `go test .` *(fails: GLFW library not initialized because DISPLAY is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aed4fce22c832ab2a63545a7744fd6