### PR TITLE
Make stop plugins button red and widen toolbar

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -314,8 +314,12 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	stopBtn.Text = "Stop Plugins"
 	stopBtn.Size = eui.Point{X: buttonWidth * 2, Y: buttonHeight}
 	stopBtn.FontSize = toolFontSize
-	stopBtn.Color = eui.ColorDarkRed
-	stopBtn.HoverColor = eui.ColorRed
+
+	stopBtnTheme := *stopBtn.Theme
+	stopBtnTheme.Button.Color = eui.ColorDarkRed
+	stopBtnTheme.Button.HoverColor = eui.ColorRed
+	stopBtnTheme.Button.ClickColor = eui.ColorLightRed
+	stopBtn.Theme = &stopBtnTheme
 	stopEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			stopAllPlugins()
@@ -692,7 +696,7 @@ func makeToolbar() {
 	hudWin.Closable = false
 	hudWin.Resizable = false
 	hudWin.AutoSize = false
-	hudWin.Size = eui.Point{X: 450, Y: 75}
+	hudWin.Size = eui.Point{X: 450 + buttonWidth, Y: 75}
 	hudWin.Movable = true
 	hudWin.NoScroll = true
 	hudWin.SetZone(eui.HZoneLeft, eui.VZoneTop)


### PR DESCRIPTION
## Summary
- Highlight the Stop Plugins control with a custom theme using dark red default, red hover, and light red click colors
- Expand toolbar window width by one button to fit controls

## Testing
- `go vet ./...` *(fails: Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: Package 'alsa' not found)*
- `go test ./...` *(fails: Package 'gtk+-3.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa6a6b54c832a84c59e694d74016c