### PR TITLE
Add sliders to tune shader lighting and glow

### DIFF
--- a/data/shaders/light.kage
+++ b/data/shaders/light.kage
@@ -2,12 +2,12 @@ package main
 
 const MaxLights = 128
 // Lights restore detail more aggressively near sources but never exceed base.
-const LightScale = 4
+const BaseLightScale = 4
 // Darkening strength per dark source; tuned to avoid over-darkening at low night levels
-const DarkScale  = 1
+const DarkScale      = 1
 // Additive glow-ball parameters
-const HaloRadiusFrac = 0.35
-const HaloStrength  = 0.3
+const HaloRadiusFrac    = 0.35
+const BaseHaloStrength  = 0.3
 
 var (
     LightCount int
@@ -24,6 +24,8 @@ var (
     DarkRadius [MaxLights]float
     DarkAlpha [MaxLights]float
     DarkIntensity [MaxLights]float
+    LightStrength float
+    GlowStrength float
     NightFactor float
 )
 
@@ -65,7 +67,7 @@ func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
             f := 1.0 / (1.0 + nd*nd)
             // Sharper falloff to localize light influence
             f = f * f
-            w := clamp(LightScale*f, 0.0, 10.0) * LightIntensity[i]
+            w := clamp(BaseLightScale*LightStrength*f, 0.0, 10.0) * LightIntensity[i]
             sumW += w
             rgb := vec3(LightR[i], LightG[i], LightB[i])
             // Equalize by luminance to balance hue influence
@@ -140,7 +142,7 @@ func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
     }
     // Tone-map halo and add with small strength
     halo = halo / (1.0 + halo)
-    finalRGB = clamp(finalRGB + HaloStrength*halo, 0.0, 1.0)
+    finalRGB = clamp(finalRGB + BaseHaloStrength*GlowStrength*halo, 0.0, 1.0)
 
     return vec4(finalRGB, base.a)
 }

