### PR TITLE
Add base bubble lifetime slider

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1391,10 +1391,8 @@ func parseDrawState(data []byte, buildCache bool) error {
 			}
 			if showBubble && !skipRender {
 				words := len(strings.Fields(txt))
-				if words < 1 {
-					words = 1
-				}
-				life := int(gs.BubbleLife * float64(words) * float64(1000/framems))
+				lifeSeconds := gs.BubbleBaseLife + float64(words)
+				life := int(lifeSeconds * float64(1000/framems))
 				if life < 1 {
 					life = 1
 				}

--- a/fake.go
+++ b/fake.go
@@ -54,10 +54,8 @@ func runFakeMode(ctx context.Context) {
 		// Helper to append a bubble and show corresponding chat message.
 		emitBubble := func(idx uint8, typ int, name, verb, txt string) {
 			words := len(strings.Fields(txt))
-			if words < 1 {
-				words = 1
-			}
-			life := int(gs.BubbleLife * float64(words) * float64(1000/framems))
+			lifeSeconds := gs.BubbleBaseLife + float64(words)
+			life := int(lifeSeconds * float64(1000/framems))
 			if life < 1 {
 				life = 1
 			}
@@ -118,7 +116,8 @@ func runFakeMode(ctx context.Context) {
 				emitBubble(1, kBubbleMonster, p2, "growls", "Grrr!")
 			case 12: // Off-screen bubble
 				words := len(strings.Fields("Over here!"))
-				life := int(gs.BubbleLife * float64(words) * float64(1000/framems))
+				lifeSeconds := gs.BubbleBaseLife + float64(words)
+				life := int(lifeSeconds * float64(1000/framems))
 				if life < 1 {
 					life = 1
 				}

--- a/settings.go
+++ b/settings.go
@@ -45,7 +45,7 @@ var gsdef settings = settings{
 	InventoryFontSize:       18,
 	PlayersFontSize:         18,
 	BubbleOpacity:           0.7,
-	BubbleLife:              1.0,
+	BubbleBaseLife:          2.0,
 	NameBgOpacity:           0.7,
 	BarOpacity:              0.5,
 	ObscuringPictureOpacity: 0.5,
@@ -128,7 +128,7 @@ type settings struct {
 	InventoryFontSize       float64
 	PlayersFontSize         float64
 	BubbleOpacity           float64
-	BubbleLife              float64
+	BubbleBaseLife          float64 `json:"BubbleLife"`
 	NameBgOpacity           float64
 	BarOpacity              float64
 	ObscuringPictureOpacity float64

--- a/ui.go
+++ b/ui.go
@@ -2586,19 +2586,19 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(bubbleOpSlider)
 
-	bubbleLifeSlider, bubbleLifeEvents := eui.NewSlider()
-	bubbleLifeSlider.Label = "Bubble Life (s/word)"
-	bubbleLifeSlider.MinValue = 0.5
-	bubbleLifeSlider.MaxValue = 5
-	bubbleLifeSlider.Value = float32(gs.BubbleLife)
-	bubbleLifeSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
-	bubbleLifeEvents.Handle = func(ev eui.UIEvent) {
+	bubbleBaseLifeSlider, bubbleBaseLifeEvents := eui.NewSlider()
+	bubbleBaseLifeSlider.Label = "Base Bubble Life (s)"
+	bubbleBaseLifeSlider.MinValue = 1
+	bubbleBaseLifeSlider.MaxValue = 5
+	bubbleBaseLifeSlider.Value = float32(gs.BubbleBaseLife)
+	bubbleBaseLifeSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
+	bubbleBaseLifeEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
-			gs.BubbleLife = float64(ev.Value)
+			gs.BubbleBaseLife = float64(ev.Value)
 			settingsDirty = true
 		}
 	}
-	right.AddItem(bubbleLifeSlider)
+	right.AddItem(bubbleBaseLifeSlider)
 
 	fadePicsCB, fadePicsEvents := eui.NewCheckbox()
 	fadePicsCB.Text = "Fade pictures over mobiles"


### PR DESCRIPTION
## Summary
- Add configurable base bubble lifetime slider
- Calculate bubble duration as base seconds plus word count

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go build` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `golangci-lint run` *(fails: Go language version mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_68b2bfdc4530832a991b54774f2aca91