### PR TITLE
test: ensure macro adds only one handler

### DIFF
--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -50,6 +50,30 @@ func TestPluginAddMacros(t *testing.T) {
 	}
 }
 
+// Test that calling pluginAddMacro multiple times for the same plugin
+// installs only one input handler while all macros still expand.
+func TestPluginAddMacroSingleHandler(t *testing.T) {
+	macroMu = sync.RWMutex{}
+	macroMaps = map[string]map[string]string{}
+	inputHandlersMu = sync.RWMutex{}
+	pluginInputHandlers = map[string][]func(string) string{}
+
+	owner := "dup"
+	pluginAddMacro(owner, "pp", "/ponder ")
+	pluginAddMacro(owner, "hi", "/hello ")
+
+	handlers := pluginInputHandlers[owner]
+	if len(handlers) != 1 {
+		t.Fatalf("unexpected handler count: %d", len(handlers))
+	}
+	if got, want := runInputHandlers("pp there"), "/ponder there"; got != want {
+		t.Fatalf("pp macro failed: got %q, want %q", got, want)
+	}
+	if got, want := runInputHandlers("hi you"), "/hello you"; got != want {
+		t.Fatalf("hi macro failed: got %q, want %q", got, want)
+	}
+}
+
 // Test that AutoReply triggers the specified command when the message starts with the trigger.
 func TestPluginAutoReplyRunsCommand(t *testing.T) {
 	macroMu = sync.RWMutex{}


### PR DESCRIPTION
## Summary
- add regression test to verify pluginAddMacro registers a single input handler even when called twice

## Testing
- `EBITENGINE_HEADLESS=1 go test -run PluginAddMacroSingleHandler` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68aee7623ad4832abd9cf17ab83d1528