### PR TITLE
feat(ui): restore toolbar buttons for settings and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Piper voices are stored in `data/piper/voices`. The client and `scripts/download
 ## Using the UI
 
 - Windows: Click the `Windows` toolbar button to toggle common panels: Players, Inventory, Chat, Console, Help, Hotkeys, Macros, Mixer, Settings, and more. Window layout and open/closed state persist between runs.
-- Actions: Use the `Actions` toolbar drop-down for Hotkeys, Macros, Plugins, Settings, Help, Snapshot, Mixer, or Exit.
+- Actions: Use the `Actions` toolbar drop-down for Hotkeys, Macros, or Plugins. Dedicated buttons provide quick access to Settings, Help, Snapshot, Mixer, and Exit.
 - Movement: Left-click to walk, or use WASD/arrow keys (hold Shift to run). An optional "Click-to-Toggle Walk" sets a target with one click.
 - Input bar: Press Enter to type; press Enter again to send. Esc cancels. Up/Down browse history. While typing, Ctrl-V pastes and Ctrl-C copies the whole line. Right-click the input bar for Paste / Copy Line / Clear Line (Paste and Clear switch to typing mode and refresh immediately).
 - Chat/Console: Chat and Console are separate windows by default. Right-click any chat or console line to copy it; the line briefly highlights. You can merge chat into the console in Settings.

--- a/data/help.txt
+++ b/data/help.txt
@@ -14,7 +14,7 @@ Communication
 UI Navigation
 -------------
 - Click the "Windows" button on the toolbar to open/close UI windows.
-- Click the "Actions" button on the toolbar for hotkeys, macros, plugins, settings, help, snapshots, mixer, or exit.
+- Click the "Actions" button on the toolbar for hotkeys, macros, or plugins.
 - Mouse wheel scrolls lists and text windows.
 - Window positions, sizes, and open/closed state persist between runs.
 

--- a/ui.go
+++ b/ui.go
@@ -220,6 +220,17 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 	}
 	row1.AddItem(winBtn)
 
+	btn, setEvents := eui.NewButton()
+	btn.Text = "Settings"
+	btn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	btn.FontSize = toolFontSize
+	setEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			settingsWin.ToggleNear(ev.Item)
+		}
+	}
+	row1.AddItem(btn)
+
 	actionsBtn, actionsEvents := eui.NewButton()
 	actionsBtn.Text = "Actions"
 	actionsBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
@@ -233,11 +244,6 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 			"Hotkeys",
 			"Macros",
 			"Plugins",
-			"Settings",
-			"Help",
-			"Snapshot",
-			"Mixer",
-			"Exit",
 		}
 		eui.ShowContextMenu(options, r.X0, r.Y1, func(i int) {
 			switch i {
@@ -249,38 +255,72 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 			case 2:
 				refreshPluginsWindow()
 				pluginsWin.ToggleNear(actionsBtn)
-			case 3:
-				settingsWin.ToggleNear(actionsBtn)
-			case 4:
-				toggleHelpWindow(actionsBtn)
-			case 5:
-				takeScreenshot()
-			case 6:
-				mixerWin.ToggleNear(actionsBtn)
-			case 7:
-				confirmExitSession()
 			}
 		})
 	}
 	row1.AddItem(actionsBtn)
 
-	/*
-		stopBtn, stopEvents := eui.NewButton()
-		stopBtn.Text = "Stop Plugins"
-		stopBtn.Size = eui.Point{X: buttonWidth * 2, Y: buttonHeight}
-		stopBtn.FontSize = toolFontSize
-
-		stopBtnTheme := *stopBtn.Theme
-		stopBtnTheme.Button.Color = eui.ColorDarkRed
-		stopBtnTheme.Button.HoverColor = eui.ColorRed
-		stopBtnTheme.Button.ClickColor = eui.ColorLightRed
-		stopBtn.Theme = &stopBtnTheme
-		stopEvents.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventClick {
-				stopAllPlugins()
-			}
+	helpBtn, helpEvents := eui.NewButton()
+	helpBtn.Text = "Help"
+	helpBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	helpBtn.FontSize = toolFontSize
+	helpEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			toggleHelpWindow(ev.Item)
 		}
-		row2.AddItem(stopBtn)
+	}
+	row2.AddItem(helpBtn)
+
+	shotBtn, shotEvents := eui.NewButton()
+	shotBtn.Text = "Snapshot"
+	shotBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	shotBtn.FontSize = toolFontSize
+	shotEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			takeScreenshot()
+		}
+	}
+	row2.AddItem(shotBtn)
+
+	exitSessBtn, exitSessEv := eui.NewButton()
+	exitSessBtn.Text = "Exit"
+	exitSessBtn.Size = eui.Point{X: buttonWidth, Y: buttonHeight}
+	exitSessBtn.FontSize = toolFontSize
+	exitSessEv.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			confirmExitSession()
+		}
+	}
+	row2.AddItem(exitSessBtn)
+
+	mixBtn, mixEvents := eui.NewButton()
+	mixBtn.Text = "Mixer"
+	mixBtn.Size = eui.Point{X: 64, Y: buttonHeight}
+	mixBtn.FontSize = 12
+	mixEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			mixerWin.ToggleNear(ev.Item)
+		}
+	}
+	row2.AddItem(mixBtn)
+
+	/*
+	   stopBtn, stopEvents := eui.NewButton()
+	   stopBtn.Text = "Stop Plugins"
+	   stopBtn.Size = eui.Point{X: buttonWidth * 2, Y: buttonHeight}
+	   stopBtn.FontSize = toolFontSize
+
+	   stopBtnTheme := *stopBtn.Theme
+	   stopBtnTheme.Button.Color = eui.ColorDarkRed
+	   stopBtnTheme.Button.HoverColor = eui.ColorRed
+	   stopBtnTheme.Button.ClickColor = eui.ColorLightRed
+	   stopBtn.Theme = &stopBtnTheme
+	   stopEvents.Handle = func(ev eui.UIEvent) {
+	           if ev.Type == eui.EventClick {
+	                   stopAllPlugins()
+	           }
+	   }
+	   row2.AddItem(stopBtn)
 	*/
 
 	// Removed toolbar volume slider and mute button (use Mixer instead)


### PR DESCRIPTION
## Summary
- restore toolbar buttons for Settings, Help, Snapshot, Mixer and Exit
- keep Actions dropdown limited to Hotkeys, Macros and Plugins
- update docs for revised toolbar layout

## Testing
- `golangci-lint run` *(fails: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eda2fc6c832a9f0508ba000ba507