### PR TITLE
Add test verifying macros window loads existing macros

### DIFF
--- a/macros_ui_test.go
+++ b/macros_ui_test.go
@@ -86,3 +86,42 @@ func TestPluginRemoveMacrosRefresh(t *testing.T) {
 		t.Fatalf("macros window not refreshed")
 	}
 }
+
+// Test that opening the macros window after macros have been added lists them correctly.
+func TestMacrosWindowLoadsExistingMacros(t *testing.T) {
+	// Reset state and ensure cleanup after the test.
+	macroMu = sync.RWMutex{}
+	macroMaps = map[string]map[string]string{}
+	pluginDisplayNames = map[string]string{}
+	pluginCategories = map[string]string{}
+	pluginSubCategories = map[string]string{}
+	macrosWin = nil
+	macrosList = nil
+	t.Cleanup(func() {
+		macroMu = sync.RWMutex{}
+		macroMaps = map[string]map[string]string{}
+		pluginDisplayNames = map[string]string{}
+		pluginCategories = map[string]string{}
+		pluginSubCategories = map[string]string{}
+		macrosWin = nil
+		macrosList = nil
+	})
+
+	// Add macros before creating the window to mimic plugins registering at startup.
+	pluginAddMacro("tester", "yy", "/yell ")
+
+	// Now create the window; it should populate with existing macros.
+	makeMacrosWindow()
+	if macrosList == nil {
+		t.Fatalf("macros window not initialized")
+	}
+	if len(macrosList.Contents) != 2 {
+		t.Fatalf("items not added to list: %d", len(macrosList.Contents))
+	}
+	if got := macrosList.Contents[0].Text; got != "tester:" {
+		t.Fatalf("unexpected plugin text: %q", got)
+	}
+	if got := macrosList.Contents[1].Text; got != "  yy = /yell" {
+		t.Fatalf("unexpected macro text: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test to ensure macros window populates when macros are registered before it's opened

## Testing
- `go vet ./...`
- `go test -run TestMacros -count=1` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b28c1f7290832aa5048e827eff9bd6