### PR TITLE
Prevent walking when clicking outside window

### DIFF
--- a/game.go
+++ b/game.go
@@ -799,7 +799,7 @@ func (g *Game) Update() error {
 	rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
 
 	winW, winH := ebiten.WindowSize()
-	inWindow := mx >= 0 && my >= 0 && mx < winW && my < winH
+	inWindow := mx > 0 && my > 0 && mx < winW-1 && my < winH-1
 	if !focused || !inWindow {
 		if walkToggled {
 			walkToggled = false


### PR DESCRIPTION
## Summary
- avoid starting player walk when clicking on window borders or outside the game window

## Testing
- `go list ./... | grep -v example_plugins | xargs -I{} sh -c 'GOWORK=off go vet {}'`
- `go list ./... | grep -v example_plugins | xargs -I{} sh -c 'GOWORK=off go test {}'` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aef295d700832aa41d34f01e6c3546