### PR TITLE
Fix plugin refresh lock and scope migration

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -279,8 +279,8 @@ func loadSettings() bool {
 		for k, v := range tmp.EnabledPlugins {
 			switch val := v.(type) {
 			case bool:
-				if val {
-					gs.EnabledPlugins[k] = "all"
+				if val && gs.LastCharacter != "" {
+					gs.EnabledPlugins[k] = gs.LastCharacter
 				}
 			case string:
 				if val != "" {

--- a/ui.go
+++ b/ui.go
@@ -430,14 +430,11 @@ func refreshPluginsWindow() {
 		allCB.Size = eui.Point{X: 40, Y: 24}
 		pluginMu.RLock()
 		scope := pluginEnabledFor[e.owner]
-		charCB.Checked = scope == playerName
-		allCB.Checked = scope == "all"
-		cb, _ := eui.NewCheckbox()
-		pluginMu.RLock()
 		cat := pluginCategories[e.owner]
 		sub := pluginSubCategories[e.owner]
-		cb.Checked = !pluginDisabled[e.owner]
 		pluginMu.RUnlock()
+		charCB.Checked = playerName != "" && scope == playerName
+		allCB.Checked = scope == "all"
 		label := e.name
 		if cat != "" {
 			label += " [" + cat
@@ -446,8 +443,6 @@ func refreshPluginsWindow() {
 			}
 			label += "]"
 		}
-		cb.Text = label
-		cb.Size = eui.Point{X: 256, Y: 24}
 		owner := e.owner
 		charEvents.Handle = func(ev eui.UIEvent) {
 			if ev.Type == eui.EventCheckboxChanged {
@@ -462,7 +457,7 @@ func refreshPluginsWindow() {
 		row.AddItem(charCB)
 		row.AddItem(allCB)
 		nameTxt, _ := eui.NewText()
-		nameTxt.Text = e.name
+		nameTxt.Text = label
 		nameTxt.Size = eui.Point{X: 256, Y: 24}
 		row.AddItem(nameTxt)
 


### PR DESCRIPTION
## Summary
- avoid leaving read lock held when refreshing plugin window
- migrate legacy plugin settings to last character instead of enabling for all

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b10e2f6ea8832a952fe2bdac5ee6a6