### PR TITLE
Parse image lighting metadata

### DIFF
--- a/climg/light.go
+++ b/climg/light.go
@@ -1,0 +1,20 @@
+package climg
+
+// LightInfo holds lighting metadata for images that emit light or darkness.
+// Color stores RGBA components. For lightcasters only RGB is used and alpha
+// should be 255. For darkcasters RGB will be zero and alpha specifies the
+// darkness intensity. Radius is in pixels and a zero radius indicates the
+// image width should be used. Plane mirrors the picture definition plane.
+type LightInfo struct {
+	Color  [4]byte
+	Radius uint16
+	Plane  int16
+}
+
+// PictDef lighting-related flags.
+const (
+	PictDefFlagEmitsLight         = 0x0200
+	PictDefFlagOnlyAttackPosesLit = 0x0100
+	PictDefFlagLightFlicker       = 0x0080
+	PictDefFlagLightDarkcaster    = 0x0040
+)

--- a/data/shaders/light.kage
+++ b/data/shaders/light.kage
@@ -1,0 +1,50 @@
+package main
+
+const MaxLights = 32
+
+var (
+    LightCount int
+    DarkCount int
+    LightPosX [MaxLights]float
+    LightPosY [MaxLights]float
+    LightRadius [MaxLights]float
+    LightR [MaxLights]float
+    LightG [MaxLights]float
+    LightB [MaxLights]float
+    DarkPosX [MaxLights]float
+    DarkPosY [MaxLights]float
+    DarkRadius [MaxLights]float
+    DarkAlpha [MaxLights]float
+)
+
+func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
+    col := imageSrc0At(texCoord)
+    for i := 0; i < MaxLights; i++ {
+        if i < LightCount {
+            dx := pos.x - LightPosX[i]
+            dy := pos.y - LightPosY[i]
+            dist := sqrt(dx*dx + dy*dy)
+            f := max(0.0, 1.0 - dist/LightRadius[i])
+            col.r += LightR[i] * f
+            col.g += LightG[i] * f
+            col.b += LightB[i] * f
+        }
+    }
+    for i := 0; i < MaxLights; i++ {
+        if i < DarkCount {
+            dx := pos.x - DarkPosX[i]
+            dy := pos.y - DarkPosY[i]
+            dist := sqrt(dx*dx + dy*dy)
+            f := max(0.0, 1.0 - dist/DarkRadius[i])
+            d := DarkAlpha[i] * f
+            col.r *= 1.0 - d
+            col.g *= 1.0 - d
+            col.b *= 1.0 - d
+        }
+    }
+    col.r = clamp(col.r, 0.0, 1.0)
+    col.g = clamp(col.g, 0.0, 1.0)
+    col.b = clamp(col.b, 0.0, 1.0)
+    return col
+}
+

