### PR TITLE
Add named chat triggers and console trigger registration

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -42,7 +42,7 @@ func chatMessage(msg string) {
 		})
 	}
 
-	runTriggers(msg)
+	runChatTriggers(msg)
 }
 
 func getChatMessages() []string {

--- a/console.go
+++ b/console.go
@@ -16,7 +16,7 @@ func consoleMessage(msg string) {
 
 	updateConsoleWindow()
 
-	runTriggers(msg)
+	runConsoleTriggers(msg)
 }
 
 func getConsoleMessages() []string {

--- a/example_plugins/README.txt
+++ b/example_plugins/README.txt
@@ -72,8 +72,8 @@ Common API calls:
 - `gt.AutoReply(trigger, cmd)` – run a command when chat starts with trigger.
 - `gt.RegisterInputHandler(func(text string) string)` – inspect or change chat
   text before it is sent.
-- `gt.RegisterTriggers([]string{"phrase"}, func(msg string))` – react to chat or
-  console messages containing any phrase.
+- `gt.RegisterTriggers(name, []string{"phrase"}, func(msg string))` – react to chat messages containing any phrase from the given speaker (name can be "" for any).
+- `gt.RegisterConsoleTriggers([]string{"phrase"}, func(msg string))` – react to console messages containing any phrase.
 - `gt.RegisterPlayerHandler(func(p gt.Player))` – react when player info
   changes.
 - `gt.PlayerName()` – name of your current character.

--- a/example_plugins/auto_yes_boats.go
+++ b/example_plugins/auto_yes_boats.go
@@ -14,7 +14,7 @@ func Init() {
 	nameLower := gt.Lower(gt.PlayerName())
 
 	// Watch for boat offers and respond automatically.
-	gt.RegisterTriggers([]string{"my fine boats"}, func(msg string) {
+	gt.RegisterTriggers("", []string{"my fine boats"}, func(msg string) {
 		lower := gt.Lower(msg)
 		if gt.Includes(lower, nameLower) {
 			gt.RunCommand("/whisper yes")

--- a/example_plugins/coin_lord.go
+++ b/example_plugins/coin_lord.go
@@ -46,7 +46,7 @@ func Init() {
 		}
 		gt.Console(fmt.Sprintf("Coins: %d (%.0f/hr)", clTotal, rate))
 	})
-	gt.RegisterTriggers([]string{"You get "}, clHandle)
+	gt.RegisterTriggers("", []string{"You get "}, clHandle)
 	gt.AddHotkey("Shift-C", "/cwdata")
 }
 

--- a/example_plugins/iron_armor.go
+++ b/example_plugins/iron_armor.go
@@ -19,7 +19,7 @@ func Init() {
 	gt.RegisterCommand("examinearmor", func(args string) { examineArmor() })
 	gt.AddHotkey("Ctrl-F10", "/ironarmortoggle")
 	gt.AddHotkey("Ctrl-F11", "/examinearmor")
-	gt.RegisterTriggers([]string{"perfect", "good", "look"}, func(msg string) {
+	gt.RegisterTriggers("", []string{"perfect", "good", "look"}, func(msg string) {
 		armorCondition = msg
 	})
 }

--- a/example_plugins/keep_alive.go
+++ b/example_plugins/keep_alive.go
@@ -15,7 +15,7 @@ var (
 )
 
 func init() {
-	gt.RegisterTriggers([]string{"Please do something to avoid being disconnected."}, watchChat)
+	gt.RegisterTriggers("", []string{"Please do something to avoid being disconnected."}, watchChat)
 	lastKeepalive = time.Now()
 }
 

--- a/example_plugins/quick_reply.go
+++ b/example_plugins/quick_reply.go
@@ -11,7 +11,7 @@ var lastThinker string // remembers who last thought to us
 
 // Init watches chat for "thinks to you" messages and adds /r.
 func Init() {
-	gt.RegisterTriggers([]string{"thinks to you"}, func(msg string) {
+	gt.RegisterTriggers("", []string{"thinks to you"}, func(msg string) {
 		words := gt.Words(msg)
 		if len(words) > 0 {
 			lastThinker = words[0]

--- a/example_plugins/rank_decoder.go
+++ b/example_plugins/rank_decoder.go
@@ -72,7 +72,7 @@ func Init() {
 	for phrase := range rankMessages {
 		phrases = append(phrases, phrase)
 	}
-	gt.RegisterTriggers(phrases, func(msg string) {
+	gt.RegisterTriggers("", phrases, func(msg string) {
 		for phrase, rank := range rankMessages {
 			if gt.Includes(msg, phrase) {
 				gt.ShowNotification("Rank " + rank)

--- a/example_plugins/sharecads.go
+++ b/example_plugins/sharecads.go
@@ -25,7 +25,7 @@ func Init() {
 			gt.Console("* Sharecads disabled")
 		}
 	})
-	gt.RegisterTriggers([]string{"You sense healing energy from "}, handleSharecads)
+	gt.RegisterTriggers("", []string{"You sense healing energy from "}, handleSharecads)
 	gt.AddHotkey("Shift-S", "/shcads")
 }
 

--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -128,8 +128,13 @@ type Player struct {
 // Players returns the list of known players.
 func Players() []Player { return nil }
 
-// RegisterTriggers registers a callback for messages containing any phrase.
-func RegisterTriggers(phrases []string, fn func(msg string)) {}
+// RegisterTriggers registers a callback for chat messages containing any phrase
+// from the specified player name. An empty name matches any speaker.
+func RegisterTriggers(name string, phrases []string, fn func(msg string)) {}
+
+// RegisterConsoleTriggers registers a callback for console messages containing
+// any phrase.
+func RegisterConsoleTriggers(phrases []string, fn func(msg string)) {}
 
 // RegisterInputHandler registers a callback to modify input text before sending.
 func RegisterInputHandler(fn func(text string) string) {}

--- a/plugin.go
+++ b/plugin.go
@@ -83,8 +83,11 @@ func exportsForPlugin(owner string) interp.Exports {
 		m["AddMacro"] = reflect.ValueOf(func(short, full string) { pluginAddMacro(owner, short, full) })
 		m["AddMacros"] = reflect.ValueOf(func(macros map[string]string) { pluginAddMacros(owner, macros) })
 		m["AutoReply"] = reflect.ValueOf(func(trigger, cmd string) { pluginAutoReply(owner, trigger, cmd) })
-		m["RegisterTriggers"] = reflect.ValueOf(func(phrases []string, handler func(string)) {
-			pluginRegisterTriggers(owner, phrases, handler)
+		m["RegisterTriggers"] = reflect.ValueOf(func(name string, phrases []string, handler func(string)) {
+			pluginRegisterTriggers(owner, name, phrases, handler)
+		})
+		m["RegisterConsoleTriggers"] = reflect.ValueOf(func(phrases []string, handler func(string)) {
+			pluginRegisterConsoleTriggers(owner, phrases, handler)
 		})
 		m["RegisterInputHandler"] = reflect.ValueOf(func(fn func(string) string) { pluginRegisterInputHandler(owner, fn) })
 		m["RegisterPlayerHandler"] = reflect.ValueOf(func(fn func(Player)) { pluginRegisterPlayerHandler(owner, fn) })
@@ -300,6 +303,7 @@ type PluginCommandHandler func(args string)
 
 type triggerHandler struct {
 	owner string
+	name  string
 	fn    func(string)
 }
 
@@ -309,21 +313,22 @@ type inputHandler struct {
 }
 
 var (
-	pluginCommands      = map[string]PluginCommandHandler{}
-	pluginMu            sync.RWMutex
-	pluginNames         = map[string]bool{}
-	pluginDisplayNames  = map[string]string{}
-	pluginDisabled      = map[string]bool{}
-	pluginPaths         = map[string]string{}
-	pluginTerminators   = map[string]func(){}
-	pluginTriggers      = map[string][]triggerHandler{}
-	triggerHandlersMu   sync.RWMutex
-	pluginInputHandlers []inputHandler
-	inputHandlersMu     sync.RWMutex
-	pluginCommandOwners = map[string]string{}
-	pluginSendHistory   = map[string][]time.Time{}
-	pluginModTime       time.Time
-	pluginModCheck      time.Time
+	pluginCommands        = map[string]PluginCommandHandler{}
+	pluginMu              sync.RWMutex
+	pluginNames           = map[string]bool{}
+	pluginDisplayNames    = map[string]string{}
+	pluginDisabled        = map[string]bool{}
+	pluginPaths           = map[string]string{}
+	pluginTerminators     = map[string]func(){}
+	pluginTriggers        = map[string][]triggerHandler{}
+	pluginConsoleTriggers = map[string][]triggerHandler{}
+	triggerHandlersMu     sync.RWMutex
+	pluginInputHandlers   []inputHandler
+	inputHandlersMu       sync.RWMutex
+	pluginCommandOwners   = map[string]string{}
+	pluginSendHistory     = map[string][]time.Time{}
+	pluginModTime         time.Time
+	pluginModCheck        time.Time
 )
 
 // pluginRegisterCommand lets plugins handle a local slash command like
@@ -499,6 +504,20 @@ func disablePlugin(owner, reason string) {
 			pluginTriggers[phrase] = hs[:n]
 		}
 	}
+	for phrase, hs := range pluginConsoleTriggers {
+		n := 0
+		for _, h := range hs {
+			if h.owner != owner {
+				hs[n] = h
+				n++
+			}
+		}
+		if n == 0 {
+			delete(pluginConsoleTriggers, phrase)
+		} else {
+			pluginConsoleTriggers[phrase] = hs[:n]
+		}
+	}
 	triggerHandlersMu.Unlock()
 	playerHandlersMu.Lock()
 	for i := 0; i < len(pluginPlayerHandlers); {
@@ -660,7 +679,23 @@ func pluginRegisterInputHandler(owner string, fn func(string) string) {
 	inputHandlersMu.Unlock()
 }
 
-func pluginRegisterTriggers(owner string, phrases []string, fn func(string)) {
+func pluginRegisterTriggers(owner, name string, phrases []string, fn func(string)) {
+	if pluginIsDisabled(owner) || fn == nil {
+		return
+	}
+	triggerHandlersMu.Lock()
+	name = strings.ToLower(name)
+	for _, p := range phrases {
+		if p == "" {
+			continue
+		}
+		p = strings.ToLower(p)
+		pluginTriggers[p] = append(pluginTriggers[p], triggerHandler{owner: owner, name: name, fn: fn})
+	}
+	triggerHandlersMu.Unlock()
+}
+
+func pluginRegisterConsoleTriggers(owner string, phrases []string, fn func(string)) {
 	if pluginIsDisabled(owner) || fn == nil {
 		return
 	}
@@ -670,7 +705,7 @@ func pluginRegisterTriggers(owner string, phrases []string, fn func(string)) {
 			continue
 		}
 		p = strings.ToLower(p)
-		pluginTriggers[p] = append(pluginTriggers[p], triggerHandler{owner: owner, fn: fn})
+		pluginConsoleTriggers[p] = append(pluginConsoleTriggers[p], triggerHandler{owner: owner, fn: fn})
 	}
 	triggerHandlersMu.Unlock()
 }
@@ -699,10 +734,26 @@ func runInputHandlers(txt string) string {
 	return txt
 }
 
-func runTriggers(msg string) {
+func runChatTriggers(msg string) {
 	triggerHandlersMu.RLock()
 	msgLower := strings.ToLower(msg)
+	speaker := strings.ToLower(chatSpeaker(msg))
 	for phrase, hs := range pluginTriggers {
+		if strings.Contains(msgLower, phrase) {
+			for _, h := range hs {
+				if h.name == "" || h.name == speaker {
+					go h.fn(msg)
+				}
+			}
+		}
+	}
+	triggerHandlersMu.RUnlock()
+}
+
+func runConsoleTriggers(msg string) {
+	triggerHandlersMu.RLock()
+	msgLower := strings.ToLower(msg)
+	for phrase, hs := range pluginConsoleTriggers {
 		if strings.Contains(msgLower, phrase) {
 			for _, h := range hs {
 				go h.fn(msg)

--- a/plugin_macros.go
+++ b/plugin_macros.go
@@ -102,7 +102,7 @@ func pluginAutoReply(owner, trigger, cmd string) {
 		return
 	}
 	trig := strings.ToLower(trigger)
-	pluginRegisterTriggers(owner, []string{trigger}, func(msg string) {
+	pluginRegisterTriggers(owner, "", []string{trigger}, func(msg string) {
 		if strings.HasPrefix(strings.ToLower(msg), trig) {
 			pluginRunCommand(owner, cmd)
 		}

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -87,13 +87,14 @@ func TestPluginAutoReplyRunsCommand(t *testing.T) {
 	pluginInputHandlers = nil
 	triggerHandlersMu = sync.RWMutex{}
 	pluginTriggers = map[string][]triggerHandler{}
+	pluginConsoleTriggers = map[string][]triggerHandler{}
 	consoleLog = messageLog{max: maxMessages}
 	commandQueue = nil
 	pendingCommand = ""
 	pluginSendHistory = map[string][]time.Time{}
 
 	pluginAutoReply("bot", "hi", "/wave")
-	runTriggers("Hi there")
+	runChatTriggers("Hi there")
 
 	msgs := getConsoleMessages()
 	if len(msgs) == 0 || msgs[len(msgs)-1] != "> /wave" {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -114,16 +114,17 @@ func TestPluginRegisterCommandConflict(t *testing.T) {
 // Test that trigger handlers registered by plugins receive messages.
 func TestPluginTriggers(t *testing.T) {
 	pluginTriggers = map[string][]triggerHandler{}
+	pluginConsoleTriggers = map[string][]triggerHandler{}
 	triggerHandlersMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
 	var got string
 	var wg sync.WaitGroup
 	wg.Add(1)
-	pluginRegisterTriggers("test", []string{"hello"}, func(msg string) {
+	pluginRegisterTriggers("test", "", []string{"hello"}, func(msg string) {
 		got = msg
 		wg.Done()
 	})
-	consoleMessage("say hello")
+	runChatTriggers("say hello")
 	wg.Wait()
 	if got != "say hello" {
 		t.Fatalf("handler did not run, got %q", got)
@@ -133,6 +134,7 @@ func TestPluginTriggers(t *testing.T) {
 // Test that disabling a plugin removes any trigger handlers it registered.
 func TestPluginRemoveTriggersOnDisable(t *testing.T) {
 	pluginTriggers = map[string][]triggerHandler{}
+	pluginConsoleTriggers = map[string][]triggerHandler{}
 	triggerHandlersMu = sync.RWMutex{}
 	pluginInputHandlers = nil
 	inputHandlersMu = sync.RWMutex{}
@@ -145,9 +147,11 @@ func TestPluginRemoveTriggersOnDisable(t *testing.T) {
 	pluginSendHistory = map[string][]time.Time{}
 
 	ran := false
-	pluginRegisterTriggers("plug", []string{"hi"}, func(msg string) { ran = true })
+	pluginRegisterTriggers("plug", "", []string{"hi"}, func(msg string) { ran = true })
+	pluginRegisterConsoleTriggers("plug", []string{"hi"}, func(msg string) { ran = true })
 	disablePlugin("plug", "test")
-	runTriggers("hi there")
+	runChatTriggers("hi there")
+	runConsoleTriggers("hi there")
 	if ran {
 		t.Fatalf("trigger ran after plugin disabled")
 	}


### PR DESCRIPTION
## Summary
- Allow plugins to register chat triggers for a specific speaker
- Add RegisterConsoleTriggers for console-only phrase handlers
- Update examples, plugin API stubs, and tests for new trigger APIs

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f32969b8832a9c65f47309e428c0