### PR TITLE
Add default button and tab navigation to EUI

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -61,6 +61,8 @@ type windowData struct {
 
 	Contents []*itemData
 
+	DefaultButton *itemData
+
 	Theme *Theme
 
 	// Render caches the pre-rendered image for this window when Dirty is

--- a/ui.go
+++ b/ui.go
@@ -1599,6 +1599,7 @@ func makeAddCharacterWindow() {
 	addBtn, addEvents := eui.NewButton()
 	addBtn.Text = "Add"
 	addBtn.Size = eui.Point{X: 200, Y: 24}
+	addCharWin.DefaultButton = addBtn
 	addEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			h := md5.Sum([]byte(addCharPass))
@@ -1807,6 +1808,7 @@ func makeLoginWindow() {
 	connBtn.Text = "Connect"
 	connBtn.Size = eui.Point{X: charWinWidth, Y: 48}
 	connBtn.Padding = 10
+	loginWin.DefaultButton = connBtn
 	connEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			if name == "" {


### PR DESCRIPTION
## Summary
- add per-window default button activated by Enter
- allow Tab to cycle between input fields
- use default buttons on login and add-character windows

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b16d968418832ab039cb124d14bea9