### PR TITLE
Add plugin console handler for plugins

### DIFF
--- a/console.go
+++ b/console.go
@@ -15,6 +15,16 @@ func consoleMessage(msg string) {
 	appendConsoleLog(msg)
 
 	updateConsoleWindow()
+
+	consoleHandlersMu.RLock()
+	var handlers []func(string)
+	for _, hs := range pluginConsoleHandlers {
+		handlers = append(handlers, hs...)
+	}
+	consoleHandlersMu.RUnlock()
+	for _, h := range handlers {
+		go h(msg)
+	}
 }
 
 func getConsoleMessages() []string {

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -73,6 +73,7 @@ Common API calls:
 - `gt.RegisterInputHandler(func(text string) string)` – inspect or change chat
   text before it is sent.
 - `gt.RegisterChatHandler(func(msg string))` – react to every chat message.
+- `gt.RegisterConsoleHandler(func(msg string))` – react to every console message.
 - `gt.RegisterPlayerHandler(func(p gt.Player))` – react when player info
   changes.
 - `gt.PlayerName()` – name of your current character.

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -131,6 +131,9 @@ func Players() []Player { return nil }
 // RegisterChatHandler registers a callback for incoming chat messages.
 func RegisterChatHandler(fn func(msg string)) {}
 
+// RegisterConsoleHandler registers a callback for console messages.
+func RegisterConsoleHandler(fn func(msg string)) {}
+
 // RegisterInputHandler registers a callback to modify input text before sending.
 func RegisterInputHandler(fn func(text string) string) {}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -110,3 +110,22 @@ func TestPluginRegisterCommandConflict(t *testing.T) {
 		t.Fatalf("original handler overwritten")
 	}
 }
+
+// Test that console handlers registered by plugins receive console messages.
+func TestPluginConsoleHandler(t *testing.T) {
+	pluginConsoleHandlers = map[string][]func(string){}
+	consoleHandlersMu = sync.RWMutex{}
+	pluginDisabled = map[string]bool{}
+	var got string
+	var wg sync.WaitGroup
+	wg.Add(1)
+	pluginRegisterConsoleHandler("test", func(msg string) {
+		got = msg
+		wg.Done()
+	})
+	consoleMessage("hello")
+	wg.Wait()
+	if got != "hello" {
+		t.Fatalf("handler did not run, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- allow plugins to register console message handlers
- expose console handler in plugin API and docs
- test plugin console handler dispatch

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: GLFW library not initialized, DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c7160650832aa6b845aec900b338