### PR TITLE
Fix hover spellcheck suggestions when input not focused

### DIFF
--- a/spell_suggestions_test.go
+++ b/spell_suggestions_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	ebiten "github.com/hajimehoshi/ebiten/v2"
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+	"gothoom/eui"
+)
+
+func TestHoverSpellSuggestionsMatchesContext(t *testing.T) {
+	win := eui.NewWindow()
+	win.MarkOpen()
+	txt, _ := eui.NewText()
+	txt.Text = "helo"
+	txt.Underlines = findMisspellings(txt.Text)
+	if len(txt.Underlines) == 0 {
+		t.Fatalf("expected misspelling to be underlined")
+	}
+	win.AddItem(txt)
+	txt.Focused = false
+
+	metrics := txt.Face.Metrics()
+	lineHeight := float32(math.Ceil(metrics.HAscent + metrics.HDescent + 2))
+	w, _ := text.Measure(txt.Text, txt.Face, 0)
+	txt.DrawRect.X0 = 0
+	txt.DrawRect.Y0 = 0
+	txt.DrawRect.X1 = float32(w)
+	txt.DrawRect.Y1 = lineHeight
+
+	cx := float32(w) / 2
+	cy := lineHeight / 2
+	cursorPosition = func() (int, int) { return int(cx), int(cy) }
+	defer func() { cursorPosition = ebiten.CursorPosition }()
+
+	var got []string
+	showContextMenu = func(opts []string, x, y float32, onSelect func(int)) *eui.ItemData {
+		got = append([]string(nil), opts...)
+		return nil
+	}
+	defer func() { showContextMenu = eui.ShowContextMenu }()
+
+	showSpellSuggestions(txt)
+
+	expected := suggestCorrections("helo", 5)
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+}

--- a/text_window.go
+++ b/text_window.go
@@ -10,6 +10,11 @@ import (
 	text "github.com/hajimehoshi/ebiten/v2/text/v2"
 )
 
+var (
+	cursorPosition  = ebiten.CursorPosition
+	showContextMenu = eui.ShowContextMenu
+)
+
 // makeTextWindow creates a standardized text window with optional input bar.
 func makeTextWindow(title string, hz eui.HZone, vz eui.VZone, withInput bool) (*eui.WindowData, *eui.ItemData, *eui.ItemData) {
 	win := eui.NewWindow()
@@ -217,13 +222,13 @@ func showSpellSuggestions(t *eui.ItemData) {
 	if t == nil || len(t.Underlines) == 0 || sc == nil {
 		return
 	}
-	if !t.Focused || t.Text == "" || t.ParentWindow == nil || !t.ParentWindow.IsOpen() {
+	if t.Text == "" || t.ParentWindow == nil || !t.ParentWindow.IsOpen() {
 		return
 	}
 	if eui.ContextMenusOpen() {
 		return
 	}
-	mx, my := ebiten.CursorPosition()
+	mx, my := cursorPosition()
 	x := float32(mx)
 	y := float32(my)
 	if x < t.DrawRect.X0 || x > t.DrawRect.X1 || y < t.DrawRect.Y0 || y > t.DrawRect.Y1 {
@@ -260,7 +265,7 @@ func showSpellSuggestions(t *eui.ItemData) {
 			if len(sugg) == 0 {
 				return
 			}
-			eui.ShowContextMenu(sugg, x, y, func(i int) {
+			showContextMenu(sugg, x, y, func(i int) {
 				if i < 0 || i >= len(sugg) {
 					return
 				}


### PR DESCRIPTION
## Summary
- allow spellcheck hover suggestions to show even when the text item isn't focused
- add unit test ensuring hover suggestions match right-click context behavior

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; pkg-config missing alsa & gtk+-3.0)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; pkg-config missing alsa & gtk+-3.0)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; pkg-config missing alsa & gtk+-3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b260e13004832a9a6d45e76f6df089