### PR TITLE
Allow dropdown menus to expand to screen height

### DIFF
--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -178,7 +178,7 @@ var defaultDropdown = &itemData{
 	HoverColor:   NewColor(96, 96, 96, 255),
 	ClickColor:   NewColor(0, 160, 160, 255),
 	OutlineColor: NewColor(0, 160, 160, 255),
-	MaxVisible:   5,
+	MaxVisible:   0,
 
 	ShadowSize:  16,
 	ShadowColor: NewColor(0, 0, 0, 160),

--- a/eui/themes/README.md
+++ b/eui/themes/README.md
@@ -37,7 +37,7 @@ Each widget block (`Window`, `Button`, `Text`, `Checkbox`, `Radio`, `Input`, `Sl
 - `OutlineColor` – color of the outline if enabled
 - `DisabledColor` – color when the widget is disabled
 - `SelectedColor` – color for selected state (tabs, sliders, dropdowns)
-- `MaxVisible` – for dropdowns, the maximum visible entries
+- `MaxVisible` – for dropdowns, the maximum visible entries (0 shows as many as fit on screen)
 
 The `Window` block also supports `TitleColor`, `TitleBGColor`, `BorderColor`, `SizeTabColor`, `DragbarColor`, `HoverTitleColor`, `HoverColor`, `ActiveColor` and `TitleTextColor`.
 

--- a/eui/themes/palettes/AccentDark.json
+++ b/eui/themes/palettes/AccentDark.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/AccentLight.json
+++ b/eui/themes/palettes/AccentLight.json
@@ -87,7 +87,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "disabled",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/Black.json
+++ b/eui/themes/palettes/Black.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "disabled",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/ConcreteGray.json
+++ b/eui/themes/palettes/ConcreteGray.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/CorporateBlue.json
+++ b/eui/themes/palettes/CorporateBlue.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/ForestMist.json
+++ b/eui/themes/palettes/ForestMist.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/HighContrast.json
+++ b/eui/themes/palettes/HighContrast.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/NeonNight.json
+++ b/eui/themes/palettes/NeonNight.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/OceanWave.json
+++ b/eui/themes/palettes/OceanWave.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/SlateNight.json
+++ b/eui/themes/palettes/SlateNight.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/SoftNeutral.json
+++ b/eui/themes/palettes/SoftNeutral.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/themes/palettes/SolarFlare.json
+++ b/eui/themes/palettes/SolarFlare.json
@@ -86,7 +86,7 @@
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "SelectedColor": "accent",
-    "MaxVisible": 5
+    "MaxVisible": 0
   },
   "Tab": {
     "TextColor": "text",

--- a/eui/util.go
+++ b/eui/util.go
@@ -472,7 +472,7 @@ func dropdownOpenRect(item *itemData, offset point) (rect, int) {
 	optionH := maxSize.Y
 	visible := item.MaxVisible
 	if visible <= 0 {
-		visible = 5
+		visible = len(item.Options)
 	}
 	if visible > len(item.Options) {
 		visible = len(item.Options)


### PR DESCRIPTION
## Summary
- Remove hard cap on dropdown items so menus grow to fill the screen while leaving a one-item margin
- Default palettes now disable the five-item limit and docs describe 0 as unlimited

## Testing
- `go vet ./eui`
- `go build ./eui`
- `go build` *(fails: plugin.go:27:39: undefined: pluginLogf)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ee0a86ac832a88c7dbeff7c35d75