### PR TITLE
Preserve custom inventory names across inventory updates

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -20,9 +20,14 @@ type InventoryItem struct {
 	Quantity int
 }
 
+// inventoryKey uniquely identifies an inventory item when storing custom names.
+//
+// Items that support templates are distinguished by a per-ID index provided by
+// the server. Legacy items that do not expose an index use -1 so a name applies
+// to all instances of the same ID.
 type inventoryKey struct {
-	ID    uint16
-	Index uint16
+	ID      uint16
+	IDIndex int16
 }
 
 var (
@@ -64,7 +69,11 @@ func rebuildInventoryIndices() {
 	for i := range inventoryItems {
 		inventoryItems[i].Index = i
 		if inventoryItems[i].Name != "" {
-			inventoryNames[inventoryKey{ID: inventoryItems[i].ID, Index: uint16(i)}] = inventoryItems[i].Name
+			key := inventoryKey{ID: inventoryItems[i].ID, IDIndex: int16(inventoryItems[i].IDIndex)}
+			if inventoryItems[i].IDIndex < 0 {
+				key.IDIndex = -1
+			}
+			inventoryNames[key] = inventoryItems[i].Name
 		}
 	}
 }
@@ -277,19 +286,19 @@ func renameInventoryItem(id uint16, idx int, name string) {
 			if inventoryItems[i].ID == id && inventoryItems[i].IDIndex == idx {
 				inventoryItems[i].Name = name
 				if name != "" {
-					inventoryNames[inventoryKey{ID: id, Index: uint16(i)}] = name
+					inventoryNames[inventoryKey{ID: id, IDIndex: int16(idx)}] = name
 				}
 				break
 			}
 		}
 	} else {
 		// Legacy items without a template index: rename all matching IDs.
+		if name != "" {
+			inventoryNames[inventoryKey{ID: id, IDIndex: -1}] = name
+		}
 		for i := range inventoryItems {
-			if inventoryItems[i].ID == id && inventoryItems[i].IDIndex < 0 {
+			if inventoryItems[i].ID == id {
 				inventoryItems[i].Name = name
-				if name != "" {
-					inventoryNames[inventoryKey{ID: id, Index: uint16(i)}] = name
-				}
 			}
 		}
 	}
@@ -345,20 +354,24 @@ func setFullInventory(ids []uint16, equipped []bool) {
 	inventoryMu.Lock()
 	newNames := make(map[inventoryKey]string)
 	for i, id := range ids {
-		key := inventoryKey{ID: id, Index: uint16(i)}
+		idIdx := seen[id]
+		key := inventoryKey{ID: id, IDIndex: int16(idIdx)}
 		name := inventoryNames[key]
 		if name == "" {
-			// Prefer name from CL_Images ClientItem metadata when available.
-			if clImages != nil {
-				if n := clImages.ItemName(uint32(id)); n != "" {
-					name = n
-				}
-			}
+			name = inventoryNames[inventoryKey{ID: id, IDIndex: -1}]
 			if name == "" {
-				if n, ok := defaultInventoryNames[id]; ok {
-					name = n
-				} else {
-					name = fmt.Sprintf("Item %d", id)
+				// Prefer name from CL_Images ClientItem metadata when available.
+				if clImages != nil {
+					if n := clImages.ItemName(uint32(id)); n != "" {
+						name = n
+					}
+				}
+				if name == "" {
+					if n, ok := defaultInventoryNames[id]; ok {
+						name = n
+					} else {
+						name = fmt.Sprintf("Item %d", id)
+					}
 				}
 			}
 		}
@@ -367,8 +380,6 @@ func setFullInventory(ids []uint16, equipped []bool) {
 		if i < len(equipped) && equipped[i] {
 			equip = true
 		}
-		// Assign per-ID index sequentially
-		idIdx := seen[id]
 		items = append(items, InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(items), IDIndex: idIdx, Quantity: 1})
 		seen[id] = idIdx + 1
 	}


### PR DESCRIPTION
## Summary
- Track custom inventory names by item ID and per-ID index rather than global position
- Rebuild inventory name map and full inventory syncs using the new key, preserving names when items are reordered or updated

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aef80447e0832a92867d191239bea3