### PR TITLE
Add triggers window and menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Piper voices are stored in `data/piper/voices`. The client and `scripts/download
 ## Using the UI
 
 - Windows: Click the `Windows` toolbar button to toggle common panels: Players, Inventory, Chat, Console, Help, Hotkeys, Macros, Mixer, Settings, and more. Window layout and open/closed state persist between runs.
-- Actions: Use the `Actions` toolbar drop-down for Hotkeys, Macros, or Plugins. Dedicated buttons provide quick access to Settings, Help, Snapshot, Mixer, and Exit.
+- Actions: Use the `Actions` toolbar drop-down for Hotkeys, Macros, Triggers, or Plugins. Dedicated buttons provide quick access to Settings, Help, Snapshot, Mixer, and Exit.
 - Movement: Left-click to walk, or use WASD/arrow keys (hold Shift to run). An optional "Click-to-Toggle Walk" sets a target with one click.
 - Input bar: Press Enter to type; press Enter again to send. Esc cancels. Up/Down browse history. While typing, Ctrl-V pastes and Ctrl-C copies the whole line. Right-click the input bar for Paste / Copy Line / Clear Line (Paste and Clear switch to typing mode and refresh immediately).
 - Chat/Console: Chat and Console are separate windows by default. Right-click any chat or console line to copy it; the line briefly highlights. You can merge chat into the console in Settings.

--- a/data/help.txt
+++ b/data/help.txt
@@ -42,6 +42,7 @@ Other Windows
 - Help: this guide. Open via Windows → Help.
 - Hotkeys: configure built-in and plugin hotkeys.
 - Macros: define text expansions for the input bar.
+- Triggers: view plugin trigger phrases.
 - Mixer: adjust overall, game, music, and TTS volumes; toggle channels.
 - Settings/Quality: tweak visuals (motion smoothing, blending), sound, notifications, and presets.
 

--- a/plugin.go
+++ b/plugin.go
@@ -500,6 +500,7 @@ func disablePlugin(owner, reason string) {
 		}
 	}
 	triggerHandlersMu.Unlock()
+	refreshTriggersList()
 	playerHandlersMu.Lock()
 	for i := 0; i < len(pluginPlayerHandlers); {
 		if pluginPlayerHandlers[i].owner == owner {
@@ -673,6 +674,7 @@ func pluginRegisterTriggers(owner string, phrases []string, fn func(string)) {
 		pluginTriggers[p] = append(pluginTriggers[p], triggerHandler{owner: owner, fn: fn})
 	}
 	triggerHandlersMu.Unlock()
+	refreshTriggersList()
 }
 
 func pluginRegisterPlayerHandler(owner string, fn func(Player)) {

--- a/triggers_ui.go
+++ b/triggers_ui.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"sort"
+
+	"gothoom/eui"
+)
+
+var (
+	triggersWin  *eui.WindowData
+	triggersList *eui.ItemData
+)
+
+func makeTriggersWindow() {
+	if triggersWin != nil {
+		return
+	}
+	triggersWin = eui.NewWindow()
+	triggersWin.Title = "Triggers"
+	triggersWin.Size = eui.Point{X: 300, Y: 200}
+	triggersWin.Closable = true
+	triggersWin.Movable = true
+	triggersWin.Resizable = true
+	triggersWin.NoScroll = true
+	triggersWin.SetZone(eui.HZoneCenter, eui.VZoneMiddleTop)
+
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	triggersWin.AddItem(flow)
+
+	triggersList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Scrollable: true, Fixed: true}
+	triggersList.Size = triggersWin.Size
+	flow.AddItem(triggersList)
+	triggersWin.OnResize = func() { triggersList.Size = triggersWin.Size }
+	triggersWin.AddWindow(false)
+	refreshTriggersList()
+}
+
+func refreshTriggersList() {
+	if triggersList == nil {
+		return
+	}
+	triggersList.Contents = triggersList.Contents[:0]
+	triggerHandlersMu.RLock()
+	type entry struct {
+		owner    string
+		triggers []string
+	}
+	byOwner := map[string]*entry{}
+	for phrase, hs := range pluginTriggers {
+		for _, h := range hs {
+			e := byOwner[h.owner]
+			if e == nil {
+				e = &entry{owner: h.owner}
+				byOwner[h.owner] = e
+			}
+			e.triggers = append(e.triggers, phrase)
+		}
+	}
+	triggerHandlersMu.RUnlock()
+	var entries []entry
+	for _, e := range byOwner {
+		entries = append(entries, *e)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].owner < entries[j].owner })
+	for _, e := range entries {
+		disp := pluginDisplayNames[e.owner]
+		if disp == "" {
+			disp = e.owner
+		}
+		triggersList.AddItem(&eui.ItemData{ItemType: eui.ITEM_TEXT, Text: disp + ":", Fixed: true})
+		sort.Strings(e.triggers)
+		for _, t := range e.triggers {
+			triggersList.AddItem(&eui.ItemData{ItemType: eui.ITEM_TEXT, Text: "  " + t, Fixed: true})
+		}
+	}
+	if triggersWin != nil {
+		triggersWin.Refresh()
+	}
+}

--- a/triggers_ui_test.go
+++ b/triggers_ui_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// Test that the triggers window lists registered triggers.
+func TestTriggersWindowListsTriggers(t *testing.T) {
+	triggerHandlersMu = sync.RWMutex{}
+	pluginTriggers = map[string][]triggerHandler{}
+	pluginDisplayNames = map[string]string{}
+	triggersWin = nil
+	triggersList = nil
+	macroMu = sync.RWMutex{}
+	macroMaps = map[string]map[string]string{}
+	t.Cleanup(func() {
+		triggerHandlersMu = sync.RWMutex{}
+		pluginTriggers = map[string][]triggerHandler{}
+		pluginDisplayNames = map[string]string{}
+		triggersWin = nil
+		triggersList = nil
+		macroMu = sync.RWMutex{}
+		macroMaps = map[string]map[string]string{}
+	})
+
+	makeTriggersWindow()
+	if triggersList == nil {
+		t.Fatalf("triggers window not initialized")
+	}
+	if len(triggersList.Contents) != 0 {
+		t.Fatalf("expected empty triggers list")
+	}
+
+	pluginRegisterTriggers("tester", []string{"hi"}, func(string) {})
+	if len(triggersList.Contents) != 2 {
+		t.Fatalf("items not added to list: %d", len(triggersList.Contents))
+	}
+	if got := triggersList.Contents[0].Text; got != "tester:" {
+		t.Fatalf("unexpected plugin text: %q", got)
+	}
+	if got := triggersList.Contents[1].Text; got != "  hi" {
+		t.Fatalf("unexpected trigger text: %q", got)
+	}
+}
+
+// Test that disabling a plugin refreshes and clears triggers.
+func TestDisablePluginRefreshesTriggers(t *testing.T) {
+	triggerHandlersMu = sync.RWMutex{}
+	pluginTriggers = map[string][]triggerHandler{}
+	pluginDisplayNames = map[string]string{}
+	triggersWin = nil
+	triggersList = nil
+	macroMu = sync.RWMutex{}
+	macroMaps = map[string]map[string]string{}
+	pluginMu = sync.RWMutex{}
+	pluginDisabled = map[string]bool{}
+	pluginTerminators = map[string]func(){}
+	t.Cleanup(func() {
+		triggerHandlersMu = sync.RWMutex{}
+		pluginTriggers = map[string][]triggerHandler{}
+		pluginDisplayNames = map[string]string{}
+		triggersWin = nil
+		triggersList = nil
+		macroMu = sync.RWMutex{}
+		macroMaps = map[string]map[string]string{}
+		pluginMu = sync.RWMutex{}
+		pluginDisabled = map[string]bool{}
+		pluginTerminators = map[string]func(){}
+	})
+
+	makeTriggersWindow()
+	pluginRegisterTriggers("plug", []string{"yo"}, func(string) {})
+	if len(triggersList.Contents) != 2 {
+		t.Fatalf("items not added to list: %d", len(triggersList.Contents))
+	}
+	triggersWin.Dirty = false
+	disablePlugin("plug", "test")
+	if len(triggersList.Contents) != 0 {
+		t.Fatalf("triggers list not cleared: %d", len(triggersList.Contents))
+	}
+	if !triggersWin.Dirty {
+		t.Fatalf("triggers window not refreshed")
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -182,6 +182,7 @@ func initUI() {
 	makePlayersWindow()
 	makeMacrosWindow()
 	makeHotkeysWindow()
+	makeTriggersWindow()
 	makePluginsWindow()
 	makeMixerWindow()
 	makeToolbar()
@@ -243,6 +244,7 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 		options := []string{
 			"Hotkeys",
 			"Macros",
+			"Triggers",
 			"Plugins",
 		}
 		eui.ShowContextMenu(options, r.X0, r.Y1, func(i int) {
@@ -253,6 +255,9 @@ func buildToolbar(toolFontSize, buttonWidth, buttonHeight float32) *eui.ItemData
 				refreshMacrosList()
 				macrosWin.ToggleNear(actionsBtn)
 			case 2:
+				refreshTriggersList()
+				triggersWin.ToggleNear(actionsBtn)
+			case 3:
 				refreshPluginsWindow()
 				pluginsWin.ToggleNear(actionsBtn)
 			}


### PR DESCRIPTION
## Summary
- add triggers UI window listing plugin trigger phrases
- expose triggers window via Actions toolbar menu
- refresh triggers list on plugin updates

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11 DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f259b83c832abd80cd6b3ccf6f38