### PR TITLE
Enable cursor navigation within text inputs

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -170,6 +170,7 @@ type itemData struct {
 	Underlines    []TextSpan
 	SecretText    string
 	HideText      bool
+	CursorPos     int
 	Handler       *EventHandler
 	Contents      []*itemData
 


### PR DESCRIPTION
## Summary
- track cursor position in text inputs
- allow moving caret with arrow keys and editing at the cursor
- render input text and caret with multiline support

## Testing
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: missing X11 extensions and ALSA libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68b28bf77f40832aa7a716459b2e901b