### PR TITLE
Prefer item name over CL_Images metadata in inventory UI

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -482,12 +482,9 @@ func promptInventoryShortcut(idx int) {
 }
 
 func officialName(k invGroupKey, it InventoryItem) string {
-	name := ""
-	if clImages != nil {
+	name := it.Name
+	if name == "" && clImages != nil {
 		name = clImages.ItemName(uint32(k.id))
-	}
-	if name == "" {
-		name = it.Name
 	}
 	if name == "" {
 		name = fmt.Sprintf("Item %d", k.id)


### PR DESCRIPTION
## Summary
- show actual inventory item names before falling back to CL_Images metadata

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af09fbd064832ab14c393b53c3c8ef