### PR TITLE
Reset frame timing when starting a new session

### DIFF
--- a/game.go
+++ b/game.go
@@ -301,6 +301,13 @@ func resetDrawState() {
 	serverFPS = 0
 	frameInterval = framems * time.Millisecond
 
+	// Clear frame timing history so new sessions start fresh without
+	// inherited intervals from previous connections.
+	frameMu.Lock()
+	lastFrameTime = time.Time{}
+	intervalHist = map[int]int{}
+	frameMu.Unlock()
+
 	stateMu.Lock()
 	initialState = cloneDrawState(state)
 	stateMu.Unlock()


### PR DESCRIPTION
## Summary
- clear frame timing history when a game session resets so interpolation starts with fresh data

## Testing
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b28c68bd04832abf60191ce2d7ce25