### PR TITLE
fix walking stop when cursor leaves game window

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -25,3 +25,16 @@ func TestStopWalkIfOutside(t *testing.T) {
 
 	gs.ClickToToggle = old
 }
+
+func TestContinueHeldWalk(t *testing.T) {
+	prev := inputState{mouseDown: true}
+	if !continueHeldWalk(prev, false, true, 0, false) {
+		t.Fatalf("walk should continue when mouse is held outside")
+	}
+	if continueHeldWalk(prev, false, false, 0, false) {
+		t.Fatalf("walk should stop when mouse button is released")
+	}
+	if !continueHeldWalk(inputState{}, true, true, 2, false) {
+		t.Fatalf("walk should start when mouse is held inside game")
+	}
+}


### PR DESCRIPTION
## Summary
- continue walking when the cursor leaves the game window until the mouse button is released
- add tests for continued walking

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afa64b6abc832a952199d6919494b3