### PR TITLE
feat: show macros by plugin

### DIFF
--- a/macros_ui_test.go
+++ b/macros_ui_test.go
@@ -10,11 +10,13 @@ func TestMacrosWindowListsMacros(t *testing.T) {
 	// Reset state and ensure cleanup after the test.
 	macroMu = sync.RWMutex{}
 	macroMaps = map[string]map[string]string{}
+	pluginDisplayNames = map[string]string{}
 	macrosWin = nil
 	macrosList = nil
 	t.Cleanup(func() {
 		macroMu = sync.RWMutex{}
 		macroMaps = map[string]map[string]string{}
+		pluginDisplayNames = map[string]string{}
 		macrosWin = nil
 		macrosList = nil
 	})
@@ -28,10 +30,13 @@ func TestMacrosWindowListsMacros(t *testing.T) {
 	}
 
 	pluginAddMacro("tester", "yy", "/yell ")
-	if len(macrosList.Contents) != 1 {
-		t.Fatalf("macro not added to list: %d", len(macrosList.Contents))
+	if len(macrosList.Contents) != 2 {
+		t.Fatalf("items not added to list: %d", len(macrosList.Contents))
 	}
-	if got := macrosList.Contents[0].Text; got != "yy = /yell" {
+	if got := macrosList.Contents[0].Text; got != "tester:" {
+		t.Fatalf("unexpected plugin text: %q", got)
+	}
+	if got := macrosList.Contents[1].Text; got != "  yy = /yell" {
 		t.Fatalf("unexpected macro text: %q", got)
 	}
 }
@@ -41,11 +46,13 @@ func TestPluginRemoveMacrosRefresh(t *testing.T) {
 	// Reset state and ensure cleanup after the test.
 	macroMu = sync.RWMutex{}
 	macroMaps = map[string]map[string]string{}
+	pluginDisplayNames = map[string]string{}
 	macrosWin = nil
 	macrosList = nil
 	t.Cleanup(func() {
 		macroMu = sync.RWMutex{}
 		macroMaps = map[string]map[string]string{}
+		pluginDisplayNames = map[string]string{}
 		macrosWin = nil
 		macrosList = nil
 	})
@@ -56,8 +63,8 @@ func TestPluginRemoveMacrosRefresh(t *testing.T) {
 	}
 
 	pluginAddMacro("tester", "yy", "/yell ")
-	if len(macrosList.Contents) != 1 {
-		t.Fatalf("macro not added to list: %d", len(macrosList.Contents))
+	if len(macrosList.Contents) != 2 {
+		t.Fatalf("items not added to list: %d", len(macrosList.Contents))
 	}
 
 	// Clear dirty flag so we can detect refresh.


### PR DESCRIPTION
## Summary
- group macros by plugin in the macros window
- ensure macros UI tests cover plugin groupings

## Testing
- `go vet`
- `go test -run 'TestMacrosWindowListsMacros|TestPluginRemoveMacrosRefresh'` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c971f4cc832aa67f4cef73611c21