### PR TITLE
Parse night updates from info text

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -453,6 +453,9 @@ func handleInfoText(data []byte) {
 		if s == "" {
 			continue
 		}
+		if parseNightCommand(s) {
+			continue
+		}
 		// Empirical: classic client handles server-sent info-text music commands
 		// like "/music/..." here. Accept only this canonical prefix from
 		// info-text (not bubbles), and otherwise avoid parsing plain text.

--- a/night_test.go
+++ b/night_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -128,5 +127,18 @@ func TestCurrentNightLevel(t *testing.T) {
 				t.Fatalf("currentNightLevel() = %d; want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestHandleInfoTextNight(t *testing.T) {
+	gNight = NightInfo{}
+	handleInfoText([]byte("/nt 42 /sa 10 /cl 1"))
+	gNight.mu.Lock()
+	lvl := gNight.Level
+	az := gNight.Azimuth
+	cloudy := gNight.Cloudy
+	gNight.mu.Unlock()
+	if lvl != 42 || az != 10 || !cloudy {
+		t.Fatalf("handleInfoText did not parse night info: {Level:%d Azimuth:%d Cloudy:%v}", lvl, az, cloudy)
 	}
 }


### PR DESCRIPTION
## Summary
- parse /nt commands from info-text messages so night level updates are not skipped
- add regression test for night parsing from info-text

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68b0322f8224832a81427685090f2ea9