### PR TITLE
Add cursor placement for text inputs

### DIFF
--- a/eui/input_cursor_test.go
+++ b/eui/input_cursor_test.go
@@ -1,0 +1,41 @@
+package eui
+
+import (
+	"math"
+	"testing"
+
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+func TestCursorIndexAtInput(t *testing.T) {
+	uiScale = 1
+	item, _ := NewInput()
+	item.DrawRect = rect{X0: 0, Y0: 0, X1: 200, Y1: 20}
+	item.FontSize = 12
+	item.Text = "hello"
+	face := itemFace(item, (item.FontSize*uiScale)+2)
+	w, _ := text.Measure("hel", face, 0)
+	mpos := point{X: float32(w), Y: 0}
+	item.clickItem(mpos, true)
+	if item.CursorPos != 3 {
+		t.Fatalf("cursor pos = %d want 3", item.CursorPos)
+	}
+}
+
+func TestCursorIndexAtText(t *testing.T) {
+	uiScale = 1
+	item, _ := NewText()
+	item.Filled = true
+	item.DrawRect = rect{X0: 0, Y0: 0, X1: 200, Y1: 40}
+	item.FontSize = 12
+	item.Text = "hello\nworld"
+	face := itemFace(item, (item.FontSize*uiScale)+2)
+	metrics := face.Metrics()
+	lineH := float32(math.Ceil(metrics.HAscent + metrics.HDescent + 2))
+	w, _ := text.Measure("wo", face, 0)
+	mpos := point{X: float32(w), Y: lineH + 1}
+	item.clickItem(mpos, true)
+	if item.CursorPos != 8 {
+		t.Fatalf("cursor pos = %d want 8", item.CursorPos)
+	}
+}


### PR DESCRIPTION
## Summary
- allow clicking within text fields to place the cursor
- test cursor positioning for input and multi-line text fields

## Testing
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go test ./eui` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b4586290832a95614474b5cbbc70