### PR TITLE
Fix template item naming

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -565,7 +565,9 @@ func handleInvCmdOther(cmd int, data []byte) ([]byte, bool) {
 			logError("inventory: cmd %x missing name", cmd)
 			return nil, false
 		}
-		name = decodeMacRoman(data[:nidx])
+		raw := append([]byte(nil), data[:nidx]...)
+		raw = stripBEPPTags(raw)
+		name = strings.TrimSpace(decodeMacRoman(raw))
 		data = data[nidx+1:]
 	}
 	switch base {

--- a/inventory.go
+++ b/inventory.go
@@ -91,7 +91,8 @@ func addInventoryItem(id uint16, idx int, name string, equip bool) {
 			}
 		}
 		// Append as a distinct instance; keep display order by placing at end
-		item := InventoryItem{ID: id, Name: name, Equipped: equip, Index: len(inventoryItems), IDIndex: idx, Quantity: 1}
+		disp := fmt.Sprintf("%s <#%d>", name, idx+1)
+		item := InventoryItem{ID: id, Name: disp, Equipped: equip, Index: len(inventoryItems), IDIndex: idx, Quantity: 1}
 		inventoryItems = append(inventoryItems, item)
 	} else {
 		// Legacy/non-template: coalesce by ID only when normalized names match.
@@ -286,9 +287,15 @@ func renameInventoryItem(id uint16, idx int, name string) {
 		// retain distinct names.
 		for i := range inventoryItems {
 			if inventoryItems[i].ID == id && inventoryItems[i].IDIndex == idx {
-				inventoryItems[i].Name = name
+				base := inventoryItems[i].Name
+				if p := strings.Index(base, " <#"); p >= 0 {
+					base = base[:p]
+				}
 				if name != "" {
+					inventoryItems[i].Name = fmt.Sprintf("%s <#%d %s>", base, idx+1, name)
 					inventoryNames[inventoryKey{ID: id, IDIndex: int16(idx)}] = name
+				} else {
+					inventoryItems[i].Name = fmt.Sprintf("%s <#%d>", base, idx+1)
 				}
 				break
 			}

--- a/inventory_packets_test.go
+++ b/inventory_packets_test.go
@@ -79,7 +79,8 @@ func TestParseInventoryMacRomanName(t *testing.T) {
 		t.Fatalf("unexpected rest %v", rest)
 	}
 	inv := getInventory()
-	if len(inv) != 1 || inv[0].Name != decodeMacRoman(nameBytes) {
+	want := decodeMacRoman(nameBytes) + " <#1>"
+	if len(inv) != 1 || inv[0].Name != want {
 		t.Fatalf("unexpected inventory %v", inv)
 	}
 	if !inventoryDirty {
@@ -176,7 +177,7 @@ func TestInventoryRenameIndexed(t *testing.T) {
 	if len(inv) != 2 {
 		t.Fatalf("unexpected inventory length %d", len(inv))
 	}
-	if inv[0].Name != "First" || inv[1].Name != "Second" {
+	if inv[0].Name != "Bag <#1 First>" || inv[1].Name != "Bag <#2 Second>" {
 		t.Fatalf("unexpected inventory %v", inv)
 	}
 	if !inventoryDirty {


### PR DESCRIPTION
## Summary
- format indexed inventory items with `<#n>` markers and custom labels
- strip BEPP tags when decoding inventory names

## Testing
- `go vet ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h missing)*
- `go test ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h missing; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0f5bc54c832abd5aadaaf59d5d2c