### PR TITLE
Move inventory quantity suffix after item name

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -180,7 +180,7 @@ func updateInventoryWindow() {
 		icon.Margin = 4
 		row.AddItem(icon)
 
-		// Text label with quantity suffix when >1
+		// Text label with quantity suffix after the name when >1
 		label := it.Name
 		if label == "" && clImages != nil {
 			label = clImages.ItemName(uint32(id))
@@ -189,7 +189,7 @@ func updateInventoryWindow() {
 			label = fmt.Sprintf("Item %d", id)
 		}
 		if qty > 1 {
-			label = fmt.Sprintf("(%v) %v", qty, label)
+			label = fmt.Sprintf("%v (%v)", label, qty)
 		}
 
 		t, _ := eui.NewText()


### PR DESCRIPTION
## Summary
- display stack counts after inventory item names

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path)*
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddc47044832a947f05332da6fa03