### PR TITLE
Fall back to server command when plugin is disabled

### DIFF
--- a/game.go
+++ b/game.go
@@ -764,6 +764,10 @@ func (g *Game) Update() error {
 							if !pluginDisabled[owner] {
 								consoleMessage("> " + txt)
 								go handler(args)
+							} else {
+								// Disabled plugin commands should fall through so the
+								// server still receives the user's input.
+								pendingCommand = txt
 							}
 						} else {
 							pendingCommand = txt


### PR DESCRIPTION
## Summary
- ensure slash commands still reach the server when a matching plugin command is disabled
- add regression test for disabled plugin command handling

## Testing
- `scripts/download_spellcheck_dict.sh`
- `go vet ./...` *(fails: gothoom/eui.Color struct literal uses unkeyed fields)*
- `go test -run DisabledPluginCommandFallsThrough` *(fails: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a2d7fbd0832ab90d23d6298274dd