### PR TITLE
Show spell suggestions on hover

### DIFF
--- a/game.go
+++ b/game.go
@@ -794,6 +794,10 @@ func (g *Game) Update() error {
 		}
 	}
 
+	if inputFlow != nil && len(inputFlow.Contents) > 0 {
+		showSpellSuggestions(inputFlow.Contents[0])
+	}
+
 	focused := ebiten.IsFocused()
 
 	/* WASD / ARROWS */


### PR DESCRIPTION
## Summary
- Display spell-check suggestions when hovering misspelled words by checking the input field each frame

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: "glfw: X11: The DISPLAY environment variable is missing")*

------
https://chatgpt.com/codex/tasks/task_e_68b247d88b18832a8576904100c8eb63