### PR TITLE
Add plugin hotkeys filter test

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -363,3 +363,33 @@ func TestPluginHotkeyStatePersisted(t *testing.T) {
 		t.Fatalf("plugin hotkey not re-added")
 	}
 }
+func TestPluginHotkeysFilter(t *testing.T) {
+	hotkeys = nil
+	pluginHotkeyEnabled = map[string]map[string]bool{}
+	pluginAddHotkey("plug1", "Ctrl-A", "cmd1")
+	pluginAddHotkey("plug2", "Ctrl-B", "cmd2")
+
+	cases := []struct {
+		name   string
+		owner  string
+		combos []string
+	}{
+		{name: "first", owner: "plug1", combos: []string{"Ctrl-A"}},
+		{name: "second", owner: "plug2", combos: []string{"Ctrl-B"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := pluginHotkeys(tc.owner)
+			if len(got) != len(tc.combos) {
+				t.Fatalf("expected %d combo(s), got %d", len(tc.combos), len(got))
+			}
+			for i, hk := range got {
+				if hk.Combo != tc.combos[i] {
+					t.Fatalf("expected combos %v, got %v", tc.combos, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven test verifying `pluginHotkeys` filters combos per plugin

## Testing
- `EBITENGINE_HEADLESS=1 go test -run TestPluginHotkeysFilter -v` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aee760f758832a849ca773ccfaf4db