### PR TITLE
Expand built-in spellcheck dictionary

### DIFF
--- a/spellcheck.go
+++ b/spellcheck.go
@@ -25,6 +25,17 @@ var commonWords = []string{
 	"the", "be", "to", "of", "and", "a", "in", "that", "have", "i", "it", "for", "not", "on", "with", "he",
 	"as", "you", "do", "at", "this", "but", "his", "by", "from", "they", "we", "say", "her", "she",
 	"or", "an", "will", "my", "one", "all", "would", "there", "their",
+	// Clan Lord terms and notable NPCs
+	"puddleby", "thoom", "sylvan", "halfling", "dwarf", "fen",
+	"healer", "fighter", "mystic", "ranger", "champion", "bloodmage", "bard",
+	"clan", "clans", "clanning", "exile", "exiles",
+	"moonstone", "sunstone", "fellblade", "greataxe", "gossamer", "kudzu",
+	"darshak", "orga", "wendecka", "noth", "undine", "arachne", "lyfelidae", "yorilla", "t'rool", "scarmis",
+	"lok'groton", "anura", "meshra",
+	"warlock", "berserker", "slasher", "hatchet", "shaman", "scout",
+	"greymyr", "worg", "wraith", "drake", "wyrm", "panther", "cougar", "ferret",
+	"rat", "ratling", "vermine", "noid", "noids", "goblin", "ogre", "orc",
+	"feral", "tenebrion", "melabrion", "qual", "kizmia",
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- remove player names from built-in `commonWords` dictionary, retaining only Clan Lord terminology and notable NPC names

## Testing
- `golangci-lint run` *(fails: the Go language version used to build golangci-lint is lower than the targeted Go version)*
- `go vet ./...` *(fails: pkg-config missing alsa; Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: pkg-config missing alsa, gtk+-3.0; Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b2200cd5c4832abba98b789c370e42