### PR TITLE
eui: respect disabled state for widgets

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -437,6 +437,9 @@ func (win *windowData) clickWindowItems(mpos point, click bool) bool {
 }
 
 func (item *itemData) clickFlows(mpos point, click bool) bool {
+	if item.Disabled {
+		return item.DrawRect.containsPoint(mpos)
+	}
 	if part := item.getScrollbarPart(mpos); part != PART_NONE {
 		if click && dragPart == PART_NONE && downWin == item.ParentWindow {
 			dragPart = part
@@ -490,6 +493,9 @@ func (item *itemData) clickFlows(mpos point, click bool) bool {
 }
 
 func (item *itemData) clickItem(mpos point, click bool) bool {
+	if item.Disabled {
+		return item.DrawRect.containsPoint(mpos)
+	}
 	if pointerPressed() && activeItem != nil && activeItem != item {
 		return false
 	}
@@ -783,6 +789,9 @@ func (item *itemData) colorAt(mpos point) (Color, bool) {
 
 func scrollFlow(items []*itemData, mpos point, delta point) bool {
 	for _, it := range items {
+		if it.Disabled {
+			continue
+		}
 		if it.ItemType == ITEM_FLOW {
 			if it.DrawRect.containsPoint(mpos) {
 				req := it.contentBounds()
@@ -846,6 +855,9 @@ func scrollFlow(items []*itemData, mpos point, delta point) bool {
 
 func scrollDropdown(items []*itemData, mpos point, delta point) bool {
 	for _, it := range items {
+		if it.Disabled {
+			continue
+		}
 		if it.ItemType == ITEM_DROPDOWN && it.Open {
 			optionH := it.GetSize().Y
 			r, _ := dropdownOpenRect(it, point{X: it.DrawRect.X0, Y: it.DrawRect.Y0})

--- a/eui/render.go
+++ b/eui/render.go
@@ -578,6 +578,9 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 	}
 	subImg := screen.SubImage(drawRect.getRectangle()).(*ebiten.Image)
 	style := item.themeStyle()
+	if item.Disabled {
+		style = disabledStyle(style)
+	}
 
 	if item.Filled || item.Outlined {
 		col := item.Color
@@ -852,6 +855,9 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 	}
 	subImg := screen.SubImage(item.DrawRect.getRectangle()).(*ebiten.Image)
 	style := item.themeStyle()
+	if item.Disabled {
+		style = disabledStyle(style)
+	}
 
 	if item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
@@ -1334,7 +1340,7 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 
 		top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
 		tcolor := style.TextColor
-		if item.ForceTextColor {
+		if item.ForceTextColor && !item.Disabled {
 			tcolor = item.TextColor
 		}
 		top.ColorScale.ScaleWithColor(tcolor)
@@ -1519,6 +1525,9 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 	}
 	subImg := screen.SubImage(visibleRect.getRectangle()).(*ebiten.Image)
 	style := item.themeStyle()
+	if item.Disabled {
+		style = disabledStyle(style)
+	}
 	drawFilledRect(subImg,
 		visibleRect.X0,
 		visibleRect.Y0,

--- a/eui/util.go
+++ b/eui/util.go
@@ -52,6 +52,24 @@ func (item *itemData) themeStyle() *itemData {
 	return nil
 }
 
+// disabledStyle returns a copy of style with all visual colors replaced by the
+// style's DisabledColor. When a widget is disabled, using this helps ensure it
+// renders in a consistent "grayed out" appearance regardless of hover or
+// active states.
+func disabledStyle(style *itemData) *itemData {
+	if style == nil {
+		return nil
+	}
+	ds := *style
+	ds.Color = style.DisabledColor
+	ds.HoverColor = style.DisabledColor
+	ds.ClickColor = style.DisabledColor
+	ds.OutlineColor = style.DisabledColor
+	ds.TextColor = style.DisabledColor
+	ds.SelectedColor = style.DisabledColor
+	return &ds
+}
+
 func (win *windowData) getWinRect() rect {
 	winPos := win.GetPos()
 	return rect{


### PR DESCRIPTION
## Summary
- render disabled widgets with DisabledColor
- ignore input for disabled widgets

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*
- `golangci-lint run ./...` *(fails: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b136c64aa4832a83467e25a0016abb