### PR TITLE
Ignore closed windows for Enter and Tab

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -516,7 +516,7 @@ func Update() error {
 	}
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyEnter) || inpututil.IsKeyJustPressed(ebiten.KeyKPEnter) {
-		if activeWindow != nil && activeWindow.DefaultButton != nil {
+		if activeWindow != nil && activeWindow.Open && activeWindow.DefaultButton != nil {
 			btn := activeWindow.DefaultButton
 			if !btn.Disabled && !btn.Invisible {
 				activeItem = btn
@@ -530,7 +530,7 @@ func Update() error {
 	}
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyTab) {
-		if activeWindow != nil {
+		if activeWindow != nil && activeWindow.Open {
 			var inputs []*itemData
 			collectInputs(activeWindow.Contents, &inputs)
 			if len(inputs) > 0 {


### PR DESCRIPTION
## Summary
- ignore closed windows when processing Enter key default buttons
- skip tab focus on closed windows

## Testing
- `go list ./... | grep -v '^go/' | xargs go vet` *(fails: no required module provides package github.com/dchest/siphash)*
- `go build ./...` *(fails: no required module provides package github.com/dchest/siphash)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a14db21c832a86a996782ace5ccc