### PR TITLE
Queue stop command on WASD release

### DIFF
--- a/game.go
+++ b/game.go
@@ -185,6 +185,8 @@ var (
 
 var keyX, keyY int16
 var walkToggled bool
+var keyWalkPrev bool
+var keyStopFrames int
 
 var inputActive bool
 var inputText []rune
@@ -589,9 +591,9 @@ func (g *Game) Update() error {
 		eui.ClearFocus(inputFlow.Contents[0])
 		inputFlow.Contents[0].Focused = false
 	}
-    eui.Update() //We really need this to return eaten clicks
-    // Advance plugin tick waiters once per frame
-    pluginAdvanceTick()
+	eui.Update() //We really need this to return eaten clicks
+	// Advance plugin tick waiters once per frame
+	pluginAdvanceTick()
 	typingElsewhere := typingInUI()
 	if inputActive && inputFlow != nil && len(inputFlow.Contents) > 0 {
 		item := inputFlow.Contents[0]
@@ -897,6 +899,10 @@ func (g *Game) Update() error {
 			keyWalk = false
 		}
 	}
+	if !keyWalk && keyWalkPrev {
+		keyStopFrames = 3
+	}
+	keyWalkPrev = keyWalk
 
 	mx, my = eui.PointerPosition()
 	inGame := pointInGameWindow(mx, my)
@@ -904,10 +910,10 @@ func (g *Game) Update() error {
 	origX, origY, worldScale = worldDrawInfo()
 	baseX := int16(float64(mx-origX)/worldScale - float64(fieldCenterX))
 	baseY := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
-    heldTime := inpututil.MouseButtonPressDuration(ebiten.MouseButtonLeft)
-    click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
-    rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
-    middleClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonMiddle)
+	heldTime := inpututil.MouseButtonPressDuration(ebiten.MouseButtonLeft)
+	click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
+	rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
+	middleClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonMiddle)
 
 	winW, winH := ebiten.WindowSize()
 	inWindow := mx > 0 && my > 0 && mx < winW-1 && my < winH-1
@@ -916,12 +922,12 @@ func (g *Game) Update() error {
 			walkToggled = false
 		}
 	}
-    if !focused || !inWindow {
-        click = false
-        rightClick = false
-        middleClick = false
-        heldTime = 0
-    }
+	if !focused || !inWindow {
+		click = false
+		rightClick = false
+		middleClick = false
+		heldTime = 0
+	}
 
 	stopWalkIfOutside(click, inGame)
 	inputMu.Lock()
@@ -938,15 +944,15 @@ func (g *Game) Update() error {
 			heldTime = 0
 		}
 	}
-    if click && !uiMouseDown && inGame {
-        handleWorldClick(baseX, baseY, ebiten.MouseButtonLeft)
-    }
-    if rightClick && inGame && !pointInUI(mx, my) {
-        handleWorldClick(baseX, baseY, ebiten.MouseButtonRight)
-    }
-    if middleClick && inGame && !pointInUI(mx, my) {
-        handleWorldClick(baseX, baseY, ebiten.MouseButtonMiddle)
-    }
+	if click && !uiMouseDown && inGame {
+		handleWorldClick(baseX, baseY, ebiten.MouseButtonLeft)
+	}
+	if rightClick && inGame && !pointInUI(mx, my) {
+		handleWorldClick(baseX, baseY, ebiten.MouseButtonRight)
+	}
+	if middleClick && inGame && !pointInUI(mx, my) {
+		handleWorldClick(baseX, baseY, ebiten.MouseButtonMiddle)
+	}
 	// (right-click handling for menus/copy is handled earlier)
 
 	// Default desired target from current pointer, even if outside game window.
@@ -992,6 +998,14 @@ func (g *Game) Update() error {
 
 	updateHotkeyRecording()
 	checkHotkeys()
+	if keyStopFrames > 0 {
+		if keyWalk {
+			keyStopFrames = 0
+		} else {
+			enqueueCommand("/move stop")
+			keyStopFrames--
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Enqueue `/move stop` commands when WASD or arrow keys are released
- Cancel queued stop commands if movement resumes before they're sent
- Track key release frames to send multiple stop commands for reliability

## Testing
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: spellcheck_words.txt missing, X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b56f3b4460832a89a619d476a08164