### PR TITLE
Persist plugin enable/disable immediately

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -430,6 +430,7 @@ func enablePlugin(owner string) {
 	}
 	loadPluginSource(owner, name, path, src, restrictedStdlib())
 	settingsDirty = true
+	saveSettings()
 	refreshPluginsWindow()
 }
 
@@ -500,6 +501,7 @@ func disablePlugin(owner, reason string) {
 	}
 	consoleMessage("[plugin:" + disp + "] stopped: " + reason)
 	settingsDirty = true
+	saveSettings()
 	refreshPluginsWindow()
 }
 


### PR DESCRIPTION
## Summary
- Flush plugin enable/disable state to disk by calling `saveSettings()` right after toggling plugin status.

## Testing
- `go build .`
- `go vet ./...` *(fails: process hung; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d05be3e8832aad2c23e728f0ecec