### PR TITLE
Add trigger-based plugin message hooks

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -42,15 +42,7 @@ func chatMessage(msg string) {
 		})
 	}
 
-	chatHandlersMu.RLock()
-	var handlers []func(string)
-	for _, hs := range pluginChatHandlers {
-		handlers = append(handlers, hs...)
-	}
-	chatHandlersMu.RUnlock()
-	for _, h := range handlers {
-		go h(msg)
-	}
+	runTriggers(msg)
 }
 
 func getChatMessages() []string {

--- a/console.go
+++ b/console.go
@@ -16,15 +16,7 @@ func consoleMessage(msg string) {
 
 	updateConsoleWindow()
 
-	consoleHandlersMu.RLock()
-	var handlers []func(string)
-	for _, hs := range pluginConsoleHandlers {
-		handlers = append(handlers, hs...)
-	}
-	consoleHandlersMu.RUnlock()
-	for _, h := range handlers {
-		go h(msg)
-	}
+	runTriggers(msg)
 }
 
 func getConsoleMessages() []string {

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -72,8 +72,8 @@ Common API calls:
 - `gt.AutoReply(trigger, cmd)` – run a command when chat starts with trigger.
 - `gt.RegisterInputHandler(func(text string) string)` – inspect or change chat
   text before it is sent.
-- `gt.RegisterChatHandler(func(msg string))` – react to every chat message.
-- `gt.RegisterConsoleHandler(func(msg string))` – react to every console message.
+- `gt.RegisterTriggers([]string{"phrase"}, func(msg string))` – react to chat or
+  console messages containing any phrase.
 - `gt.RegisterPlayerHandler(func(p gt.Player))` – react when player info
   changes.
 - `gt.PlayerName()` – name of your current character.

--- a/example_plugins/auto_yes_boats.go
+++ b/example_plugins/auto_yes_boats.go
@@ -13,13 +13,10 @@ func Init() {
 	// Grab our own name in lowercase so comparisons are easy.
 	nameLower := gt.Lower(gt.PlayerName())
 
-	// Watch every chat line the client receives.
-	gt.RegisterChatHandler(func(msg string) {
+	// Watch for boat offers and respond automatically.
+	gt.RegisterTriggers([]string{"my fine boats"}, func(msg string) {
 		lower := gt.Lower(msg)
-
-		// Boat ferrymen say "My fine boats" when offering a ride.
-		// If the message also mentions our name we whisper "yes".
-		if gt.Includes(lower, "my fine boats") && gt.Includes(lower, nameLower) {
+		if gt.Includes(lower, nameLower) {
 			gt.RunCommand("/whisper yes")
 		}
 	})

--- a/example_plugins/coin_lord.go
+++ b/example_plugins/coin_lord.go
@@ -46,7 +46,7 @@ func Init() {
 		}
 		gt.Console(fmt.Sprintf("Coins: %d (%.0f/hr)", clTotal, rate))
 	})
-	gt.RegisterChatHandler(clHandle)
+	gt.RegisterTriggers([]string{"You get "}, clHandle)
 	gt.AddHotkey("Shift-C", "/cwdata")
 }
 

--- a/example_plugins/iron_armor.go
+++ b/example_plugins/iron_armor.go
@@ -19,7 +19,7 @@ func Init() {
 	gt.RegisterCommand("examinearmor", func(args string) { examineArmor() })
 	gt.AddHotkey("Ctrl-F10", "/ironarmortoggle")
 	gt.AddHotkey("Ctrl-F11", "/examinearmor")
-	gt.RegisterChatHandler(func(msg string) {
+	gt.RegisterTriggers([]string{"perfect", "good", "look"}, func(msg string) {
 		armorCondition = msg
 	})
 }

--- a/example_plugins/keep_alive.go
+++ b/example_plugins/keep_alive.go
@@ -15,7 +15,7 @@ var (
 )
 
 func init() {
-	gt.RegisterChatHandler(watchChat)
+	gt.RegisterTriggers([]string{"Please do something to avoid being disconnected."}, watchChat)
 	lastKeepalive = time.Now()
 }
 

--- a/example_plugins/quick_reply.go
+++ b/example_plugins/quick_reply.go
@@ -11,13 +11,10 @@ var lastThinker string // remembers who last thought to us
 
 // Init watches chat for "thinks to you" messages and adds /r.
 func Init() {
-	gt.RegisterChatHandler(func(msg string) {
-		lower := gt.Lower(msg)
-		if gt.Includes(lower, "thinks to you") {
-			words := gt.Words(msg)
-			if len(words) > 0 {
-				lastThinker = words[0]
-			}
+	gt.RegisterTriggers([]string{"thinks to you"}, func(msg string) {
+		words := gt.Words(msg)
+		if len(words) > 0 {
+			lastThinker = words[0]
 		}
 	})
 	gt.RegisterCommand("r", func(args string) {

--- a/example_plugins/rank_decoder.go
+++ b/example_plugins/rank_decoder.go
@@ -68,7 +68,11 @@ var rankMessages = map[string]string{
 }
 
 func Init() {
-	gt.RegisterChatHandler(func(msg string) {
+	phrases := make([]string, 0, len(rankMessages))
+	for phrase := range rankMessages {
+		phrases = append(phrases, phrase)
+	}
+	gt.RegisterTriggers(phrases, func(msg string) {
 		for phrase, rank := range rankMessages {
 			if gt.Includes(msg, phrase) {
 				gt.ShowNotification("Rank " + rank)

--- a/example_plugins/sharecads.go
+++ b/example_plugins/sharecads.go
@@ -25,7 +25,7 @@ func Init() {
 			gt.Console("* Sharecads disabled")
 		}
 	})
-	gt.RegisterChatHandler(handleSharecads)
+	gt.RegisterTriggers([]string{"You sense healing energy from "}, handleSharecads)
 	gt.AddHotkey("Shift-S", "/shcads")
 }
 

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -128,11 +128,8 @@ type Player struct {
 // Players returns the list of known players.
 func Players() []Player { return nil }
 
-// RegisterChatHandler registers a callback for incoming chat messages.
-func RegisterChatHandler(fn func(msg string)) {}
-
-// RegisterConsoleHandler registers a callback for console messages.
-func RegisterConsoleHandler(fn func(msg string)) {}
+// RegisterTriggers registers a callback for messages containing any phrase.
+func RegisterTriggers(phrases []string, fn func(msg string)) {}
 
 // RegisterInputHandler registers a callback to modify input text before sending.
 func RegisterInputHandler(fn func(text string) string) {}

--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -102,7 +102,7 @@ func pluginAutoReply(owner, trigger, cmd string) {
 		return
 	}
 	trig := strings.ToLower(trigger)
-	pluginRegisterChatHandler(owner, func(msg string) {
+	pluginRegisterTriggers(owner, []string{trigger}, func(msg string) {
 		if strings.HasPrefix(strings.ToLower(msg), trig) {
 			pluginRunCommand(owner, cmd)
 		}


### PR DESCRIPTION
## Summary
- add trigger registration API for plugins to react to chat and console phrases
- route messages through trigger hooks in console and chat handlers
- update plugin stubs and examples for trigger-based usage
- track plugin ownership for input and player handlers so they can be cleaned up when plugins unload
- add regression test ensuring triggers are removed when a plugin disables

## Testing
- `go vet ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e117bc08832a9ca46717509e0dc6