### PR TITLE
Preserve walking when cursor leaves window

### DIFF
--- a/game.go
+++ b/game.go
@@ -801,10 +801,12 @@ func (g *Game) Update() error {
 
 	winW, winH := ebiten.WindowSize()
 	inWindow := mx > 0 && my > 0 && mx < winW-1 && my < winH-1
-	if !focused || !inWindow {
+	if !focused {
 		if walkToggled {
 			walkToggled = false
 		}
+	}
+	if !focused || !inWindow {
 		click = false
 		rightClick = false
 		heldTime = 0


### PR DESCRIPTION
## Summary
- keep walk toggle active when moving cursor outside game window, only reset on focus loss

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: GLFW library is not initialized; DISPLAY variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af2904ec80832abb91f7a06355c112