### PR TITLE
Avoid interpolating large overlay sprites

### DIFF
--- a/game.go
+++ b/game.go
@@ -1317,6 +1317,13 @@ func drawPicture(screen *ebiten.Image, ox, oy int, p framePicture, alpha float64
 		w, h = clImages.Size(uint32(p.PictID))
 	}
 
+	// Large images on planes above the player are typically fullscreen effects
+	// like weather. Skip interpolation so they don't appear to lag behind.
+	if p.Plane > 0 && (w >= gameAreaSizeX || h >= gameAreaSizeY) {
+		offX = 0
+		offY = 0
+	}
+
 	var mobileX, mobileY float64
 	if gs.ObjectPinning && gs.MotionSmoothing && w <= 500 && h <= 500 {
 		if dx, dy, ok := pictureMobileOffset(p, mobiles, prevMobiles, prevPictures, alpha); ok {


### PR DESCRIPTION
## Summary
- Skip position interpolation for images covering the entire game area when drawn above the player

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aef33aaa60832ab84463cd99d2d67b