### PR TITLE
Add /notts command to manage TTS blocklist

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -19,9 +19,10 @@ func chatMessage(msg string) {
 		return
 	}
 
-	if name := chatSpeaker(msg); name != "" {
+	speaker := chatSpeaker(msg)
+	if speaker != "" {
 		playersMu.RLock()
-		p, ok := players[name]
+		p, ok := players[speaker]
 		blocked := ok && (p.Blocked || p.Ignored)
 		playersMu.RUnlock()
 		if blocked {
@@ -35,7 +36,9 @@ func chatMessage(msg string) {
 	updateChatWindow()
 
 	if gs.ChatTTS && !blockTTS && !isSelfChatMessage(msg) {
-		speakChatMessage(msg)
+		if speaker == "" || !isTTSBlocked(speaker) {
+			speakChatMessage(msg)
+		}
 	} else if !gs.ChatTTS {
 		chatTTSDisabledOnce.Do(func() {
 			consoleMessage("Chat TTS is disabled. Enable it in settings to hear messages.")

--- a/chat_tts_blocklist.go
+++ b/chat_tts_blocklist.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"strings"
+	"sync"
+)
+
+var (
+	ttsBlocklist   map[string]struct{}
+	ttsBlocklistMu sync.RWMutex
+)
+
+func init() {
+	ttsBlocklist = make(map[string]struct{})
+	syncTTSBlocklist()
+	pluginRegisterCommand("client", "notts", handleNoTTSCommand)
+}
+
+func syncTTSBlocklist() {
+	ttsBlocklistMu.Lock()
+	ttsBlocklist = make(map[string]struct{}, len(gs.ChatTTSBlocklist))
+	for _, n := range gs.ChatTTSBlocklist {
+		name := strings.ToLower(utfFold(strings.TrimSpace(n)))
+		if name != "" {
+			ttsBlocklist[name] = struct{}{}
+		}
+	}
+	ttsBlocklistMu.Unlock()
+}
+
+func isTTSBlocked(name string) bool {
+	name = strings.ToLower(utfFold(strings.TrimSpace(name)))
+	ttsBlocklistMu.RLock()
+	_, ok := ttsBlocklist[name]
+	ttsBlocklistMu.RUnlock()
+	return ok
+}
+
+func handleNoTTSCommand(args string) {
+	fields := strings.Fields(args)
+	if len(fields) != 2 {
+		consoleMessage("Usage: /notts add|remove <name>")
+		return
+	}
+	action := strings.ToLower(fields[0])
+	name := strings.ToLower(utfFold(fields[1]))
+	if name == "" {
+		return
+	}
+
+	ttsBlocklistMu.Lock()
+	defer ttsBlocklistMu.Unlock()
+
+	switch action {
+	case "add":
+		if _, exists := ttsBlocklist[name]; exists {
+			consoleMessage(name + " is already in the TTS blocklist.")
+			return
+		}
+		ttsBlocklist[name] = struct{}{}
+		gs.ChatTTSBlocklist = append(gs.ChatTTSBlocklist, name)
+		settingsDirty = true
+		consoleMessage("Added " + name + " to the TTS blocklist.")
+	case "remove":
+		if _, exists := ttsBlocklist[name]; !exists {
+			consoleMessage(name + " is not in the TTS blocklist.")
+			return
+		}
+		delete(ttsBlocklist, name)
+		for i, n := range gs.ChatTTSBlocklist {
+			if strings.ToLower(utfFold(n)) == name {
+				gs.ChatTTSBlocklist = append(gs.ChatTTSBlocklist[:i], gs.ChatTTSBlocklist[i+1:]...)
+				break
+			}
+		}
+		settingsDirty = true
+		consoleMessage("Removed " + name + " from the TTS blocklist.")
+	default:
+		consoleMessage("Usage: /notts add|remove <name>")
+	}
+}

--- a/chat_tts_blocklist_test.go
+++ b/chat_tts_blocklist_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2/audio"
+)
+
+func TestNoTTSBlocklist(t *testing.T) {
+	origCtx := audioContext
+	audioContext = audio.NewContext(44100)
+	defer func() { audioContext = origCtx }()
+
+	origGS := gs
+	gs.ChatTTS = true
+	gs.Mute = false
+	blockTTS = false
+	gs.ChatTTSBlocklist = []string{"blocked"}
+	syncTTSBlocklist()
+	defer func() { gs = origGS; syncTTSBlocklist() }()
+
+	stopAllTTS()
+
+	var mu sync.Mutex
+	var got []string
+	origFunc := playChatTTSFunc
+	playChatTTSFunc = func(ctx context.Context, text string) {
+		mu.Lock()
+		got = append(got, text)
+		mu.Unlock()
+	}
+	defer func() { playChatTTSFunc = origFunc }()
+
+	chatMessage("Blocked hello")
+	chatMessage("Allowed hi")
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	msgs := append([]string(nil), got...)
+	mu.Unlock()
+	if len(msgs) != 1 || msgs[0] != "Allowed hi" {
+		t.Fatalf("got %v", msgs)
+	}
+}
+
+func TestHandleNoTTSCommand(t *testing.T) {
+	orig := gs.ChatTTSBlocklist
+	gs.ChatTTSBlocklist = []string{}
+	syncTTSBlocklist()
+	handleNoTTSCommand("add foo")
+	if !isTTSBlocked("foo") {
+		t.Fatalf("foo not added to blocklist")
+	}
+	handleNoTTSCommand("remove foo")
+	if isTTSBlocked("foo") {
+		t.Fatalf("foo not removed from blocklist")
+	}
+	gs.ChatTTSBlocklist = orig
+	syncTTSBlocklist()
+}

--- a/settings.go
+++ b/settings.go
@@ -86,6 +86,7 @@ var gsdef settings = settings{
 	ChatTTSVolume:        1.0,
 	ChatTTSSpeed:         1.5,
 	ChatTTSVoice:         "en_US-hfc_female-medium",
+	ChatTTSBlocklist:     []string{"koppi", "crius"},
 	Notifications:        true,
 	NotifyFallen:         true,
 	NotifyNotFallen:      true,
@@ -174,6 +175,7 @@ type settings struct {
 	ChatTTSVolume        float64
 	ChatTTSSpeed         float64
 	ChatTTSVoice         string
+	ChatTTSBlocklist     []string
 	Notifications        bool
 	NotifyFallen         bool
 	NotifyNotFallen      bool
@@ -252,6 +254,7 @@ type WindowState struct {
 const settingsFile = "settings.json"
 
 func loadSettings() bool {
+	defer syncTTSBlocklist()
 	path := filepath.Join(dataDirPath, settingsFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -298,6 +301,10 @@ func loadSettings() bool {
 
 	if gs.EnabledPlugins == nil {
 		gs.EnabledPlugins = make(map[string]string)
+	}
+
+	if gs.ChatTTSBlocklist == nil {
+		gs.ChatTTSBlocklist = append([]string(nil), gsdef.ChatTTSBlocklist...)
 	}
 
 	if gs.DenoiseAmount < 0 || gs.DenoiseAmount > 1 {


### PR DESCRIPTION
## Summary
- add configurable TTS blocklist with default entries
- support `/notts add|remove <name>` command to update blocklist
- skip chat TTS for names on the blocklist and test behavior

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b140a87534832aaca5ec6848c9c258