### PR TITLE
Reset state before playback or connection

### DIFF
--- a/bubbles_ignore_test.go
+++ b/bubbles_ignore_test.go
@@ -32,21 +32,14 @@ func buildDrawData(name string, bubbleType int, text string) []byte {
 	return buf
 }
 
-func resetDrawState() {
+func resetTestState() {
+	resetDrawState()
 	players = make(map[string]*Player)
 	thinkMessages = nil
-	stateMu.Lock()
-	state = drawState{
-		descriptors: make(map[uint8]frameDescriptor),
-		mobiles:     make(map[uint8]frameMobile),
-		prevMobiles: make(map[uint8]frameMobile),
-		prevDescs:   make(map[uint8]frameDescriptor),
-	}
-	stateMu.Unlock()
 }
 
 func TestBubbleDroppedForBlockedPlayer(t *testing.T) {
-	resetDrawState()
+	resetTestState()
 	players["Bob"] = &Player{Name: "Bob", Blocked: true}
 	data := buildDrawData("Bob", kBubbleNormal, "hello")
 	if err := parseDrawState(data, false); err != nil {
@@ -61,7 +54,7 @@ func TestBubbleDroppedForBlockedPlayer(t *testing.T) {
 }
 
 func TestThinkMessageDroppedForIgnoredPlayer(t *testing.T) {
-	resetDrawState()
+	resetTestState()
 	players["Bob"] = &Player{Name: "Bob", Ignored: true}
 	data := buildDrawData("Bob", kBubbleThought, "hmm")
 	if err := parseDrawState(data, false); err != nil {

--- a/game.go
+++ b/game.go
@@ -283,6 +283,29 @@ var (
 	stateMu      sync.Mutex
 )
 
+// resetDrawState clears all game state and interpolation data.
+// It also resets timing counters so new sessions start from a clean slate.
+func resetDrawState() {
+	stateMu.Lock()
+	state = drawState{
+		descriptors: make(map[uint8]frameDescriptor),
+		mobiles:     make(map[uint8]frameMobile),
+		prevMobiles: make(map[uint8]frameMobile),
+		prevDescs:   make(map[uint8]frameDescriptor),
+	}
+	stateMu.Unlock()
+
+	resetInterpolation()
+
+	frameCounter = 0
+	serverFPS = 0
+	frameInterval = framems * time.Millisecond
+
+	stateMu.Lock()
+	initialState = cloneDrawState(state)
+	stateMu.Unlock()
+}
+
 // prepareRenderCacheLocked populates render-ready, sorted/partitioned slices.
 // Call with stateMu held and only when a new game state is applied.
 func prepareRenderCacheLocked() {

--- a/login.go
+++ b/login.go
@@ -211,6 +211,7 @@ func fetchRandomDemoCharacter(clientVersion int) (string, error) {
 // login connects to the server and performs the login handshake.
 // It runs the network loops and blocks until the context is canceled.
 func login(ctx context.Context, clientVersion int) error {
+	resetDrawState()
 	for {
 		imagesVersion, err := readKeyFileVersion(filepath.Join(dataDirPath, CL_ImagesFile))
 		imagesMissing := false

--- a/movie.go
+++ b/movie.go
@@ -52,15 +52,7 @@ func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
 	}
 	logDebug("movie version %d.%d headerLen %d", version, revision, headerLen)
 
-	stateMu.Lock()
-	state = drawState{
-		descriptors: make(map[uint8]frameDescriptor),
-		mobiles:     make(map[uint8]frameMobile),
-		prevMobiles: make(map[uint8]frameMobile),
-		prevDescs:   make(map[uint8]frameDescriptor),
-	}
-	initialState = cloneDrawState(state)
-	stateMu.Unlock()
+	resetDrawState()
 
 	pos := headerLen
 	sign := []byte{0xde, 0xad, 0xbe, 0xef}


### PR DESCRIPTION
## Summary
- add `resetDrawState` helper to clear game state and interpolation buffers
- reset draw state before parsing clmov files and before attempting a login
- update tests to use the shared reset helper

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b14037d6ac832a9cd043932cd43327