### PR TITLE
Fix undefined variable in bubble outline rendering

### DIFF
--- a/bubble.go
+++ b/bubble.go
@@ -247,6 +247,7 @@ func drawBubble(screen *ebiten.Image, txt string, x, y int, typ int, far bool, n
 		outline.Close()
 
 		vs, is = outline.AppendVerticesAndIndicesForStroke(nil, nil, &vector.StrokeOptions{Width: float32(gs.GameScale)})
+		op := &ebiten.DrawTrianglesOptions{ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha, AntiAlias: true}
 		for i := range vs {
 			vs[i].SrcX = 0
 			vs[i].SrcY = 0


### PR DESCRIPTION
## Summary
- define DrawTrianglesOptions before drawing bubble outlines to fix undefined variable

## Testing
- `go vet ./...` *(fails: no output; process hung, aborted)*
- `go build` *(fails: climg/mask.go:52:44: undefined: io)*

------
https://chatgpt.com/codex/tasks/task_e_68b32e63eadc832a9255a5574fc9ff84