### PR TITLE
feat: add hover spellcheck suggestions

### DIFF
--- a/spellcheck.go
+++ b/spellcheck.go
@@ -75,3 +75,13 @@ func findMisspellings(s string) []eui.TextSpan {
 	}
 	return spans
 }
+func suggestCorrections(word string, n int) []string {
+	if sc == nil {
+		return nil
+	}
+	suggestions, err := sc.Suggest(word, n)
+	if err != nil {
+		return nil
+	}
+	return suggestions
+}


### PR DESCRIPTION
## Summary
- show context menu suggestions for misspelled words on hover and allow quick replacement
- expose helper for fetching spellcheck corrections

## Testing
- `go vet ./...` *(fails: Package 'alsa', required by 'virtual:world', not found; Xrandr.h missing)*
- `go build ./...` *(fails: Package 'alsa' and X11/gtk headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2229a5324832a94d1eb80fb0fdd2f