### PR TITLE
Fix console input cursor sync reset

### DIFF
--- a/console_ui.go
+++ b/console_ui.go
@@ -28,9 +28,6 @@ func updateConsoleWindow() {
 	if inputFlow != nil && len(inputFlow.Contents) > 0 {
 		inputItem := inputFlow.Contents[0]
 		inputItem.Focused = inputActive
-		if inputItem.Focused {
-			inputPos = inputItem.CursorPos
-		}
 		inputItem.CursorPos = inputPos
 	}
 	if messagesFlow != nil {

--- a/game.go
+++ b/game.go
@@ -590,6 +590,9 @@ func (g *Game) Update() error {
 	}
 	eui.Update() //We really need this to return eaten clicks
 	typingElsewhere := typingInUI()
+	if inputActive && inputFlow != nil && len(inputFlow.Contents) > 0 {
+		inputPos = inputFlow.Contents[0].CursorPos
+	}
 	checkPluginMods()
 	updateNotifications()
 	updateThinkMessages()


### PR DESCRIPTION
## Summary
- keep console input cursor from resetting each frame so characters append in the expected order
- sync stored cursor position from the UI before processing input

## Testing
- `go vet ./...` *(fails: spellcheck.go: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: spellcheck.go: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: spellcheck.go: pattern spellcheck_words.txt: no matching files found; glfw Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ba974d50832abf25bb53c40f472f