### PR TITLE
Use blend copy for ponder bubble wave circles

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -699,6 +699,10 @@ func drawBubbleCircle(screen *ebiten.Image, cx, cy, radius float32, col color.Co
 		vs[i].ColorB = float32(b) / 0xffff
 		vs[i].ColorA = float32(a) / 0xffff
 	}
-	op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true}
+	op := &ebiten.DrawTrianglesOptions{
+		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
+		AntiAlias:      true,
+		Blend:          ebiten.BlendCopy,
+	}
 	screen.DrawTriangles(vs, is, whiteImage, op)
 }


### PR DESCRIPTION
## Summary
- ensure ponder bubble waves use a copy blend so overlapping circles keep uniform alpha

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*


------
https://chatgpt.com/codex/tasks/task_e_68af2975a964832ab13b7de563864e3e