### PR TITLE
Add basic spellcheck with red underlines

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1382,6 +1382,36 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		top.ColorScale.ScaleWithColor(tcolor)
 		text.Draw(subImg, item.Text, face, top)
 
+		if len(item.Underlines) > 0 {
+			metrics := face.Metrics()
+			lineSpacing := float32(textSize) * 1.2
+			rs := []rune(item.Text)
+			for _, ul := range item.Underlines {
+				if ul.Start < 0 || ul.End > len(rs) || ul.Start >= ul.End {
+					continue
+				}
+				line := 0
+				lineStart := 0
+				for i := 0; i < ul.Start; i++ {
+					if rs[i] == '\n' {
+						line++
+						lineStart = i + 1
+					}
+				}
+				prefix := string(rs[lineStart:ul.Start])
+				x0, _ := text.Measure(prefix, face, 0)
+				word := string(rs[ul.Start:ul.End])
+				w, _ := text.Measure(word, face, 0)
+				baseY := offset.Y + float32(line)*lineSpacing + float32(metrics.HAscent)
+				y := baseY + 1
+				vector.StrokeLine(subImg,
+					offset.X+float32(x0), y,
+					offset.X+float32(x0+w), y,
+					1,
+					color.NRGBA{R: 0xFF, G: 0x00, B: 0x00, A: 0xFF}, true)
+			}
+		}
+
 	} else if item.ItemType == ITEM_PROGRESS {
 
 		// Draw progress track

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -167,6 +167,7 @@ type itemData struct {
 	OnColorChange func(Color)
 	WheelColor    Color
 	TextPtr       *string
+	Underlines    []TextSpan
 	SecretText    string
 	HideText      bool
 	Handler       *EventHandler
@@ -213,6 +214,11 @@ type rect struct {
 
 type point struct {
 	X, Y float32
+}
+
+type TextSpan struct {
+	Start int
+	End   int
 }
 
 type flowType int

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/hajimehoshi/ebiten/v2 v2.8.8
 
 require (
 	github.com/dustin/go-humanize v1.0.1
+	github.com/f1monkey/spellchecker v1.2.0
 	github.com/google/gopacket v1.1.19
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hugolgst/rich-go v0.0.0-20240715122152-74618cc1ace2
@@ -25,10 +26,12 @@ require (
 
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d // indirect
+	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/oto/v3 v3.3.3 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
+	github.com/f1monkey/bitmap v1.4.0 // indirect
 	github.com/go-text/typesetting v0.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,14 @@
 github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
+github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/gomobile v0.0.0-20250329061421-6d0a8e981e4c h1:Ccgks2VROTr6bIm1FFxG2jT6P1DaCBMj8g/O9xbOQ08=
@@ -11,6 +19,10 @@ github.com/ebitengine/oto/v3 v3.3.3 h1:m6RV69OqoXYSWCDsHXN9rc07aDuDstGHtait7HXSM
 github.com/ebitengine/oto/v3 v3.3.3/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/f1monkey/bitmap v1.4.0 h1:Is1PqZWrTawUowD/qE7Vnlh9fzXrEs/qxJHDQ47jZ3g=
+github.com/f1monkey/bitmap v1.4.0/go.mod h1:qOc9q5FQxdvMyjVDnmvfJxUtz8JIryqOGxpg4Vtg4nY=
+github.com/f1monkey/spellchecker v1.2.0 h1:kGQyLp8ZpVikKVSPkVG/Xpc5FRWXCqD0PUZ9ZMhPy8I=
+github.com/f1monkey/spellchecker v1.2.0/go.mod h1:uryb3bLmUmHcPeHIze8Joq4Dq2/ApYfeWn6SQ28URKI=
 github.com/go-text/typesetting v0.3.0 h1:OWCgYpp8njoxSRpwrdd1bQOxdjOXDj9Rqart9ML4iF4=
 github.com/go-text/typesetting v0.3.0/go.mod h1:qjZLkhRgOEYMhU9eHBr3AR4sfnGJvOXNLt8yRAySFuY=
 github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=
@@ -33,6 +45,8 @@ github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/sinshu/go-meltysynth v0.0.0-20230205031334-05d311382fc4 h1:VgeknFh4pciKVtwtjn9tZtItvV20x/+10NnUXKfyW6s=
@@ -41,6 +55,8 @@ github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EE
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/sqweek/dialog v0.0.0-20240226140203-065105509627 h1:2JL2wmHXWIAxDofCK+AdkFi1KEg3dgkefCsm7isADzQ=
 github.com/sqweek/dialog v0.0.0-20240226140203-065105509627/go.mod h1:/qNPSY91qTz/8TgHEMioAUc6q7+3SOybeKczHMXFcXw=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/thiagokokada/dark-mode-go v0.0.1 h1:layfdBOM9xaxBa1Dw6f97ng/GbRJh+f8+afBOvDzXz4=
 github.com/thiagokokada/dark-mode-go v0.0.1/go.mod h1:IQrRBLMIz8vfFZ/sdZr7ASfW1SpE9TJwUCDbKbG2AQU=
 github.com/traefik/yaegi v0.16.1 h1:f1De3DVJqIDKmnasUF6MwmWv1dSEEat0wcpXhD2On3E=
@@ -80,3 +96,5 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/download_spellcheck_dict.sh
+++ b/scripts/download_spellcheck_dict.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DICT_URL="https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt"
+TARGET="$ROOT_DIR/spellcheck_words.txt"
+
+echo "Downloading US English dictionary..."
+curl -L "$DICT_URL" -o "$TARGET"
+echo "Dictionary saved to $TARGET"

--- a/spellcheck.go
+++ b/spellcheck.go
@@ -1,0 +1,77 @@
+package main
+
+//go:generate scripts/download_spellcheck_dict.sh
+
+import (
+	"bytes"
+	_ "embed"
+	"strings"
+	"unicode"
+
+	"github.com/f1monkey/spellchecker"
+
+	"gothoom/eui"
+)
+
+//go:embed spellcheck_words.txt
+var embeddedDict []byte
+
+var sc *spellchecker.Spellchecker
+
+// commonWords provides a tiny built-in dictionary so the checker works out of
+// the box without large data files. A more complete word list can be added
+// later by placing a file at spellcheck_words.txt.
+var commonWords = []string{
+	"the", "be", "to", "of", "and", "a", "in", "that", "have", "i", "it", "for", "not", "on", "with", "he",
+	"as", "you", "do", "at", "this", "but", "his", "by", "from", "they", "we", "say", "her", "she",
+	"or", "an", "will", "my", "one", "all", "would", "there", "their",
+}
+
+func init() {
+	var err error
+	sc, err = spellchecker.New("abcdefghijklmnopqrstuvwxyz'", spellchecker.WithMaxErrors(1))
+	if err != nil {
+		sc = nil
+		return
+	}
+	if len(embeddedDict) > 0 {
+		if err := sc.AddFrom(bytes.NewReader(embeddedDict)); err != nil {
+			// ignore errors reading embedded dictionary
+			sc.Add(commonWords...)
+		}
+	} else {
+		// Fallback to a minimal set of common words.
+		sc.Add(commonWords...)
+	}
+}
+
+func findMisspellings(s string) []eui.TextSpan {
+	if sc == nil {
+		return nil
+	}
+	rs := []rune(s)
+	spans := []eui.TextSpan{}
+	start := -1
+	for i, r := range rs {
+		if unicode.IsLetter(r) || r == '\'' {
+			if start == -1 {
+				start = i
+			}
+			continue
+		}
+		if start != -1 {
+			word := strings.ToLower(string(rs[start:i]))
+			if !sc.IsCorrect(word) {
+				spans = append(spans, eui.TextSpan{Start: start, End: i})
+			}
+			start = -1
+		}
+	}
+	if start != -1 {
+		word := strings.ToLower(string(rs[start:]))
+		if !sc.IsCorrect(word) {
+			spans = append(spans, eui.TextSpan{Start: start, End: len(rs)})
+		}
+	}
+	return spans
+}

--- a/text_window.go
+++ b/text_window.go
@@ -137,6 +137,10 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 		// Soft-wrap the input message to the available width and grow the input area.
 		_, inLines := wrapText(inputMsg, face, wrapWidthPx)
 		wrappedIn := strings.Join(inLines, "\n")
+		var miss []eui.TextSpan
+		if inputMsg != "" && !strings.HasPrefix(inputMsg, "[") {
+			miss = findMisspellings(wrappedIn)
+		}
 		inLinesN := len(inLines)
 		if inLinesN < 1 {
 			inLinesN = 1
@@ -158,6 +162,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			t.Face = face
 			t.Size = eui.Point{X: clientWAvail, Y: inputContentH}
 			t.Filled = true
+			t.Underlines = miss
 			input.AddItem(t)
 		} else {
 			if input.Contents[0].Text != wrappedIn || input.Contents[0].FontSize != float32(fontSize) {
@@ -167,6 +172,7 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 			input.Contents[0].Face = face
 			input.Contents[0].Size.X = clientWAvail
 			input.Contents[0].Size.Y = inputContentH
+			input.Contents[0].Underlines = miss
 		}
 		if scrollInput {
 			input.Scroll.Y = 1e9


### PR DESCRIPTION
## Summary
- add minimal dictionary-based spellchecker
- underline flagged words in text items
- wire spellcheck into text window input
- embed spellcheck word list and add helper script to fetch US dictionary

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; X11/extensions/Xrandr.h: No such file or directory)*
- `GOOS=windows go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b20bff3440832abe9f2070e5eb98ac