### PR TITLE
Condense toolbar tools into Actions menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Piper voices are stored in `data/piper/voices`. The client and `scripts/download
 ## Using the UI
 
 - Windows: Click the `Windows` toolbar button to toggle common panels: Players, Inventory, Chat, Console, Help, Hotkeys, Macros, Mixer, Settings, and more. Window layout and open/closed state persist between runs.
+- Actions: Use the `Actions` toolbar drop-down for Hotkeys, Macros, Plugins, Settings, Help, Snapshot, Mixer, or Exit.
 - Movement: Left-click to walk, or use WASD/arrow keys (hold Shift to run). An optional "Click-to-Toggle Walk" sets a target with one click.
 - Input bar: Press Enter to type; press Enter again to send. Esc cancels. Up/Down browse history. While typing, Ctrl-V pastes and Ctrl-C copies the whole line. Right-click the input bar for Paste / Copy Line / Clear Line (Paste and Clear switch to typing mode and refresh immediately).
 - Chat/Console: Chat and Console are separate windows by default. Right-click any chat or console line to copy it; the line briefly highlights. You can merge chat into the console in Settings.

--- a/data/help.txt
+++ b/data/help.txt
@@ -14,6 +14,7 @@ Communication
 UI Navigation
 -------------
 - Click the "Windows" button on the toolbar to open/close UI windows.
+- Click the "Actions" button on the toolbar for hotkeys, macros, plugins, settings, help, snapshots, mixer, or exit.
 - Mouse wheel scrolls lists and text windows.
 - Window positions, sizes, and open/closed state persist between runs.
 

--- a/ui.go
+++ b/ui.go
@@ -220,95 +220,49 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	}
 	row1.AddItem(winBtn)
 
-	hotBtn, hotEvents := eui.NewButton()
-	hotBtn.Text = "Hotkeys"
-	hotBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	hotBtn.FontSize = toolFontSize
-	hotEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			hotkeysWin.ToggleNear(ev.Item)
+	actionsBtn, actionsEvents := eui.NewButton()
+	actionsBtn.Text = "Actions"
+	actionsBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	actionsBtn.FontSize = toolFontSize
+	actionsEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type != eui.EventClick {
+			return
 		}
-	}
-	row1.AddItem(hotBtn)
-
-	macroBtn, macroEvents := eui.NewButton()
-	macroBtn.Text = "Macros"
-	macroBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	macroBtn.FontSize = toolFontSize
-	macroEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			refreshMacrosList()
-			macrosWin.ToggleNear(ev.Item)
+		r := ev.Item.DrawRect
+		options := []string{
+			"Hotkeys",
+			"Macros",
+			"Plugins",
+			"Settings",
+			"Help",
+			"Snapshot",
+			"Mixer",
+			"Exit",
 		}
+		eui.ShowContextMenu(options, r.X0, r.Y1, func(i int) {
+			switch i {
+			case 0:
+				hotkeysWin.ToggleNear(actionsBtn)
+			case 1:
+				refreshMacrosList()
+				macrosWin.ToggleNear(actionsBtn)
+			case 2:
+				refreshPluginsWindow()
+				pluginsWin.ToggleNear(actionsBtn)
+			case 3:
+				settingsWin.ToggleNear(actionsBtn)
+			case 4:
+				toggleHelpWindow(actionsBtn)
+			case 5:
+				takeScreenshot()
+			case 6:
+				mixerWin.ToggleNear(actionsBtn)
+			case 7:
+				confirmExitSession()
+			}
+		})
 	}
-	row1.AddItem(macroBtn)
-
-	plugBtn, plugEvents := eui.NewButton()
-	plugBtn.Text = "Plugins"
-	plugBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	plugBtn.FontSize = toolFontSize
-	plugEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			refreshPluginsWindow()
-			pluginsWin.ToggleNear(ev.Item)
-		}
-	}
-	row1.AddItem(plugBtn)
-
-	btn, setEvents := eui.NewButton()
-	btn.Text = "Settings"
-	btn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	btn.FontSize = toolFontSize
-	setEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			settingsWin.ToggleNear(ev.Item)
-		}
-	}
-	row1.AddItem(btn)
-
-	helpBtn, helpEvents := eui.NewButton()
-	helpBtn.Text = "Help"
-	helpBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	helpBtn.FontSize = toolFontSize
-	helpEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			toggleHelpWindow(ev.Item)
-		}
-	}
-	row2.AddItem(helpBtn)
-
-	shotBtn, shotEvents := eui.NewButton()
-	shotBtn.Text = "Snapshot"
-	shotBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	shotBtn.FontSize = toolFontSize
-	shotEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			takeScreenshot()
-		}
-	}
-	row2.AddItem(shotBtn)
-
-	exitSessBtn, exitSessEv := eui.NewButton()
-	exitSessBtn.Text = "Exit"
-	exitSessBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
-	exitSessBtn.FontSize = toolFontSize
-	exitSessEv.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			confirmExitSession()
-		}
-	}
-	row2.AddItem(exitSessBtn)
-
-	mixBtn, mixEvents := eui.NewButton()
-	mixBtn.Text = "Mixer"
-	mixBtn.Size = eui.Point{X: 64, Y: buttonHeight}
-	mixBtn.FontSize = 12
-	mixEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventClick {
-			mixerWin.ToggleNear(ev.Item)
-		}
-	}
-	row2.AddItem(mixBtn)
+	row1.AddItem(actionsBtn)
 
 	/*
 		stopBtn, stopEvents := eui.NewButton()


### PR DESCRIPTION
## Summary
- Replace individual Hotkeys/Macros/Plugins/Settings/Help/Snapshot/Mixer/Exit toolbar buttons with a single **Actions** button and drop-down menu
- Document the new Actions drop-down in README and in-game help

## Testing
- `go vet ./...` *(fails: pkg-config could not find gtk+-3.0; installed dependencies but vet still ran for extended time and was terminated)*
- `go build ./...` *(terminated after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ea8b7270832a99a4c386475866de