### PR TITLE
Sync console input text after mouse cursor placement

### DIFF
--- a/game.go
+++ b/game.go
@@ -593,6 +593,8 @@ func (g *Game) Update() error {
 	if inputActive && inputFlow != nil && len(inputFlow.Contents) > 0 {
 		item := inputFlow.Contents[0]
 		inputPos = plainCursorPos(item.Text, item.CursorPos)
+		plain := strings.ReplaceAll(item.Text, "\n", "")
+		inputText = []rune(plain)
 	}
 	checkPluginMods()
 	updateNotifications()


### PR DESCRIPTION
## Summary
- synchronize internal console input buffer with UI after mouse clicks
- prevent misordered text when typing after using mouse to reposition cursor

## Testing
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d32187d4832aaec46b141503ccf0