### PR TITLE
Disable plugins missing required metadata

### DIFF
--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -391,7 +391,12 @@ func TestPluginRemoveHotkeyClearsState(t *testing.T) {
 
 	origDisabled := pluginDisabled
 	pluginDisabled = map[string]bool{}
-	t.Cleanup(func() { pluginDisabled = origDisabled })
+	origInvalid := pluginInvalid
+	pluginInvalid = map[string]bool{}
+	t.Cleanup(func() {
+		pluginDisabled = origDisabled
+		pluginInvalid = origInvalid
+	})
 	origEnabledPlugins := pluginEnabledFor
 	pluginEnabledFor = map[string]string{}
 	t.Cleanup(func() { pluginEnabledFor = origEnabledPlugins })

--- a/plugin_macros_test.go
+++ b/plugin_macros_test.go
@@ -113,6 +113,7 @@ func TestPluginRemoveMacrosOnDisable(t *testing.T) {
 	pluginInputHandlers = nil
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginInvalid = map[string]bool{}
 	pluginEnabledFor = map[string]string{}
 	pluginDisplayNames = map[string]string{}
 	pluginCategories = map[string]string{}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -39,6 +39,7 @@ func TestPluginRegisterAndDisableCommand(t *testing.T) {
 	pluginCommands = map[string]PluginCommandHandler{}
 	pluginCommandOwners = map[string]string{}
 	pluginDisabled = map[string]bool{}
+	pluginInvalid = map[string]bool{}
 	pluginEnabledFor = map[string]string{}
 	pluginSendHistory = map[string][]time.Time{}
 	consoleLog = messageLog{max: maxMessages}
@@ -118,6 +119,7 @@ func TestPluginTriggers(t *testing.T) {
 	pluginConsoleTriggers = map[string][]triggerHandler{}
 	triggerHandlersMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginInvalid = map[string]bool{}
 	pluginEnabledFor = map[string]string{}
 	triggered := false
 	var wg sync.WaitGroup
@@ -142,6 +144,7 @@ func TestPluginRemoveTriggersOnDisable(t *testing.T) {
 	inputHandlersMu = sync.RWMutex{}
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginInvalid = map[string]bool{}
 	pluginEnabledFor = map[string]string{}
 	pluginDisplayNames = map[string]string{}
 	pluginCategories = map[string]string{}
@@ -179,6 +182,7 @@ func TestDisablePluginRemovesHandlers(t *testing.T) {
 	triggerHandlersMu = sync.RWMutex{}
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginInvalid = map[string]bool{}
 	pluginEnabledFor = map[string]string{}
 	pluginDisplayNames = map[string]string{"plug": "Plug"}
 	pluginTerminators = map[string]func(){}

--- a/triggers_ui_test.go
+++ b/triggers_ui_test.go
@@ -61,6 +61,7 @@ func TestDisablePluginRefreshesTriggers(t *testing.T) {
 	macroMaps = map[string]map[string]string{}
 	pluginMu = sync.RWMutex{}
 	pluginDisabled = map[string]bool{}
+	pluginInvalid = map[string]bool{}
 	pluginEnabledFor = map[string]string{}
 	pluginTerminators = map[string]func(){}
 	t.Cleanup(func() {
@@ -75,6 +76,7 @@ func TestDisablePluginRefreshesTriggers(t *testing.T) {
 		macroMaps = map[string]map[string]string{}
 		pluginMu = sync.RWMutex{}
 		pluginDisabled = map[string]bool{}
+		pluginInvalid = map[string]bool{}
 		pluginEnabledFor = map[string]string{}
 		pluginTerminators = map[string]func(){}
 	})

--- a/ui.go
+++ b/ui.go
@@ -438,9 +438,14 @@ func refreshPluginsWindow() {
 		scope := pluginEnabledFor[e.owner]
 		cat := pluginCategories[e.owner]
 		sub := pluginSubCategories[e.owner]
+		invalid := pluginInvalid[e.owner]
 		pluginMu.RUnlock()
 		charCB.Checked = playerName != "" && scope == playerName
 		allCB.Checked = scope == "all"
+		if invalid {
+			charCB.Disabled = true
+			allCB.Disabled = true
+		}
 		label := e.name
 		if cat != "" {
 			label += " [" + cat
@@ -466,13 +471,17 @@ func refreshPluginsWindow() {
 		nameTxt.Text = label
 		nameTxt.FontSize = 12
 		nameTxt.Size = pluginSize
+		if invalid {
+			nameTxt.Disabled = true
+		}
 		row.AddItem(nameTxt)
 
 		reloadBtn, rh := eui.NewButton()
 		reloadBtn.Text = "Reload"
 		reloadBtn.Size = eui.Point{X: 55, Y: 24}
+		reloadBtn.Disabled = invalid
 		rh.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventClick {
+			if ev.Type == eui.EventClick && !invalid {
 				pluginMu.RLock()
 				enabled := !pluginDisabled[owner]
 				pluginMu.RUnlock()


### PR DESCRIPTION
## Summary
- Track plugin metadata validity and disable plugins missing name, author, category, or sub-category
- Prevent invalid plugins from running and gray out their UI controls
- Update tests to reset plugin invalid state

## Testing
- `go vet ./...` *(fails: pattern example_plugins: no matching files found)*
- `go build ./...` *(fails: pattern example_plugins: no matching files found)*
- `go test ./...` *(fails: pattern example_plugins: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b118b47ffc832aae745f8780dc2740