### PR TITLE
Add plugin storage API backed by hashed JSON files

### DIFF
--- a/gt/pluginapi.go
+++ b/gt/pluginapi.go
@@ -230,3 +230,12 @@ func HasItem(name string) bool { return false }
 
 // FrameNumber returns the current frame counter.
 func FrameNumber() int { return 0 }
+
+// StorageGet retrieves a value previously stored with StorageSet.
+func StorageGet(key string) any { return nil }
+
+// StorageSet stores a value associated with key for the plugin.
+func StorageSet(key string, value any) {}
+
+// StorageDelete removes a stored value for key.
+func StorageDelete(key string) {}

--- a/plugin_storage.go
+++ b/plugin_storage.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"time"
+)
+
+type pluginStore struct {
+	path  string
+	data  map[string]any
+	dirty bool
+	mu    sync.Mutex
+}
+
+var (
+	pluginStores  = map[string]*pluginStore{}
+	pluginStoreMu sync.Mutex
+)
+
+func pluginStoragePath(owner string) string {
+	pluginMu.RLock()
+	name := pluginDisplayNames[owner]
+	author := pluginAuthors[owner]
+	pluginMu.RUnlock()
+	sum := sha256.Sum256([]byte(name + ":" + author))
+	file := hex.EncodeToString(sum[:]) + ".json"
+	return filepath.Join(dataDirPath, "plugins", "storage", file)
+}
+
+func getPluginStore(owner string) *pluginStore {
+	pluginStoreMu.Lock()
+	ps, ok := pluginStores[owner]
+	if ok {
+		pluginStoreMu.Unlock()
+		return ps
+	}
+	path := pluginStoragePath(owner)
+	data := map[string]any{}
+	if b, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(b, &data); err != nil {
+			log.Printf("load plugin storage %s: %v", path, err)
+		}
+	}
+	ps = &pluginStore{path: path, data: data}
+	pluginStores[owner] = ps
+	pluginStoreMu.Unlock()
+	return ps
+}
+
+func pluginStorageGet(owner, key string) any {
+	ps := getPluginStore(owner)
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	return ps.data[key]
+}
+
+func pluginStorageSet(owner, key string, value any) {
+	ps := getPluginStore(owner)
+	ps.mu.Lock()
+	if old, ok := ps.data[key]; !ok || !reflect.DeepEqual(old, value) {
+		if ps.data == nil {
+			ps.data = make(map[string]any)
+		}
+		ps.data[key] = value
+		ps.dirty = true
+	}
+	ps.mu.Unlock()
+}
+
+func pluginStorageDelete(owner, key string) {
+	ps := getPluginStore(owner)
+	ps.mu.Lock()
+	if _, ok := ps.data[key]; ok {
+		delete(ps.data, key)
+		ps.dirty = true
+	}
+	ps.mu.Unlock()
+}
+
+func savePluginStores() {
+	pluginStoreMu.Lock()
+	stores := make([]*pluginStore, 0, len(pluginStores))
+	for _, ps := range pluginStores {
+		stores = append(stores, ps)
+	}
+	pluginStoreMu.Unlock()
+	for _, ps := range stores {
+		ps.mu.Lock()
+		if !ps.dirty {
+			ps.mu.Unlock()
+			continue
+		}
+		data, err := json.MarshalIndent(ps.data, "", "  ")
+		if err != nil {
+			ps.mu.Unlock()
+			log.Printf("save plugin storage %s: %v", ps.path, err)
+			continue
+		}
+		ps.dirty = false
+		path := ps.path
+		ps.mu.Unlock()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			log.Printf("save plugin storage %s: %v", path, err)
+			continue
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			log.Printf("save plugin storage %s: %v", path, err)
+		}
+	}
+}
+
+func init() {
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		for range ticker.C {
+			savePluginStores()
+		}
+	}()
+}

--- a/plugin_storage_test.go
+++ b/plugin_storage_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestPluginStorageSetGetDelete(t *testing.T) {
+	origDir := dataDirPath
+	dataDirPath = t.TempDir()
+	t.Cleanup(func() { dataDirPath = origDir })
+
+	owner := "plug_file"
+	pluginDisplayNames = map[string]string{owner: "Plug"}
+	pluginAuthors = map[string]string{owner: "Auth"}
+	pluginStores = map[string]*pluginStore{}
+	pluginStoreMu = sync.Mutex{}
+
+	if v := pluginStorageGet(owner, "foo"); v != nil {
+		t.Fatalf("expected nil, got %v", v)
+	}
+
+	pluginStorageSet(owner, "foo", "bar")
+	if v := pluginStorageGet(owner, "foo"); v != "bar" {
+		t.Fatalf("got %v, want bar", v)
+	}
+
+	store := getPluginStore(owner)
+	if !store.dirty {
+		t.Fatalf("store not marked dirty")
+	}
+
+	savePluginStores()
+
+	if store.dirty {
+		t.Fatalf("store still dirty after save")
+	}
+
+	path := pluginStoragePath(owner)
+	sum := sha256.Sum256([]byte("Plug:Auth"))
+	wantFile := hex.EncodeToString(sum[:]) + ".json"
+	if filepath.Base(path) != wantFile {
+		t.Fatalf("path %s does not match hash %s", filepath.Base(path), wantFile)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read storage: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["foo"] != "bar" {
+		t.Fatalf("file contents %v", m)
+	}
+
+	pluginStorageDelete(owner, "foo")
+	savePluginStores()
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read storage: %v", err)
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["foo"]; ok {
+		t.Fatalf("value not deleted: %v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- allow plugins to persist data with StorageGet/Set/Delete helpers
- parse `PluginAuthor` and store data in data/plugins/storage/<hash>.json
- add tests for plugin storage hashing and persistence

## Testing
- `go vet ./...` *(fails: Package 'alsa' not found)*
- `go test ./...` *(fails: Package 'alsa' not found)*
- `go build ./...` *(fails: Xrandr.h and 'alsa' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b10345b334832aa4352fa7501105fc