### PR TITLE
Avoid registering handlers for disabled plugins

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -311,6 +311,10 @@ var (
 	pluginModCheck      time.Time
 )
 
+func pluginIsDisabled(owner string) bool {
+	return pluginDisabled[owner]
+}
+
 // pluginRegisterCommand lets plugins handle a local slash command like
 // "/example". The name should be without the leading slash and will be
 // matched case-insensitively.
@@ -594,7 +598,7 @@ func pluginUnequip(id uint16) {
 }
 
 func pluginRegisterInputHandler(owner string, fn func(string) string) {
-	if fn == nil {
+	if pluginIsDisabled(owner) || fn == nil {
 		return
 	}
 	inputHandlersMu.Lock()
@@ -603,7 +607,7 @@ func pluginRegisterInputHandler(owner string, fn func(string) string) {
 }
 
 func pluginRegisterChatHandler(owner string, fn func(string)) {
-	if fn == nil {
+	if pluginIsDisabled(owner) || fn == nil {
 		return
 	}
 	chatHandlersMu.Lock()
@@ -612,7 +616,7 @@ func pluginRegisterChatHandler(owner string, fn func(string)) {
 }
 
 func pluginRegisterPlayerHandler(owner string, fn func(Player)) {
-	if fn == nil {
+	if pluginIsDisabled(owner) || fn == nil {
 		return
 	}
 	playerHandlersMu.Lock()

--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -23,6 +23,9 @@ var (
 // being sent.  For example, adding ("pp", "/ponder ") means that typing
 // "pp" or "pp hello" becomes "/ponder " or "/ponder hello" respectively.
 func pluginAddMacro(owner, short, full string) {
+	if pluginIsDisabled(owner) {
+		return
+	}
 	short = strings.ToLower(short)
 	macroMu.Lock()
 	m := macroMaps[owner]
@@ -57,6 +60,9 @@ func pluginAddMacro(owner, short, full string) {
 
 // pluginAddMacros registers many macros at once for the given plugin.
 func pluginAddMacros(owner string, macros map[string]string) {
+	if pluginIsDisabled(owner) {
+		return
+	}
 	for k, v := range macros {
 		pluginAddMacro(owner, k, v)
 	}
@@ -76,6 +82,9 @@ func pluginRemoveMacros(owner string) {
 // begins with trigger.  Comparison is case-insensitive.  It is handy for simple
 // automatic responses.
 func pluginAutoReply(owner, trigger, cmd string) {
+	if pluginIsDisabled(owner) {
+		return
+	}
 	trig := strings.ToLower(trigger)
 	pluginRegisterChatHandler(owner, func(msg string) {
 		if strings.HasPrefix(strings.ToLower(msg), trig) {


### PR DESCRIPTION
## Summary
- Guard macro and handler registration with `pluginIsDisabled`
- Add helper `pluginIsDisabled` and skip registration when a plugin is disabled

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0c0496240832a8579a78787265c5b