--- a/lighting_shader.go
+++ b/lighting_shader.go
@@ -161,6 +161,9 @@ func applyLightingShader(dst *ebiten.Image, lights []lightSource, darks []darkSo
 	uniforms["DarkAlpha"] = da
 	uniforms["DarkIntensity"] = dint
 
+	uniforms["LightStrength"] = float32(gs.ShaderLightStrength)
+	uniforms["GlowStrength"] = float32(gs.ShaderGlowStrength)
+
 	// Compute smoothed night factor for reveal scaling in shader.
 	// If we have night smoothing state, use it; otherwise fall back to current level.
 	nightFactor := float32(0)

--- a/settings.go
+++ b/settings.go
@@ -82,6 +82,8 @@ var gsdef settings = settings{
 	GameSound:            true,
 	GameScale:            2,
 	BarPlacement:         BarPlacementBottom,
+	ShaderLightStrength:  1.0,
+	ShaderGlowStrength:   1.0,
 	MaxNightLevel:        100,
 	ForceNightLevel:      -1,
 	ChatTTS:              true,
@@ -207,6 +209,9 @@ type settings struct {
 	ChatWindow      WindowState
 	WindowZones     map[string]eui.WindowZoneState
 
+	ShaderLightStrength float64
+	ShaderGlowStrength  float64
+
 	imgPlanesDebug      bool
 	smoothingDebug      bool
 	pictAgainDebug      bool
@@ -323,6 +328,13 @@ func loadSettings() bool {
 	}
 	if gs.ChatTTSVoice == "" {
 		gs.ChatTTSVoice = gsdef.ChatTTSVoice
+	}
+
+	if gs.ShaderLightStrength < 0 || gs.ShaderLightStrength > 2 {
+		gs.ShaderLightStrength = gsdef.ShaderLightStrength
+	}
+	if gs.ShaderGlowStrength < 0 || gs.ShaderGlowStrength > 2 {
+		gs.ShaderGlowStrength = gsdef.ShaderGlowStrength
 	}
 
 	if gs.WindowWidth > 0 && gs.WindowHeight > 0 {
@@ -686,6 +698,12 @@ func applyQualityPreset(name string) {
 	}
 	if debugWin != nil {
 		debugWin.Refresh()
+	}
+	if shaderLightSlider != nil {
+		shaderLightSlider.Disabled = !gs.shaderLighting
+	}
+	if shaderGlowSlider != nil {
+		shaderGlowSlider.Disabled = !gs.shaderLighting
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -82,32 +82,34 @@ var (
 	pictBlendLabel   *eui.ItemData
 	totalCacheLabel  *eui.ItemData
 
-	soundTestLabel  *eui.ItemData
-	soundTestID     int
-	recordBtn       *eui.ItemData
-	recordStatus    *eui.ItemData
-	qualityPresetDD *eui.ItemData
-	denoiseCB       *eui.ItemData
-	motionCB        *eui.ItemData
-	noSmoothCB      *eui.ItemData
-	animCB          *eui.ItemData
-	pictBlendCB     *eui.ItemData
-	throttleSoundCB *eui.ItemData
-	precacheSoundCB *eui.ItemData
-	precacheImageCB *eui.ItemData
-	noCacheCB       *eui.ItemData
-	potatoCB        *eui.ItemData
-	volumeSlider    *eui.ItemData
-	muteBtn         *eui.ItemData
-	mixerWin        *eui.WindowData
-	masterMixSlider *eui.ItemData
-	gameMixSlider   *eui.ItemData
-	musicMixSlider  *eui.ItemData
-	ttsMixSlider    *eui.ItemData
-	mixMuteBtn      *eui.ItemData
-	gameMixCB       *eui.ItemData
-	musicMixCB      *eui.ItemData
-	ttsMixCB        *eui.ItemData
+	soundTestLabel    *eui.ItemData
+	soundTestID       int
+	recordBtn         *eui.ItemData
+	recordStatus      *eui.ItemData
+	qualityPresetDD   *eui.ItemData
+	shaderLightSlider *eui.ItemData
+	shaderGlowSlider  *eui.ItemData
+	denoiseCB         *eui.ItemData
+	motionCB          *eui.ItemData
+	noSmoothCB        *eui.ItemData
+	animCB            *eui.ItemData
+	pictBlendCB       *eui.ItemData
+	throttleSoundCB   *eui.ItemData
+	precacheSoundCB   *eui.ItemData
+	precacheImageCB   *eui.ItemData
+	noCacheCB         *eui.ItemData
+	potatoCB          *eui.ItemData
+	volumeSlider      *eui.ItemData
+	muteBtn           *eui.ItemData
+	mixerWin          *eui.WindowData
+	masterMixSlider   *eui.ItemData
+	gameMixSlider     *eui.ItemData
+	musicMixSlider    *eui.ItemData
+	ttsMixSlider      *eui.ItemData
+	mixMuteBtn        *eui.ItemData
+	gameMixCB         *eui.ItemData
+	musicMixCB        *eui.ItemData
+	ttsMixCB          *eui.ItemData
 )
 
 var ttsTestPhrase = "The quick brown fox jumps over the lazy dog"
@@ -3450,12 +3452,60 @@ func makeQualityWindow() {
 			if qualityPresetDD != nil {
 				qualityPresetDD.Selected = detectQualityPreset()
 			}
+			if shaderLightSlider != nil {
+				shaderLightSlider.Disabled = !ev.Checked
+			}
+			if shaderGlowSlider != nil {
+				shaderGlowSlider.Disabled = !ev.Checked
+			}
 			if debugWin != nil {
 				debugWin.Refresh()
 			}
 		}
 	}
 	left.AddItem(shaderQualityCB)
+
+	sLS, shaderLightEvents := eui.NewSlider()
+	shaderLightSlider = sLS
+	shaderLightSlider.Label = "Light Strength"
+	shaderLightSlider.MinValue = 0
+	shaderLightSlider.MaxValue = 200
+	shaderLightSlider.IntOnly = true
+	shaderLightSlider.Value = float32(gs.ShaderLightStrength * 100)
+	shaderLightSlider.Size = eui.Point{X: width - 10, Y: 24}
+	shaderLightSlider.Disabled = !gs.shaderLighting
+	shaderLightSlider.Tooltip = "Adjust intensity of shader lighting"
+	shaderLightEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.ShaderLightStrength = float64(ev.Value / 100)
+			settingsDirty = true
+			if debugWin != nil {
+				debugWin.Refresh()
+			}
+		}
+	}
+	left.AddItem(shaderLightSlider)
+
+	sGS, shaderGlowEvents := eui.NewSlider()
+	shaderGlowSlider = sGS
+	shaderGlowSlider.Label = "Glow Strength"
+	shaderGlowSlider.MinValue = 0
+	shaderGlowSlider.MaxValue = 200
+	shaderGlowSlider.IntOnly = true
+	shaderGlowSlider.Value = float32(gs.ShaderGlowStrength * 100)
+	shaderGlowSlider.Size = eui.Point{X: width - 10, Y: 24}
+	shaderGlowSlider.Disabled = !gs.shaderLighting
+	shaderGlowSlider.Tooltip = "Adjust strength of glow halos"
+	shaderGlowEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.ShaderGlowStrength = float64(ev.Value / 100)
+			settingsDirty = true
+			if debugWin != nil {
+				debugWin.Refresh()
+			}
+		}
+	}
+	left.AddItem(shaderGlowSlider)
 
 	vsyncCB, vsyncEvents := eui.NewCheckbox()
 	vsyncCB.Text = "VSync - Limit FPS"


### PR DESCRIPTION
## Summary
- add adjustable uniforms for shader light and glow strength
- expose light and glow sliders in the quality settings UI
- store light and glow strengths in settings

## Testing
- `go vet .` *(fails: labels.go:176:9 struct literal uses unkeyed fields)*
- `go build .`


------
https://chatgpt.com/codex/tasks/task_e_68b2bede3d40832a9d885841196ea777