### PR TITLE
Parse BEPP tags instead of stripping

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -236,10 +236,17 @@ func stripBEPPTags(b []byte) []byte {
 				}
 			}
 			if i+2 < len(b) {
+				tagA, tagB := b[i+1], b[i+2]
 				i += 3
+				if j := bytes.Index(b[i:], []byte{0xC2, tagA, tagB}); j >= 0 {
+					out = append(out, stripBEPPTags(b[i:i+j])...)
+					i += j + 3
+					continue
+				}
 				continue
 			}
-			break
+			i++
+			continue
 		}
 		// Preserve MacRoman high-bit printable characters so decodeMacRoman
 		// can convert them (e.g., curly apostrophes). Handle ASCII control

--- a/strip_bepp_tags_test.go
+++ b/strip_bepp_tags_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestStripBEPPTagsPaired(t *testing.T) {
+	raw := []byte{0xC2, 'p', 'n'}
+	raw = append(raw, []byte("Bob")...)
+	raw = append(raw, 0xC2, 'p', 'n')
+	raw = append(raw, []byte(" hi")...)
+	got := string(stripBEPPTags(raw))
+	want := "Bob hi"
+	if got != want {
+		t.Fatalf("stripBEPPTags returned %q, want %q", got, want)
+	}
+}
+
+func TestStripBEPPTagsUnterminated(t *testing.T) {
+	raw := []byte{0xC2, 'p', 'n'}
+	raw = append(raw, []byte("Bob hi")...)
+	got := string(stripBEPPTags(raw))
+	want := "Bob hi"
+	if got != want {
+		t.Fatalf("stripBEPPTags returned %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- parse BEPP tag pairs in `stripBEPPTags` so inner content is preserved
- add unit tests covering paired and unterminated BEPP tags

## Testing
- `go vet ./...` *(fails: night_test.go:4:2: "strings" imported and not used)*
- `go test ./...` *(fails: night_test.go:4:2: "strings" imported and not used)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b033904910832ab28026a640326c50