### PR TITLE
Fix console input cursor reset when clicking

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -28,6 +28,9 @@ func updateConsoleWindow() {
 	if inputFlow != nil && len(inputFlow.Contents) > 0 {
 		inputItem := inputFlow.Contents[0]
 		inputItem.Focused = inputActive
+		if inputItem.Focused {
+			inputPos = inputItem.CursorPos
+		}
 		inputItem.CursorPos = inputPos
 	}
 	if messagesFlow != nil {


### PR DESCRIPTION
## Summary
- Preserve cursor position when clicking in console input by syncing global state

## Testing
- `go vet ./...` *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b74c2bf4832a8f0c3c10ad5274c9