### PR TITLE
Return error on malformed inventory in draw state

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1391,7 +1391,7 @@ func parseDrawState(data []byte, buildCache bool) error {
 			}
 			if showBubble && !skipRender {
 				words := len(strings.Fields(txt))
-                lifeSeconds := gs.BubbleBaseLife + float64(words)*gs.BubbleLifePerWord
+				lifeSeconds := gs.BubbleBaseLife + float64(words)*gs.BubbleLifePerWord
 				life := int(lifeSeconds * float64(1000/framems))
 				if life < 1 {
 					life = 1
@@ -1550,7 +1550,10 @@ func parseDrawState(data []byte, buildCache bool) error {
 	prevSounds = newSounds
 
 	stage = "inventory"
-	parseInventory(stateData)
+	rest, ok := parseInventory(stateData)
+	if !ok || len(rest) > 0 {
+		return errors.New(stage)
+	}
 
 	return nil
 }

--- a/inventory_error_test.go
+++ b/inventory_error_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "testing"
+
+// Test that parseDrawState reports an error when inventory data is malformed.
+func TestParseDrawStateBadInventory(t *testing.T) {
+	resetTestState()
+	data := buildDrawData("Bob", kBubbleNormal, "hi")
+	// Replace inventory with an incomplete multiple command.
+	data[len(data)-1] = byte(kInvCmdMultiple)
+	if err := parseDrawState(data, false); err == nil {
+		t.Fatalf("parseDrawState succeeded for malformed inventory")
+	}
+}


### PR DESCRIPTION
## Summary
- return an error if `parseInventory` fails or leaves extra bytes when parsing draw state
- add a test case ensuring malformed inventory data is reported

## Testing
- `go vet ./...` *(fails: unkeyed fields and copying lock value)*
- `go test ./...` *(fails: missing DISPLAY environment variable for GLFW)*

------
https://chatgpt.com/codex/tasks/task_e_68b5663103a8832aa5953cdf5963df67