### PR TITLE
Add flag to enable HD textures

### DIFF
--- a/images.go
+++ b/images.go
@@ -276,7 +276,7 @@ func loadImageFrame(id uint16, frame int) *ebiten.Image {
 		imageMu.Unlock()
 	}
 
-	if frame == 0 {
+	if frame == 0 && hdTextures {
 		if img := loadHDOverride(id); img != nil {
 			statImageLoaded(id)
 			if !gs.NoCaching {

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ var (
 	clientVersion int
 	experimental  bool
 	showUIScale   bool
+	hdTextures    bool
 )
 
 func main() {
@@ -67,6 +68,7 @@ func main() {
 	flag.BoolVar(&musicDebug, "musicDebug", false, "show bard music messages in chat")
 	flag.BoolVar(&experimental, "experimental", false, "enable experimental features like CL_Images/CL_Sounds patching")
 	flag.BoolVar(&showUIScale, "uiscale", false, "show UI scaling options")
+	flag.BoolVar(&hdTextures, "hd", false, "enable HD texture loading from data/hd")
 	genPGO := flag.Bool("pgo", false, "create default.pgo using test.clMov at 30 fps for 30s")
 	flag.Parse()
 


### PR DESCRIPTION
## Summary
- add `-hd` launch flag to enable loading high-resolution texture overrides
- default to standard textures unless `-hd` is specified

## Testing
- `go vet .` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*
- `go build ./...` *(fails: Package gtk+-3.0 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68b046197258832a9d081041b5cbfa22