--- a/lighting_shader.go
+++ b/lighting_shader.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	_ "embed"
+	"github.com/hajimehoshi/ebiten/v2"
+	"gothoom/climg"
+)
+
+const maxLights = 32
+
+//go:embed data/shaders/light.kage
+var lightShaderSrc []byte
+
+var (
+	lightingShader *ebiten.Shader
+	lightingTmp    *ebiten.Image
+	frameLights    []lightSource
+	frameDarks     []darkSource
+)
+
+func init() {
+	var err error
+	lightingShader, err = ebiten.NewShader(lightShaderSrc)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type lightSource struct {
+	X, Y    float32
+	Radius  float32
+	R, G, B float32
+}
+
+type darkSource struct {
+	X, Y   float32
+	Radius float32
+	Alpha  float32
+}
+
+func ensureLightingTmp(w, h int) {
+	if lightingTmp == nil || lightingTmp.Bounds().Dx() != w || lightingTmp.Bounds().Dy() != h {
+		lightingTmp = ebiten.NewImage(w, h)
+	}
+}
+
+func applyLightingShader(dst *ebiten.Image, lights []lightSource, darks []darkSource) {
+	w, h := dst.Bounds().Dx(), dst.Bounds().Dy()
+	ensureLightingTmp(w, h)
+	lightingTmp.DrawImage(dst, nil)
+
+	uniforms := map[string]any{
+		"LightCount": len(lights),
+		"DarkCount":  len(darks),
+	}
+	var lposX, lposY, lradius, lr, lg, lb [maxLights]float32
+	for i := 0; i < len(lights) && i < maxLights; i++ {
+		ls := lights[i]
+		lposX[i] = ls.X
+		lposY[i] = ls.Y
+		lradius[i] = ls.Radius
+		lr[i] = ls.R
+		lg[i] = ls.G
+		lb[i] = ls.B
+	}
+	var dposX, dposY, dradius, da [maxLights]float32
+	for i := 0; i < len(darks) && i < maxLights; i++ {
+		ds := darks[i]
+		dposX[i] = ds.X
+		dposY[i] = ds.Y
+		dradius[i] = ds.Radius
+		da[i] = ds.Alpha
+	}
+	uniforms["LightPosX"] = lposX
+	uniforms["LightPosY"] = lposY
+	uniforms["LightRadius"] = lradius
+	uniforms["LightR"] = lr
+	uniforms["LightG"] = lg
+	uniforms["LightB"] = lb
+	uniforms["DarkPosX"] = dposX
+	uniforms["DarkPosY"] = dposY
+	uniforms["DarkRadius"] = dradius
+	uniforms["DarkAlpha"] = da
+
+	op := &ebiten.DrawRectShaderOptions{}
+	op.Images[0] = lightingTmp
+	op.Uniforms = uniforms
+	dst.DrawRectShader(w, h, lightingShader, op)
+}
+
+func addLightSource(pictID uint32, x, y float64, size int) {
+	if !gs.shaderLighting || clImages == nil {
+		return
+	}
+	flags := clImages.Flags(pictID)
+	if flags&climg.PictDefFlagEmitsLight == 0 {
+		return
+	}
+	li, ok := clImages.Lighting(pictID)
+	if !ok {
+		return
+	}
+	radius := float32(li.Radius)
+	if radius == 0 {
+		radius = float32(size)
+	}
+	radius *= float32(gs.GameScale)
+	cx := float32(x)
+	cy := float32(y)
+	if flags&climg.PictDefFlagLightDarkcaster != 0 {
+		if len(frameDarks) < maxLights {
+			alpha := float32(li.Color[3]) / 255
+			frameDarks = append(frameDarks, darkSource{X: cx, Y: cy, Radius: radius, Alpha: alpha})
+		}
+	} else {
+		if len(frameLights) < maxLights {
+			r := float32(li.Color[0]) / 255
+			g := float32(li.Color[1]) / 255
+			b := float32(li.Color[2]) / 255
+			frameLights = append(frameLights, lightSource{X: cx, Y: cy, Radius: radius, R: r, G: g, B: b})
+		}
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -104,6 +104,7 @@ var gsdef settings = settings{
 	EnabledPlugins:  map[string]bool{},
 	vsync:           true,
 	nightEffect:     true,
+	shaderLighting:  false,
 	throttleSounds:  true,
 }
 
@@ -204,6 +205,7 @@ type settings struct {
 	EnabledPlugins      map[string]bool
 	vsync               bool
 	nightEffect         bool
+	shaderLighting      bool
 	precacheSounds      bool
 	precacheImages      bool
 	throttleSounds      bool

--- a/ui.go
+++ b/ui.go
@@ -3538,6 +3538,19 @@ func makeDebugWindow() {
 	}
 	debugFlow.AddItem(pluginOutCB)
 
+	shaderCB, shaderEvents := eui.NewCheckbox()
+	shaderCB.Text = "Shader lighting"
+	shaderCB.Size = eui.Point{X: width, Y: 24}
+	shaderCB.Checked = gs.shaderLighting
+	shaderCB.Tooltip = "Experimental shader-based light and dark rendering"
+	shaderEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.shaderLighting = ev.Checked
+			settingsDirty = true
+		}
+	}
+	debugFlow.AddItem(shaderCB)
+
 	smoothinCB, smoothinEvents := eui.NewCheckbox()
 	smoothinCB.Text = "Tint moving objects red"
 	smoothinCB.Size = eui.Point{X: width, Y: 24}


### PR DESCRIPTION
## Summary
- parse and cache LightingData records for CLImage entries
- expose PictDef lighting flags and helper accessors

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afb768b078832ab27b2365bd743780