### PR TITLE
Handle flexible night command spacing

### DIFF
--- a/night.go
+++ b/night.go
@@ -47,7 +47,9 @@ const ambientNightStrength = 0.4
 
 var blackImg *ebiten.Image
 
-var nightRE = regexp.MustCompile(`(?i)^/nt ([0-9]+) /sa ([-0-9]+) /cl ([01])`)
+// nightRE matches server night commands. Historically the server may send
+// multiple spaces between arguments, so allow flexible whitespace here.
+var nightRE = regexp.MustCompile(`(?i)^/nt\s+([0-9]+)\s+/sa\s+([-0-9]+)\s+/cl\s+([01])`)
 
 func (n *NightInfo) calcCurLevel() {
 	delta := 0

--- a/night_test.go
+++ b/night_test.go
@@ -28,6 +28,14 @@ func TestParseNightCommand(t *testing.T) {
 			cloudy:    false,
 		},
 		{
+			name:      "new style extra spaces",
+			cmd:       "/nt 52  /sa  10  /cl 1",
+			baseLevel: 52,
+			level:     52,
+			azimuth:   10,
+			cloudy:    true,
+		},
+		{
 			name:      "legacy long mixed case",
 			cmd:       "/nT 10 20 30 40",
 			baseLevel: 10,
@@ -55,8 +63,12 @@ func TestParseNightCommand(t *testing.T) {
 			gNight.mu.Unlock()
 			if gotBase != tt.baseLevel || gotLevel != tt.level || gotAzimuth != tt.azimuth || gotCloudy != tt.cloudy {
 				t.Fatalf("parseNightCommand(%q) = {BaseLevel:%d Level:%d Azimuth:%d Cloudy:%v}, want {BaseLevel:%d Level:%d Azimuth:%d Cloudy:%v}", tt.cmd, gotBase, gotLevel, gotAzimuth, gotCloudy, tt.baseLevel, tt.level, tt.azimuth, tt.cloudy)
+			}
+		})
+	}
+}
 
-        func TestCurrentNightLevel(t *testing.T) {
+func TestCurrentNightLevel(t *testing.T) {
 	cases := []struct {
 		name   string
 		force  int


### PR DESCRIPTION
## Summary
- relax night command regex to allow extra spaces
- add coverage for extra-spaced night commands and repair broken night tests

## Testing
- `CGO_ENABLED=0 go vet ./...` *(fails: undefined: context)*
- `go build ./...` *(fails: undefined: context)*

------
https://chatgpt.com/codex/tasks/task_e_68b02e5a927c832aa84610cd26812841