### PR TITLE
Group duplicate inventory entries in full sync

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -33,6 +33,8 @@ var (
 
 var invFoldCaser = cases.Fold()
 
+const kItemFlagData = 0x0400
+
 // normalizeInventoryName returns a canonical form of an item name for comparisons.
 // It trims whitespace, removes diacritics and performs case folding so items with
 // minor name variations (e.g. capitalization differences) can be coalesced.
@@ -340,15 +342,26 @@ func triggerInventoryShortcut(idx int) {
 }
 
 func setFullInventory(ids []uint16, equipped []bool) {
-	items := make([]InventoryItem, 0, len(ids))
-	seen := make(map[uint16]int)
-	inventoryMu.Lock()
+	oldNames := make(map[inventoryKey]string)
+	inventoryMu.RLock()
+	for k, v := range inventoryNames {
+		oldNames[k] = v
+	}
+	inventoryMu.RUnlock()
+
+	type groupKey struct {
+		id   uint16
+		name string
+	}
+
+	grouped := make([]InventoryItem, 0, len(ids))
+	groupPos := make(map[groupKey]int)
+	tmplCounts := make(map[uint16]int)
 	newNames := make(map[inventoryKey]string)
+
 	for i, id := range ids {
-		key := inventoryKey{ID: id, Index: uint16(i)}
-		name := inventoryNames[key]
+		name := oldNames[inventoryKey{ID: id, Index: uint16(i)}]
 		if name == "" {
-			// Prefer name from CL_Images ClientItem metadata when available.
 			if clImages != nil {
 				if n := clImages.ItemName(uint32(id)); n != "" {
 					name = n
@@ -362,17 +375,47 @@ func setFullInventory(ids []uint16, equipped []bool) {
 				}
 			}
 		}
-		newNames[key] = name
-		equip := false
-		if i < len(equipped) && equipped[i] {
-			equip = true
+		equip := i < len(equipped) && equipped[i]
+
+		isTemplate := false
+		if clImages != nil {
+			if it, ok := clImages.Item(uint32(id)); ok {
+				if it.Flags&kItemFlagData != 0 {
+					isTemplate = true
+				}
+			}
 		}
-		// Assign per-ID index sequentially
-		idIdx := seen[id]
-		items = append(items, InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(items), IDIndex: idIdx, Quantity: 1})
-		seen[id] = idIdx + 1
+
+		if isTemplate {
+			idx := tmplCounts[id]
+			tmplCounts[id] = idx + 1
+			item := InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(grouped), IDIndex: idx, Quantity: 1}
+			grouped = append(grouped, item)
+			if name != "" {
+				newNames[inventoryKey{ID: id, Index: uint16(len(grouped) - 1)}] = name
+			}
+			continue
+		}
+
+		gk := groupKey{id: id, name: normalizeInventoryName(name)}
+		if pos, ok := groupPos[gk]; ok {
+			grouped[pos].Quantity++
+			if equip {
+				grouped[pos].Equipped = true
+			}
+			continue
+		}
+
+		item := InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(grouped), IDIndex: -1, Quantity: 1}
+		grouped = append(grouped, item)
+		groupPos[gk] = len(grouped) - 1
+		if name != "" {
+			newNames[inventoryKey{ID: id, Index: uint16(len(grouped) - 1)}] = name
+		}
 	}
-	inventoryItems = items
+
+	inventoryMu.Lock()
+	inventoryItems = grouped
 	inventoryNames = newNames
 	inventoryMu.Unlock()
 	inventoryDirty = true

--- a/set_full_inventory_group_test.go
+++ b/set_full_inventory_group_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"gothoom/climg"
+)
+
+func testCLImages(items map[uint32]*climg.ClientItem) *climg.CLImages {
+	ci := &climg.CLImages{}
+	rv := reflect.ValueOf(ci).Elem().FieldByName("items")
+	reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem().Set(reflect.ValueOf(items))
+	return ci
+}
+
+func TestSetFullInventoryGroupsNonTemplate(t *testing.T) {
+	resetInventory()
+	old := clImages
+	defer func() { clImages = old }()
+	clImages = testCLImages(map[uint32]*climg.ClientItem{
+		100: {Flags: 0},
+		200: {Flags: kItemFlagData},
+	})
+	ids := []uint16{100, 100, 200, 200}
+	eq := []bool{false, false, false, false}
+	setFullInventory(ids, eq)
+	items := getInventory()
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	if items[0].ID != 100 || items[0].Quantity != 2 || items[0].IDIndex != -1 {
+		t.Fatalf("unexpected first item %+v", items[0])
+	}
+	if items[1].ID != 200 || items[1].IDIndex != 0 || items[1].Quantity != 1 {
+		t.Fatalf("unexpected second item %+v", items[1])
+	}
+	if items[2].ID != 200 || items[2].IDIndex != 1 || items[2].Quantity != 1 {
+		t.Fatalf("unexpected third item %+v", items[2])
+	}
+}


### PR DESCRIPTION
## Summary
- Coalesce legacy inventory items by normalized name during full inventory sync
- Preserve template items with per-ID indices using CL_Images metadata
- Add test covering non-template grouping behavior

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aef670e004832ab04b63c06484f971