### PR TITLE
Prevent hotkeys and console input while typing in UI fields

### DIFF
--- a/game.go
+++ b/game.go
@@ -585,6 +585,7 @@ func (g *Game) Update() error {
 	})
 
 	eui.Update() //We really need this to return eaten clicks
+	typingElsewhere := typingInUI()
 	checkPluginMods()
 	updateNotifications()
 	updateThinkMessages()
@@ -671,6 +672,12 @@ func (g *Game) Update() error {
 
 	/* Console input */
 	changedInput := false
+	if typingElsewhere && inputActive {
+		inputActive = false
+		inputText = inputText[:0]
+		historyPos = len(inputHistory)
+		changedInput = true
+	}
 	if inputActive {
 		if newChars := ebiten.AppendInputChars(nil); len(newChars) > 0 {
 			inputText = append(inputText, newChars...)
@@ -790,7 +797,7 @@ func (g *Game) Update() error {
 			historyPos = len(inputHistory)
 			changedInput = true
 		}
-	} else {
+	} else if !typingElsewhere {
 		if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
 			inputActive = true
 			inputText = inputText[:0]

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -892,7 +892,7 @@ func hotkeyEquipAlreadyEquipped(cmd string) bool {
 }
 
 func checkHotkeys() {
-	if recording || inputActive {
+	if recording || inputActive || typingInUI() {
 		return
 	}
 	if combo := detectCombo(); combo != "" {

--- a/input_ui.go
+++ b/input_ui.go
@@ -82,3 +82,44 @@ func pointInItems(items []*eui.ItemData, fx, fy float32) bool {
 	}
 	return false
 }
+
+// typingInUI reports whether any EUI text input other than the console input bar
+// currently has focus.
+func typingInUI() bool {
+	var inputItem *eui.ItemData
+	if inputFlow != nil && len(inputFlow.Contents) > 0 {
+		inputItem = inputFlow.Contents[0]
+	}
+	windows := eui.Windows()
+	for _, win := range windows {
+		if !win.IsOpen() {
+			continue
+		}
+		if typingInItems(win.Contents, inputItem) {
+			return true
+		}
+	}
+	return false
+}
+
+func typingInItems(items []*eui.ItemData, exclude *eui.ItemData) bool {
+	for _, it := range items {
+		if it == nil {
+			continue
+		}
+		if it.Focused && (it.ItemType == eui.ITEM_TEXT || it.ItemType == eui.ITEM_INPUT) && it != exclude {
+			return true
+		}
+		if len(it.Contents) > 0 && typingInItems(it.Contents, exclude) {
+			return true
+		}
+		if len(it.Tabs) > 0 {
+			for _, tab := range it.Tabs {
+				if typingInItems(tab.Contents, exclude) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/input_ui_test.go
+++ b/input_ui_test.go
@@ -37,3 +37,32 @@ func TestPointInGameWindow(t *testing.T) {
 		t.Fatalf("pointInGameWindow should ignore exterior point")
 	}
 }
+
+func TestTypingInUI(t *testing.T) {
+	for _, w := range eui.Windows() {
+		w.Close()
+	}
+
+	consoleWin = eui.NewWindow()
+	inputFlow = &eui.ItemData{}
+	consoleWin.AddItem(inputFlow)
+	inp, _ := eui.NewText()
+	inputFlow.AddItem(inp)
+	consoleWin.MarkOpen()
+
+	inp.Focused = true
+	if typingInUI() {
+		t.Fatalf("typingInUI should ignore console input")
+	}
+
+	inp.Focused = false
+	win := eui.NewWindow()
+	other, _ := eui.NewInput()
+	other.Focused = true
+	win.AddItem(other)
+	win.MarkOpen()
+
+	if !typingInUI() {
+		t.Fatalf("typingInUI should detect focused input")
+	}
+}


### PR DESCRIPTION
## Summary
- Detect focused text fields and skip console input when typing elsewhere
- Ignore hotkeys while typing into non-console inputs
- Add regression test for typing focus

## Testing
- `go vet ./...` *(fails: missing X11/ALSA headers)*
- `go test ./...` *(fails: missing X11/ALSA headers)*
- `go build ./...` *(fails: missing X11/ALSA headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a3be5dc8832a9c1f8aa47a128603