### PR TITLE
Add default F12 fullscreen hotkey

### DIFF
--- a/hotkeys.go
+++ b/hotkeys.go
@@ -125,7 +125,7 @@ func loadHotkeys() {
 	}
 	pluginHotkeyMu.Unlock()
 
-	// Ensure the default right-click use hotkey exists.
+	// Ensure default hotkeys exist.
 	def := Hotkey{Name: "Click To Use", Combo: "RightClick", Commands: []HotkeyCommand{{Command: "/use @clicked"}}, Disabled: true}
 	exists := false
 	for _, hk := range newList {
@@ -136,6 +136,18 @@ func loadHotkeys() {
 	}
 	if !exists {
 		newList = append(newList, def)
+	}
+
+	fs := Hotkey{Name: "Toggle Fullscreen", Combo: "F12", Commands: []HotkeyCommand{{Command: "/fullscreen"}}}
+	exists = false
+	for _, hk := range newList {
+		if hk.Combo == fs.Combo && hk.Plugin == "" {
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		newList = append(newList, fs)
 	}
 
 	hotkeysMu.Lock()
@@ -903,6 +915,16 @@ func checkHotkeys() {
 			if hk.Combo == combo && !hk.Disabled {
 				for _, c := range hk.Commands {
 					cmd := strings.TrimSpace(c.Command)
+					lower := strings.ToLower(cmd)
+					if lower == "/fullscreen" {
+						SettingsLock.Lock()
+						gs.Fullscreen = !gs.Fullscreen
+						ebiten.SetFullscreen(gs.Fullscreen)
+						ebiten.SetWindowFloating(gs.Fullscreen || gs.AlwaysOnTop)
+						SettingsLock.Unlock()
+						settingsDirty = true
+						continue
+					}
 					// Show hotkey-triggered command as if it were typed
 					var ok bool
 					cmd, ok = applyHotkeyVars(cmd)

--- a/ui.go
+++ b/ui.go
@@ -2162,7 +2162,7 @@ func makeSettingsWindow() {
 	}
 
 	fullscreenCB, fullscreenEvents := eui.NewCheckbox()
-	fullscreenCB.Text = "Fullscreen"
+	fullscreenCB.Text = "Fullscreen (F12)"
 	fullscreenCB.Size = eui.Point{X: panelWidth, Y: 24}
 	fullscreenCB.Checked = gs.Fullscreen
 	fullscreenEvents.Handle = func(ev eui.UIEvent) {


### PR DESCRIPTION
## Summary
- Add built-in F12 hotkey for toggling fullscreen
- Show F12 as the shortcut next to the Fullscreen checkbox in settings

## Testing
- `go vet ./...` *(fails: gothoom/eui.Color struct literal uses unkeyed fields)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2c0497d84832aa29e8f95c5ab4719