### PR TITLE
fix console input mouse cursor focus

### DIFF
--- a/eui/clear_focus_test.go
+++ b/eui/clear_focus_test.go
@@ -1,0 +1,28 @@
+package eui
+
+import "testing"
+
+// TestClearFocus verifies ClearFocus removes focus only when the provided
+// item currently holds focus.
+func TestClearFocus(t *testing.T) {
+	uiScale = 1
+	item, _ := NewInput()
+	item.DrawRect = rect{X0: 0, Y0: 0, X1: 10, Y1: 10}
+	item.clickItem(point{X: 1, Y: 1}, true)
+	if focusedItem != item {
+		t.Fatalf("expected item to be focused")
+	}
+
+	// Clearing focus with a different item should do nothing.
+	other, _ := NewInput()
+	ClearFocus(other)
+	if focusedItem != item {
+		t.Fatalf("focus should remain on original item")
+	}
+
+	// Clearing focus with the focused item should remove focus.
+	ClearFocus(item)
+	if focusedItem != nil {
+		t.Fatalf("focus was not cleared")
+	}
+}

--- a/eui/public.go
+++ b/eui/public.go
@@ -166,3 +166,12 @@ func SetCurrentStyleName(name string) { currentStyleName = name }
 
 // AccentSaturation returns the current accent color saturation value.
 func AccentSaturation() float64 { return accentSaturation }
+
+// ClearFocus removes focus from the provided item if it is currently focused.
+func ClearFocus(it *ItemData) {
+	if focusedItem == it {
+		focusedItem.Focused = false
+		focusedItem.markDirty()
+		focusedItem = nil
+	}
+}

--- a/game.go
+++ b/game.go
@@ -586,6 +586,7 @@ func (g *Game) Update() error {
 	})
 
 	if inputFlow != nil && len(inputFlow.Contents) > 0 {
+		eui.ClearFocus(inputFlow.Contents[0])
 		inputFlow.Contents[0].Focused = false
 	}
 	eui.Update() //We really need this to return eaten clicks


### PR DESCRIPTION
## Summary
- clear focus before updating UI so console input click no longer interleaves typed text
- expose `eui.ClearFocus` to drop focus from specified item
- add test coverage for focus clearing helper

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h missing)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing; Package 'alsa' not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b2d860a514832a95d2c095bb726feb