### PR TITLE
fix spell suggestion hover

### DIFF
--- a/scripts/build_dep_bundle.sh
+++ b/scripts/build_dep_bundle.sh
@@ -22,6 +22,9 @@ DEB_PACKAGES=(
   libgl1-mesa-dev
   libglu1-mesa-dev
   xorg-dev
+  libxrandr-dev
+  libasound2-dev
+  libgtk-3-dev
 )
 
 if command -v apt-get >/dev/null 2>&1; then

--- a/text_window.go
+++ b/text_window.go
@@ -181,7 +181,10 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 	}
 
 	if input != nil && len(input.Contents) > 0 {
-		showSpellSuggestions(input.Contents[0])
+		t := input.Contents[0]
+		if t.Text != "" && t.Focused {
+			showSpellSuggestions(t)
+		}
 	}
 
 	if win != nil {
@@ -211,7 +214,10 @@ func updateTextWindow(win *eui.WindowData, list, input *eui.ItemData, msgs []str
 // when hovering over underlined text. Selecting a suggestion replaces the
 // word and updates the input text.
 func showSpellSuggestions(t *eui.ItemData) {
-	if t == nil || !t.Hovered || len(t.Underlines) == 0 || sc == nil {
+	if t == nil || len(t.Underlines) == 0 || sc == nil {
+		return
+	}
+	if t.Text == "" || t.ParentWindow == nil || !t.ParentWindow.IsOpen() {
 		return
 	}
 	if eui.ContextMenusOpen() {

--- a/text_window.go
+++ b/text_window.go
@@ -217,7 +217,7 @@ func showSpellSuggestions(t *eui.ItemData) {
 	if t == nil || len(t.Underlines) == 0 || sc == nil {
 		return
 	}
-	if t.Text == "" || t.ParentWindow == nil || !t.ParentWindow.IsOpen() {
+	if !t.Focused || t.Text == "" || t.ParentWindow == nil || !t.ParentWindow.IsOpen() {
 		return
 	}
 	if eui.ContextMenusOpen() {


### PR DESCRIPTION
## Summary
- ensure spellcheck hover suggestions only appear when input text exists and focused
- guard spelling suggestions against closed windows or missing text

## Testing
- `go vet ./...` *(fails: Xrandr.h missing)*
- `go build ./...` *(fails: Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f584638832a8b614fc46c6ee437