### PR TITLE
Add dependency bundle builder script

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ go build
 ```
 Requirements: Go **1.24+**, OpenGL + X11 development libraries.
 
+### Dependency bundle for faster setup
+To prefetch all Debian packages and Go modules into a single archive for
+offline installs, run:
+```bash
+scripts/build_dep_bundle.sh
+```
+Unpack `gothoom_deps.tar.gz` on another machine and install the `.deb`
+files from `apt/`. Set `GOMODCACHE` to the extracted `go/mod` directory to
+reuse the module cache when running `go mod download`.
+
 ### Cross-platform release builds
 A helper script builds **Linux + Windows** binaries (and can sign Windows EXEs and macOS `.app` bundles). On Ubuntu it will install missing tools like `zip`/`osslsigncode` automatically. Set cert env vars, then run:
 ```bash

--- a/scripts/build_dep_bundle.sh
+++ b/scripts/build_dep_bundle.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build a tarball containing goThoom's system and Go module dependencies.
+# The resulting archive can be unpacked on another machine to speed up
+# environment setup without hitting the network.
+
+set -euo pipefail
+
+# Usage: scripts/build_dep_bundle.sh [output.tar.gz]
+# Default output is gothoom_deps.tar.gz in the current directory.
+
+OUT_FILE="${1:-gothoom_deps.tar.gz}"
+WORK_DIR="$(mktemp -d)"
+APT_DIR="$WORK_DIR/apt"
+GO_DIR="$WORK_DIR/go"
+
+mkdir -p "$APT_DIR" "$GO_DIR"
+
+# Packages needed to build goThoom.
+DEB_PACKAGES=(
+  golang-go
+  build-essential
+  libgl1-mesa-dev
+  libglu1-mesa-dev
+  xorg-dev
+)
+
+if command -v apt-get >/dev/null 2>&1; then
+  echo "Downloading Debian packages..."
+  apt-get update -qq
+  (
+    cd "$APT_DIR"
+    apt-get download "${DEB_PACKAGES[@]}"
+  )
+else
+  echo "apt-get not found; skipping Debian package download" >&2
+fi
+
+# Cache Go modules into a local mod cache inside the bundle.
+GO_CACHE="$GO_DIR/mod"
+mkdir -p "$GO_CACHE"
+
+echo "Downloading Go modules..."
+GOMODCACHE="$GO_CACHE" go mod download
+
+# Create archive.
+
+tar -czf "$OUT_FILE" -C "$WORK_DIR" .
+
+echo "Dependency bundle written to $OUT_FILE"


### PR DESCRIPTION
## Summary
- add helper script to bundle Debian packages and Go modules into a tarball
- document optional dependency bundle creation in README

## Testing
- `shellcheck scripts/build_dep_bundle.sh`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b201f04994832a988f6852985d1db4