### PR TITLE
Buffer UDP reads and add tests

### DIFF
--- a/example_scripts/example.txt
+++ b/example_scripts/example.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/network.go
+++ b/network.go
@@ -101,26 +101,38 @@ func writeAll(conn net.Conn, data []byte) error {
 	return nil
 }
 
-// readUDPMessage reads a single length-prefixed message from the UDP connection.
+// udpBuffer holds leftover datagram data between reads.
+var udpBuffer []byte
+
+// readUDPMessage reads a single length-prefixed message from the UDP
+// connection. Packets may be fragmented across multiple datagrams or multiple
+// messages may be present in a single datagram. Data is accumulated in
+// udpBuffer until a full message is available.
 func readUDPMessage(connection net.Conn) ([]byte, error) {
-	buf := make([]byte, 65535)
-	n, err := connection.Read(buf)
-	if err != nil {
-		//logError("read udp: %v", err)
-		return nil, err
+	for {
+		if len(udpBuffer) >= 2 {
+			sz := int(binary.BigEndian.Uint16(udpBuffer[:2]))
+			if len(udpBuffer) >= 2+sz {
+				msg := append([]byte(nil), udpBuffer[2:2+sz]...)
+				udpBuffer = udpBuffer[2+sz:]
+				tag := binary.BigEndian.Uint16(msg[:2])
+				logDebug("recv udp tag %d len %d", tag, len(msg))
+				hexDump("recv", msg)
+				return msg, nil
+			}
+		}
+
+		buf := make([]byte, 65535)
+		n, err := connection.Read(buf)
+		if err != nil {
+			//logError("read udp: %v", err)
+			return nil, err
+		}
+		if n == 0 {
+			return nil, fmt.Errorf("short udp packet")
+		}
+		udpBuffer = append(udpBuffer, buf[:n]...)
 	}
-	if n < 2 {
-		return nil, fmt.Errorf("short udp packet")
-	}
-	sz := int(binary.BigEndian.Uint16(buf[:2]))
-	if sz > n-2 {
-		return nil, fmt.Errorf("incomplete udp packet")
-	}
-	msg := append([]byte(nil), buf[2:2+sz]...)
-	tag := binary.BigEndian.Uint16(msg[:2])
-	logDebug("recv udp tag %d len %d", tag, len(msg))
-	hexDump("recv", msg)
-	return msg, nil
 }
 
 // sendPlayerInput sends the provided mouse state to the server. When
@@ -200,13 +212,13 @@ func processServerMessage(msg []byte) {
 		return
 	}
 	tag := binary.BigEndian.Uint16(msg[:2])
-    if tag == 2 {
-        noteFrame()
-        // Advance plugin tick sleepers on each server frame
-        pluginAdvanceTick()
-        handleDrawState(msg, true)
-        return
-    }
+	if tag == 2 {
+		noteFrame()
+		// Advance plugin tick sleepers on each server frame
+		pluginAdvanceTick()
+		handleDrawState(msg, true)
+		return
+	}
 	if txt := decodeMessage(msg); txt != "" {
 		consoleMessage(txt)
 	} else {

--- a/network_test.go
+++ b/network_test.go
@@ -26,6 +26,30 @@ type dummyAddr struct{}
 func (dummyAddr) Network() string { return "dummy" }
 func (dummyAddr) String() string  { return "dummy" }
 
+// packetConn returns predetermined datagrams on each Read call.
+type packetConn struct {
+	packets [][]byte
+	idx     int
+}
+
+func (c *packetConn) Read(b []byte) (int, error) {
+	if c.idx >= len(c.packets) {
+		return 0, io.EOF
+	}
+	p := c.packets[c.idx]
+	c.idx++
+	copy(b, p)
+	return len(p), nil
+}
+
+func (c *packetConn) Write(b []byte) (int, error)        { return len(b), nil }
+func (c *packetConn) Close() error                       { return nil }
+func (c *packetConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (c *packetConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (c *packetConn) SetDeadline(t time.Time) error      { return nil }
+func (c *packetConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *packetConn) SetWriteDeadline(t time.Time) error { return nil }
+
 // extractCommand reads the command number from a packet written to bufConn.
 func extractCommand(t *testing.T, buf *bufConn) uint32 {
 	data := buf.Bytes()
@@ -95,5 +119,51 @@ func TestSendPlayerInputCommandNumIncrementsWithCommand(t *testing.T) {
 	}
 	if cmd := extractCommand(t, conn); cmd != 10 {
 		t.Fatalf("packet command=%d, want 10", cmd)
+	}
+}
+
+func TestReadUDPMessageFragmented(t *testing.T) {
+	udpBuffer = nil
+	msg := []byte{0x00, 0x03, 0xde, 0xad, 0xbe, 0xef}
+	datagrams := [][]byte{{0x00}, append([]byte{0x06}, msg...)}
+	conn := &packetConn{packets: datagrams}
+
+	got, err := readUDPMessage(conn)
+	if err != nil {
+		t.Fatalf("readUDPMessage: %v", err)
+	}
+	if !bytes.Equal(got, msg) {
+		t.Fatalf("got %x want %x", got, msg)
+	}
+	if conn.idx != 2 {
+		t.Fatalf("expected 2 reads, got %d", conn.idx)
+	}
+}
+
+func TestReadUDPMessageMultiple(t *testing.T) {
+	udpBuffer = nil
+	msg1 := []byte{0x00, 0x01}
+	msg2 := []byte{0x00, 0x02, 0xff}
+	d := append([]byte{0x00, byte(len(msg1))}, msg1...)
+	d = append(d, []byte{0x00, byte(len(msg2))}...)
+	d = append(d, msg2...)
+	conn := &packetConn{packets: [][]byte{d}}
+
+	got1, err := readUDPMessage(conn)
+	if err != nil {
+		t.Fatalf("readUDPMessage 1: %v", err)
+	}
+	if !bytes.Equal(got1, msg1) {
+		t.Fatalf("msg1 %x want %x", got1, msg1)
+	}
+	got2, err := readUDPMessage(conn)
+	if err != nil {
+		t.Fatalf("readUDPMessage 2: %v", err)
+	}
+	if !bytes.Equal(got2, msg2) {
+		t.Fatalf("msg2 %x want %x", got2, msg2)
+	}
+	if conn.idx != 1 {
+		t.Fatalf("expected 1 read, got %d", conn.idx)
 	}
 }


### PR DESCRIPTION
## Summary
- buffer incoming UDP datagrams so messages can span packets
- cover fragmented and multi-message UDP packets with new tests
- include placeholder example script for plugin embedding

## Testing
- `go vet ./...` *(fails: gothoom/eui.Color struct literal uses unkeyed fields)*
- `go build ./...`
- `go test ./...` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68b566129fa8832aa173ae38de1ff869