### PR TITLE
Avoid extra unequip commands for clothing

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -183,30 +183,12 @@ func equipInventoryItem(id uint16, idx int, equip bool) {
 	inventoryDirty = true
 }
 
-// queueEquipCommand enqueues the necessary server commands to equip an item
-// and unequip any clothing already occupying the same slot. idx is the
-// server-provided 0-based index for template items or -1 otherwise.
+// queueEquipCommand enqueues the server command to equip an item. The server
+// automatically bumps clothing that occupies the same slot, so no explicit
+// /unequip commands are sent here. The local inventory state is adjusted via
+// equipInventoryItem to mirror the server's behavior. idx is the server-
+// provided 0-based index for template items or -1 otherwise.
 func queueEquipCommand(id uint16, idx int) {
-	if clImages != nil {
-		slot := clImages.ItemSlot(uint32(id))
-		isClothing := slot >= kItemSlotForehead && slot <= kItemSlotHead &&
-			slot != kItemSlotRightHand && slot != kItemSlotLeftHand &&
-			slot != kItemSlotBothHands
-		if isClothing {
-			items := getInventory()
-			for _, it := range items {
-				if !it.Equipped {
-					continue
-				}
-				if it.ID == id && (idx < 0 || it.IDIndex == idx) {
-					continue
-				}
-				if clImages.ItemSlot(uint32(it.ID)) == slot {
-					enqueueCommand(fmt.Sprintf("/unequip %d", it.ID))
-				}
-			}
-		}
-	}
 	if idx >= 0 {
 		enqueueCommand(fmt.Sprintf("/equip %d %d", id, idx+1))
 	} else {


### PR DESCRIPTION
## Summary
- Stop queuing `/unequip` commands when equipping clothing; rely on the server to bump conflicting items
- Leave local inventory updates to `equipInventoryItem` so the client mirrors server behavior

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -run TestQueueEquipCommandNoUnequip -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68aedd85879c832aa30989f08fc3bddd