### PR TITLE
Avoid GT_Players updates during movie playback

### DIFF
--- a/game.go
+++ b/game.go
@@ -615,7 +615,7 @@ func (g *Game) Update() error {
 	}
 
 	if time.Since(lastPlayersSave) >= 10*time.Second {
-		if playersDirty || playersPersistDirty {
+		if clmov == "" && !playingMovie && (playersDirty || playersPersistDirty) {
 			savePlayersPersist()
 			playersPersistDirty = false
 		}

--- a/movie_player.go
+++ b/movie_player.go
@@ -300,6 +300,15 @@ func (p *moviePlayer) makePlaybackWindow() {
 		}
 		playingMovie = false
 		movieMode = false
+		// Clear any players loaded during playback so GT_Players.json
+		// is unaffected.
+		playersMu.Lock()
+		players = make(map[string]*Player)
+		playersMu.Unlock()
+		loadPlayersPersist()
+		updatePlayersWindow()
+		playersPersistDirty = false
+		playersDirty = false
 		// Clear the selected movie path and reopen the login window.
 		clmov = ""
 		pcapPath = ""


### PR DESCRIPTION
## Summary
- Skip saving players when a clmov movie is being played so GT_Players.json stays unchanged
- Reset in-memory players after closing a movie and reload persisted data

## Testing
- `go vet ./...` *(fails: X11/ALSA/GTK development headers missing)*
- `go build ./...` *(fails: X11/ALSA/GTK development headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afa81a3300832ab7a5f6ebffe775dc