### PR TITLE
Fix About window initial sizing and toggle behavior

### DIFF
--- a/about_ui.go
+++ b/about_ui.go
@@ -28,11 +28,20 @@ func openAboutWindow(anchor *eui.ItemData) {
 	if aboutWin == nil {
 		return
 	}
+
+	if aboutWin.Open {
+		aboutWin.Close()
+		return
+	}
+
 	updateTextWindow(aboutWin, aboutList, nil, aboutLines, 15, "", monoFaceSource)
 	if anchor != nil {
 		aboutWin.MarkOpenNear(anchor)
 	} else {
 		aboutWin.MarkOpen()
+	}
+	if aboutWin.OnResize != nil {
+		aboutWin.OnResize()
 	}
 	aboutWin.Refresh()
 }


### PR DESCRIPTION
## Summary
- Toggle About window closed when already open
- Reflow About text after opening for correct AutoSize layout

## Testing
- `go vet ./...` *(fails: Xrandr.h missing; ALSA pkg-config not found)*
- `go build ./...` *(fails: Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b57069c124832aabe1d18c40301101