### PR TITLE
Prevent click-through after closing window

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -136,7 +136,7 @@ func Update() error {
 			if click && dragPart == PART_NONE && downWin == win {
 				if part == PART_CLOSE {
 					win.Close()
-					continue
+					break
 				}
 				if part == PART_MAXIMIZE {
 					if win.OnMaximize != nil {


### PR DESCRIPTION
## Summary
- stop propagating clicks after closing a window to avoid accidental click-through

## Testing
- `go test ./eui` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go vet ./eui` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aef5603ba4832aa9712ecde0fa3152