### PR TITLE
Notify server of inventory selection

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -346,18 +346,25 @@ func handleInventoryClick(id uint16, idx int) {
 		}
 		lastInvClickTime = time.Time{}
 	} else {
-		selectedInvID = id
-		selectedInvIdx = idx
+		selectInventoryItem(id, idx)
 		lastInvClickID = id
 		lastInvClickIdx = idx
 		lastInvClickTime = now
-		updateInventoryWindow()
 	}
 }
 
 func selectInventoryItem(id uint16, idx int) {
+	if id == selectedInvID && idx == selectedInvIdx {
+		return
+	}
 	selectedInvID = id
 	selectedInvIdx = idx
+	serverIdx := idx
+	if serverIdx < 0 {
+		serverIdx = 0
+	}
+	enqueueCommand(fmt.Sprintf("\\BE-SELECT %d %d", id, serverIdx))
+	nextCommand()
 	updateInventoryWindow()
 }
 


### PR DESCRIPTION
## Summary
- notify server when inventory selection changes by sending `\BE-SELECT`
- reuse `selectInventoryItem` when handling inventory clicks

## Testing
- `go vet ./...` *(fails: Package alsa was not found in the pkg-config search path; X11 headers missing)*
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path; X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aef477ce10832a9461f5971a917705