### PR TITLE
Track plugin enablement per character

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -390,6 +390,9 @@ func TestPluginRemoveHotkeyClearsState(t *testing.T) {
 	origDisabled := pluginDisabled
 	pluginDisabled = map[string]bool{}
 	t.Cleanup(func() { pluginDisabled = origDisabled })
+	origEnabledPlugins := pluginEnabledFor
+	pluginEnabledFor = map[string]string{}
+	t.Cleanup(func() { pluginEnabledFor = origEnabledPlugins })
 
 	makeHotkeysWindow()
 

--- a/login.go
+++ b/login.go
@@ -319,6 +319,7 @@ func login(ctx context.Context, clientVersion int) error {
 			return fmt.Errorf("character password required")
 		}
 		playerName = utfFold(name)
+		applyEnabledPlugins()
 
 		var resp []byte
 		var result int16

--- a/main.go
+++ b/main.go
@@ -168,6 +168,7 @@ func main() {
 			}
 
 			playerName = extractMoviePlayerName(frames)
+			applyEnabledPlugins()
 
 			mp := newMoviePlayer(frames, clMovFPS, cancel)
 			mp.makePlaybackWindow()

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+func pluginAutoReply(owner, trigger, command string) {
+	pluginRegisterTriggers(owner, "", []string{trigger}, func() {
+		enqueueCommand(command)
+		consoleMessage("> " + command)
+	})
+}
+
 // Test that a single macro expands input text and matches case-insensitively.
 func TestPluginAddMacroExpandsInput(t *testing.T) {
 	// Reset shared state.
@@ -114,6 +121,7 @@ func TestPluginRemoveMacrosOnDisable(t *testing.T) {
 	pluginInputHandlers = nil
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginEnabledFor = map[string]string{}
 	pluginDisplayNames = map[string]string{}
 	pluginTerminators = map[string]func(){}
 	pluginCommandOwners = map[string]string{}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -39,6 +39,7 @@ func TestPluginRegisterAndDisableCommand(t *testing.T) {
 	pluginCommands = map[string]PluginCommandHandler{}
 	pluginCommandOwners = map[string]string{}
 	pluginDisabled = map[string]bool{}
+	pluginEnabledFor = map[string]string{}
 	pluginSendHistory = map[string][]time.Time{}
 	consoleLog = messageLog{max: maxMessages}
 	commandQueue = nil
@@ -117,17 +118,18 @@ func TestPluginTriggers(t *testing.T) {
 	pluginConsoleTriggers = map[string][]triggerHandler{}
 	triggerHandlersMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
-	var got string
+	pluginEnabledFor = map[string]string{}
+	triggered := false
 	var wg sync.WaitGroup
 	wg.Add(1)
-	pluginRegisterTriggers("test", "", []string{"hello"}, func(msg string) {
-		got = msg
+	pluginRegisterTriggers("test", "", []string{"hello"}, func() {
+		triggered = true
 		wg.Done()
 	})
 	runChatTriggers("say hello")
 	wg.Wait()
-	if got != "say hello" {
-		t.Fatalf("handler did not run, got %q", got)
+	if !triggered {
+		t.Fatalf("handler did not run")
 	}
 }
 
@@ -140,6 +142,7 @@ func TestPluginRemoveTriggersOnDisable(t *testing.T) {
 	inputHandlersMu = sync.RWMutex{}
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginEnabledFor = map[string]string{}
 	pluginDisplayNames = map[string]string{}
 	pluginTerminators = map[string]func(){}
 	pluginCommandOwners = map[string]string{}
@@ -147,8 +150,8 @@ func TestPluginRemoveTriggersOnDisable(t *testing.T) {
 	pluginSendHistory = map[string][]time.Time{}
 
 	ran := false
-	pluginRegisterTriggers("plug", "", []string{"hi"}, func(msg string) { ran = true })
-	pluginRegisterConsoleTriggers("plug", []string{"hi"}, func(msg string) { ran = true })
+	pluginRegisterTriggers("plug", "", []string{"hi"}, func() { ran = true })
+	pluginRegisterConsoleTriggers("plug", []string{"hi"}, func() { ran = true })
 	disablePlugin("plug", "test")
 	runChatTriggers("hi there")
 	runConsoleTriggers("hi there")

--- a/triggers_ui_test.go
+++ b/triggers_ui_test.go
@@ -32,7 +32,7 @@ func TestTriggersWindowListsTriggers(t *testing.T) {
 		t.Fatalf("expected empty triggers list")
 	}
 
-	pluginRegisterTriggers("tester", []string{"hi"}, func(string) {})
+	pluginRegisterTriggers("tester", "", []string{"hi"}, func() {})
 	if len(triggersList.Contents) != 2 {
 		t.Fatalf("items not added to list: %d", len(triggersList.Contents))
 	}
@@ -55,6 +55,7 @@ func TestDisablePluginRefreshesTriggers(t *testing.T) {
 	macroMaps = map[string]map[string]string{}
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginEnabledFor = map[string]string{}
 	pluginTerminators = map[string]func(){}
 	t.Cleanup(func() {
 		triggerHandlersMu = sync.RWMutex{}
@@ -66,11 +67,12 @@ func TestDisablePluginRefreshesTriggers(t *testing.T) {
 		macroMaps = map[string]map[string]string{}
 		pluginMu = sync.RWMutex{}
 		pluginDisabled = map[string]bool{}
+		pluginEnabledFor = map[string]string{}
 		pluginTerminators = map[string]func(){}
 	})
 
 	makeTriggersWindow()
-	pluginRegisterTriggers("plug", []string{"yo"}, func(string) {})
+	pluginRegisterTriggers("plug", "", []string{"yo"}, func() {})
 	if len(triggersList.Contents) != 2 {
 		t.Fatalf("items not added to list: %d", len(triggersList.Contents))
 	}


### PR DESCRIPTION
## Summary
- persist plugin enablement per character or for all characters
- add character/all checkboxes with legend to plugin window
- enable character-specific plugins on login and movie load

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b10214db10832a95cbe6dd5a663021