### PR TITLE
fix: preserve whitespace in night command parsing

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -242,9 +242,18 @@ func stripBEPPTags(b []byte) []byte {
 			break
 		}
 		// Preserve MacRoman high-bit printable characters so decodeMacRoman
-		// can convert them (e.g., curly apostrophes). Only drop ASCII control
-		// characters here.
+		// can convert them (e.g., curly apostrophes). Handle ASCII control
+		// characters carefully: keep CR/LF for line splitting and convert
+		// other whitespace to spaces so token boundaries remain intact.
 		if c < 0x20 {
+			switch c {
+			case '\r', '\n':
+				out = append(out, '\r')
+			case '\t', '\v', '\f':
+				out = append(out, ' ')
+			default:
+				// drop any other control character
+			}
 			i++
 			continue
 		}

--- a/night_test.go
+++ b/night_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseNightCommand(t *testing.T) {
 	tests := []struct {
@@ -54,9 +57,30 @@ func TestParseNightCommand(t *testing.T) {
 			gotCloudy := gNight.Cloudy
 			gNight.mu.Unlock()
 			if gotBase != tt.baseLevel || gotLevel != tt.level || gotAzimuth != tt.azimuth || gotCloudy != tt.cloudy {
-				t.Fatalf("parseNightCommand(%q) = {BaseLevel:%d Level:%d Azimuth:%d Cloudy:%v}, want {BaseLevel:%d Level:%d Azimuth:%d Cloudy:%v}", tt.cmd, gotBase, gotLevel, gotAzimuth, gotCloudy, tt.baseLevel, tt.level, tt.azimuth, tt.cloudy)
+				t.Fatalf("parseNightCommand(%q) = {BaseLevel:%d Level:%d Azimuth:%d Cloudy:%v}, want {BaseLevel:%d Level:%d Azimuth:%d Cloudy:%v}",
+					tt.cmd, gotBase, gotLevel, gotAzimuth, gotCloudy, tt.baseLevel, tt.level, tt.azimuth, tt.cloudy)
+			}
+		})
+	}
+}
 
-        func TestCurrentNightLevel(t *testing.T) {
+func TestParseNightCommandWithTabs(t *testing.T) {
+	raw := []byte("/NT 51\t/SA -1\t/CL 0")
+	msg := stripBEPPTags(raw)
+	line := strings.TrimSpace(decodeMacRoman(msg))
+	gNight = NightInfo{}
+	if !parseNightCommand(line) {
+		t.Fatalf("parseNightCommand(%q) = false, want true", line)
+	}
+	gNight.mu.Lock()
+	base, level, az, cloudy := gNight.BaseLevel, gNight.Level, gNight.Azimuth, gNight.Cloudy
+	gNight.mu.Unlock()
+	if base != 51 || level != 51 || az != -1 || cloudy {
+		t.Fatalf("unexpected night data: base=%d level=%d az=%d cloudy=%v", base, level, az, cloudy)
+	}
+}
+
+func TestCurrentNightLevel(t *testing.T) {
 	cases := []struct {
 		name   string
 		force  int
@@ -71,7 +95,6 @@ func TestParseNightCommand(t *testing.T) {
 		{"ForcedDayOverrides", 0, 100, 0, 80, 0},
 		{"Force100FlagOverridesMax", -1, 25, kLightForce100Pct, 80, 80},
 	}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gNight.mu.Lock()


### PR DESCRIPTION
## Summary
- keep tabs and carriage returns when stripping BEPP tags
- test night command parsing with tab-separated values

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02f8e1404832aa5688fa464505d7f