### PR TITLE
Disable invalid plugins in UI

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -338,6 +338,16 @@ var (
 	pluginModCheck        time.Time
 )
 
+const (
+	minPluginMetaLen = 2
+	maxPluginMetaLen = 40
+)
+
+func invalidPluginValue(s string) bool {
+	l := len(s)
+	return l < minPluginMetaLen || l > maxPluginMetaLen
+}
+
 // pluginRegisterCommand lets plugins handle a local slash command like
 // "/example". The name should be without the leading slash and will be
 // matched case-insensitively.
@@ -942,16 +952,28 @@ func rescanPlugins() {
 			if match := authorRE.FindSubmatch(src); len(match) >= 2 {
 				author = strings.TrimSpace(string(match[1]))
 			}
-			invalid := name == "" || author == "" || category == "" || subCategory == ""
-			if name == "" {
-				consoleMessage("[plugin] missing name: " + path)
-				name = base
+			invalid := invalidPluginValue(name) || invalidPluginValue(author) || invalidPluginValue(category) || subCategory == ""
+			if invalidPluginValue(name) {
+				if name == "" {
+					consoleMessage("[plugin] missing name: " + path)
+					name = base
+				} else {
+					consoleMessage("[plugin] invalid name: " + path)
+				}
 			}
-			if author == "" {
-				consoleMessage("[plugin] missing author: " + path)
+			if invalidPluginValue(author) {
+				if author == "" {
+					consoleMessage("[plugin] missing author: " + path)
+				} else {
+					consoleMessage("[plugin] invalid author: " + path)
+				}
 			}
-			if category == "" {
-				consoleMessage("[plugin] missing category: " + path)
+			if invalidPluginValue(category) {
+				if category == "" {
+					consoleMessage("[plugin] missing category: " + path)
+				} else {
+					consoleMessage("[plugin] invalid category: " + path)
+				}
 			}
 			if subCategory == "" {
 				consoleMessage("[plugin] missing sub-category: " + path)
@@ -1086,16 +1108,22 @@ func loadPlugins() {
 			if match := authorRE.FindSubmatch(src); len(match) >= 2 {
 				author = strings.TrimSpace(string(match[1]))
 			}
-			invalid := len(match) < 2 || name == "" || author == "" || category == "" || subCategory == ""
-			if name == "" {
+			invalid := len(match) < 2 || invalidPluginValue(name) || invalidPluginValue(author) || invalidPluginValue(category) || subCategory == ""
+			if len(match) < 2 || name == "" {
 				consoleMessage("[plugin] missing name: " + path)
 				name = base
+			} else if invalidPluginValue(name) {
+				consoleMessage("[plugin] invalid name: " + path)
 			}
 			if author == "" {
 				consoleMessage("[plugin] missing author: " + path)
+			} else if invalidPluginValue(author) {
+				consoleMessage("[plugin] invalid author: " + path)
 			}
 			if category == "" {
 				consoleMessage("[plugin] missing category: " + path)
+			} else if invalidPluginValue(category) {
+				consoleMessage("[plugin] invalid category: " + path)
 			}
 			if subCategory == "" {
 				consoleMessage("[plugin] missing sub-category: " + path)

--- a/ui.go
+++ b/ui.go
@@ -476,22 +476,23 @@ func refreshPluginsWindow() {
 		}
 		row.AddItem(nameTxt)
 
-		reloadBtn, rh := eui.NewButton()
-		reloadBtn.Text = "Reload"
-		reloadBtn.Size = eui.Point{X: 55, Y: 24}
-		reloadBtn.Disabled = invalid
-		rh.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventClick && !invalid {
-				pluginMu.RLock()
-				enabled := !pluginDisabled[owner]
-				pluginMu.RUnlock()
-				if enabled {
-					disablePlugin(owner, "reloaded")
-					enablePlugin(owner)
+		if !invalid {
+			reloadBtn, rh := eui.NewButton()
+			reloadBtn.Text = "Reload"
+			reloadBtn.Size = eui.Point{X: 55, Y: 24}
+			rh.Handle = func(ev eui.UIEvent) {
+				if ev.Type == eui.EventClick {
+					pluginMu.RLock()
+					enabled := !pluginDisabled[owner]
+					pluginMu.RUnlock()
+					if enabled {
+						disablePlugin(owner, "reloaded")
+						enablePlugin(owner)
+					}
 				}
 			}
+			row.AddItem(reloadBtn)
 		}
-		row.AddItem(reloadBtn)
 
 		pluginsList.AddItem(row)
 	}


### PR DESCRIPTION
## Summary
- validate plugin name, author, and category lengths to flag invalid plugins
- hide reload button and disable toggles for invalid plugins in the plugins window

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b11bb9c3ac832a8976b283d2a50f7e