### PR TITLE
Handle night info in info-text

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -444,6 +444,9 @@ func handleInfoText(data []byte) {
 		if s == "" {
 			continue
 		}
+		if parseNightCommand(s) {
+			continue
+		}
 		// Empirical: classic client handles server-sent info-text music commands
 		// like "/music/..." here. Accept only this canonical prefix from
 		// info-text (not bubbles), and otherwise avoid parsing plain text.

--- a/night_parse_test.go
+++ b/night_parse_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestHandleInfoTextParsesNight(t *testing.T) {
+	gNight = NightInfo{}
+	handleInfoText([]byte("/nt 83 /sa -1 /cl 1\r"))
+	gNight.mu.Lock()
+	lvl := gNight.BaseLevel
+	az := gNight.Azimuth
+	cloudy := gNight.Cloudy
+	gNight.mu.Unlock()
+	if lvl != 83 || az != -1 || !cloudy {
+		t.Fatalf("unexpected night values: level=%d az=%d cloudy=%v", lvl, az, cloudy)
+	}
+}


### PR DESCRIPTION
## Summary
- parse night command lines in info-text
- add test ensuring night parsing works from info text

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68b03acdf440832aabfca992a2a391cb