### PR TITLE
Preserve spaces in text wrapping

### DIFF
--- a/textwrap_test.go
+++ b/textwrap_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+func TestWrapTextPreservesSpaces(t *testing.T) {
+	face := &text.GoTextFace{Size: 12}
+	_, lines := wrapText("foo  bar", face, 1000)
+	if len(lines) != 1 {
+		t.Fatalf("lines = %d want 1", len(lines))
+	}
+	if lines[0] != "foo  bar" {
+		t.Fatalf("line = %q want %q", lines[0], "foo  bar")
+	}
+}


### PR DESCRIPTION
## Summary
- prevent `wrapText` from collapsing consecutive spaces so input bar shows them correctly
- add regression test for space preservation

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bd59893c832aa64eccb96c4d451b