### PR TITLE
Add name tag label color option and thicken player list border

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"image/color"
 	"math"
 	"sort"
 	"strings"
@@ -371,11 +372,15 @@ func mobileOnEdge(m frameMobile, d frameDescriptor) bool {
 
 // buildNameTagImage creates a cached image for a mobile name tag using the
 // current font and settings. Returns the image and its width/height in pixels.
-func buildNameTagImage(name string, colorCode uint8, opacity uint8, style uint8) (*ebiten.Image, int, int) {
+// The frame color defaults to the name color unless frameClr overrides it.
+func buildNameTagImage(name string, colorCode uint8, opacity uint8, style uint8, frameClr color.RGBA) (*ebiten.Image, int, int) {
 	if name == "" {
 		return nil, 0, 0
 	}
-	textClr, bgClr, frameClr := mobileNameColors(colorCode)
+	textClr, bgClr, defFrame := mobileNameColors(colorCode)
+	if frameClr.A == 0 {
+		frameClr = defFrame
+	}
 	face := mainFont
 	switch style {
 	case styleBold:
@@ -1224,7 +1229,16 @@ func parseDrawState(data []byte, buildCache bool) (int32, int32, error) {
 				m.nameTagH = prev.nameTagH
 				m.nameTagKey = prev.nameTagKey
 			} else {
-				img, iw, ih := buildNameTagImage(d.Name, m.Colors, uint8(gs.NameBgOpacity*255+0.5), style)
+				frame := color.RGBA{}
+				if gs.NameTagLabelColors {
+					playersMu.RLock()
+					if p, ok := players[d.Name]; ok && p.FriendLabel > 0 && p.FriendLabel <= len(labelColors) {
+						lc := labelColors[p.FriendLabel-1]
+						frame = color.RGBA{lc.R, lc.G, lc.B, 0xff}
+					}
+					playersMu.RUnlock()
+				}
+				img, iw, ih := buildNameTagImage(d.Name, m.Colors, uint8(gs.NameBgOpacity*255+0.5), style, frame)
 				m.nameTag = img
 				m.nameTagW = iw
 				m.nameTagH = ih

--- a/game.go
+++ b/game.go
@@ -589,9 +589,9 @@ func (g *Game) Update() error {
 		eui.ClearFocus(inputFlow.Contents[0])
 		inputFlow.Contents[0].Focused = false
 	}
-    eui.Update() //We really need this to return eaten clicks
-    // Advance plugin tick waiters once per frame
-    pluginAdvanceTick()
+	eui.Update() //We really need this to return eaten clicks
+	// Advance plugin tick waiters once per frame
+	pluginAdvanceTick()
 	typingElsewhere := typingInUI()
 	if inputActive && inputFlow != nil && len(inputFlow.Contents) > 0 {
 		item := inputFlow.Contents[0]
@@ -904,10 +904,10 @@ func (g *Game) Update() error {
 	origX, origY, worldScale = worldDrawInfo()
 	baseX := int16(float64(mx-origX)/worldScale - float64(fieldCenterX))
 	baseY := int16(float64(my-origY)/worldScale - float64(fieldCenterY))
-    heldTime := inpututil.MouseButtonPressDuration(ebiten.MouseButtonLeft)
-    click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
-    rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
-    middleClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonMiddle)
+	heldTime := inpututil.MouseButtonPressDuration(ebiten.MouseButtonLeft)
+	click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
+	rightClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonRight)
+	middleClick := inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonMiddle)
 
 	winW, winH := ebiten.WindowSize()
 	inWindow := mx > 0 && my > 0 && mx < winW-1 && my < winH-1
@@ -916,12 +916,12 @@ func (g *Game) Update() error {
 			walkToggled = false
 		}
 	}
-    if !focused || !inWindow {
-        click = false
-        rightClick = false
-        middleClick = false
-        heldTime = 0
-    }
+	if !focused || !inWindow {
+		click = false
+		rightClick = false
+		middleClick = false
+		heldTime = 0
+	}
 
 	stopWalkIfOutside(click, inGame)
 	inputMu.Lock()
@@ -938,15 +938,15 @@ func (g *Game) Update() error {
 			heldTime = 0
 		}
 	}
-    if click && !uiMouseDown && inGame {
-        handleWorldClick(baseX, baseY, ebiten.MouseButtonLeft)
-    }
-    if rightClick && inGame && !pointInUI(mx, my) {
-        handleWorldClick(baseX, baseY, ebiten.MouseButtonRight)
-    }
-    if middleClick && inGame && !pointInUI(mx, my) {
-        handleWorldClick(baseX, baseY, ebiten.MouseButtonMiddle)
-    }
+	if click && !uiMouseDown && inGame {
+		handleWorldClick(baseX, baseY, ebiten.MouseButtonLeft)
+	}
+	if rightClick && inGame && !pointInUI(mx, my) {
+		handleWorldClick(baseX, baseY, ebiten.MouseButtonRight)
+	}
+	if middleClick && inGame && !pointInUI(mx, my) {
+		handleWorldClick(baseX, baseY, ebiten.MouseButtonMiddle)
+	}
 	// (right-click handling for menus/copy is handled earlier)
 
 	// Default desired target from current pointer, even if outside game window.
@@ -1905,12 +1905,14 @@ func drawMobileNameTag(screen *ebiten.Image, snap drawSnapshot, m frameMobile, a
 				screen.DrawImage(m.nameTag, op)
 			} else {
 				textClr, bgClr, frameClr := mobileNameColors(m.Colors)
-				playersMu.RLock()
-				if p, ok := players[d.Name]; ok && p.FriendLabel > 0 && p.FriendLabel <= len(labelColors) {
-					lc := labelColors[p.FriendLabel-1]
-					frameClr = color.RGBA{lc.R, lc.G, lc.B, frameClr.A}
+				if gs.NameTagLabelColors {
+					playersMu.RLock()
+					if p, ok := players[d.Name]; ok && p.FriendLabel > 0 && p.FriendLabel <= len(labelColors) {
+						lc := labelColors[p.FriendLabel-1]
+						frameClr = color.RGBA{lc.R, lc.G, lc.B, frameClr.A}
+					}
+					playersMu.RUnlock()
 				}
-				playersMu.RUnlock()
 				bgClr.A = nameAlpha
 				frameClr.A = nameAlpha
 				face := mainFont

--- a/players_ui.go
+++ b/players_ui.go
@@ -46,32 +46,32 @@ func updatePlayersWindow() {
 
 	// Gather current players and filter to non-NPCs with names.
 	ps := getPlayers()
-    // Sort: online (recently seen and not explicitly offline) first,
-    // then by label/color group, then by name.
-    sort.Slice(ps, func(i, j int) bool {
-        staleI := time.Since(ps[i].LastSeen) > 5*time.Minute
-        staleJ := time.Since(ps[j].LastSeen) > 5*time.Minute
-        offI := ps[i].Offline || staleI
-        offJ := ps[j].Offline || staleJ
-        if offI != offJ {
-            return !offI && offJ
-        }
-        // Same online/offline status: sort by label group.
-        li := ps[i].FriendLabel
-        lj := ps[j].FriendLabel
-        // Treat unlabeled (0) as after labeled groups.
-        if li == 0 && lj != 0 {
-            return false
-        }
-        if lj == 0 && li != 0 {
-            return true
-        }
-        if li != lj {
-            return li < lj
-        }
-        // Final tie-breaker: by name.
-        return ps[i].Name < ps[j].Name
-    })
+	// Sort: online (recently seen and not explicitly offline) first,
+	// then by label/color group, then by name.
+	sort.Slice(ps, func(i, j int) bool {
+		staleI := time.Since(ps[i].LastSeen) > 5*time.Minute
+		staleJ := time.Since(ps[j].LastSeen) > 5*time.Minute
+		offI := ps[i].Offline || staleI
+		offJ := ps[j].Offline || staleJ
+		if offI != offJ {
+			return !offI && offJ
+		}
+		// Same online/offline status: sort by label group.
+		li := ps[i].FriendLabel
+		lj := ps[j].FriendLabel
+		// Treat unlabeled (0) as after labeled groups.
+		if li == 0 && lj != 0 {
+			return false
+		}
+		if lj == 0 && li != 0 {
+			return true
+		}
+		if li != lj {
+			return li < lj
+		}
+		// Final tie-breaker: by name.
+		return ps[i].Name < ps[j].Name
+	})
 	exiles := make([]Player, 0, len(ps))
 	shareCount, shareeCount := 0, 0
 	onlineCount := 0
@@ -91,7 +91,7 @@ func updatePlayersWindow() {
 		}
 	}
 
-    myClan := ""
+	myClan := ""
 	if playerName != "" {
 		playersMu.RLock()
 		if me, ok := players[playerName]; ok {
@@ -167,9 +167,9 @@ func updatePlayersWindow() {
 		if p.Sharing {
 			tags = append(tags, ">")
 		}
-        if sameRealClan(p.Clan, myClan) {
-            tags = append(tags, "*")
-        }
+		if sameRealClan(p.Clan, myClan) {
+			tags = append(tags, "*")
+		}
 		if len(tags) > 0 {
 			name = fmt.Sprintf("%s %s", name, strings.Join(tags, "--"))
 		}
@@ -178,7 +178,7 @@ func updatePlayersWindow() {
 
 		if p.FriendLabel > 0 {
 			row.Outlined = true
-			row.Border = 2
+			row.Border = 3
 			row.OutlineColor = labelColor(p.FriendLabel)
 		}
 
@@ -336,40 +336,40 @@ func openPlayersContextMenu(name string, pos eui.Point) {
 	// Close any existing context menus.
 	eui.CloseContextMenus()
 
-    displayName := name
-    options := []string{}
-    actions := []func(){}
+	displayName := name
+	options := []string{}
+	actions := []func(){}
 
-    // If the player has a label color/group, show that as a disabled header
-    // line at the top of the menu. Otherwise, fall back to showing the
-    // player's name as the header.
-    headerCount := 0
-    if displayName != "" {
-        if p := getPlayer(displayName); p != nil && p.FriendLabel > 0 {
-            idx := p.FriendLabel
-            colorName := ""
-            if idx > 0 && idx <= len(defaultLabelNames) {
-                colorName = defaultLabelNames[idx-1]
-            }
-            groupName := labelName(idx)
-            header := ""
-            if colorName != "" && groupName != "" && !strings.EqualFold(colorName, groupName) {
-                header = fmt.Sprintf("%s — %s", colorName, groupName)
-            } else if groupName != "" {
-                header = groupName
-            } else if colorName != "" {
-                header = colorName
-            }
-            if header != "" {
-                options = append(options, header)
-                headerCount = 1
-            }
-        }
-        if headerCount == 0 {
-            options = append(options, displayName)
-            headerCount = 1
-        }
-    }
+	// If the player has a label color/group, show that as a disabled header
+	// line at the top of the menu. Otherwise, fall back to showing the
+	// player's name as the header.
+	headerCount := 0
+	if displayName != "" {
+		if p := getPlayer(displayName); p != nil && p.FriendLabel > 0 {
+			idx := p.FriendLabel
+			colorName := ""
+			if idx > 0 && idx <= len(defaultLabelNames) {
+				colorName = defaultLabelNames[idx-1]
+			}
+			groupName := labelName(idx)
+			header := ""
+			if colorName != "" && groupName != "" && !strings.EqualFold(colorName, groupName) {
+				header = fmt.Sprintf("%s — %s", colorName, groupName)
+			} else if groupName != "" {
+				header = groupName
+			} else if colorName != "" {
+				header = colorName
+			}
+			if header != "" {
+				options = append(options, header)
+				headerCount = 1
+			}
+		}
+		if headerCount == 0 {
+			options = append(options, displayName)
+			headerCount = 1
+		}
+	}
 
 	// Thank: immediate thank.
 	if displayName != "" {
@@ -460,13 +460,13 @@ func openPlayersContextMenu(name string, pos eui.Point) {
 	if len(options) == 0 {
 		return
 	}
-    menu := eui.ShowContextMenu(options, pos.X, pos.Y, func(i int) {
-        adj := i - headerCount
-        if adj >= 0 && adj < len(actions) {
-            actions[adj]()
-        }
-    })
-    if menu != nil && headerCount > 0 {
-        menu.HeaderCount = headerCount
-    }
+	menu := eui.ShowContextMenu(options, pos.X, pos.Y, func(i int) {
+		adj := i - headerCount
+		if adj >= 0 && adj < len(actions) {
+			actions[adj]()
+		}
+	})
+	if menu != nil && headerCount > 0 {
+		menu.HeaderCount = headerCount
+	}
 }

--- a/settings.go
+++ b/settings.go
@@ -49,6 +49,7 @@ var gsdef settings = settings{
 	BubbleBaseLife:          2.0,
 	BubbleLifePerWord:       1.0,
 	NameBgOpacity:           0.7,
+	NameTagLabelColors:      false,
 	BarOpacity:              0.5,
 	ObscuringPictureOpacity: 0.5,
 	FadeObscuringPictures:   true,
@@ -110,7 +111,7 @@ var gsdef settings = settings{
 	PlayersWindow:   WindowState{Open: true},
 	MessagesWindow:  WindowState{Open: true},
 	ChatWindow:      WindowState{Open: true},
-    EnabledPlugins:  map[string]any{},
+	EnabledPlugins:  map[string]any{},
 	vsync:           true,
 	nightEffect:     true,
 	shaderLighting:  true,
@@ -135,6 +136,7 @@ type settings struct {
 	BubbleBaseLife          float64 `json:"BubbleLife"`
 	BubbleLifePerWord       float64 `json:"BubblePerWord"`
 	NameBgOpacity           float64
+	NameTagLabelColors      bool
 	BarOpacity              float64
 	ObscuringPictureOpacity float64
 	FadeObscuringPictures   bool
@@ -222,7 +224,7 @@ type settings struct {
 	pluginOutputDebug   bool
 	hideMoving          bool
 	hideMobiles         bool
-    EnabledPlugins      map[string]any
+	EnabledPlugins      map[string]any
 	vsync               bool
 	nightEffect         bool
 	shaderLighting      bool
@@ -276,10 +278,10 @@ func loadSettings() bool {
 		return false
 	}
 
-    type settingsFile struct {
-        settings
-        EnabledPlugins map[string]any `json:"EnabledPlugins"`
-    }
+	type settingsFile struct {
+		settings
+		EnabledPlugins map[string]any `json:"EnabledPlugins"`
+	}
 
 	tmp := settingsFile{settings: gsdef}
 	if err := json.Unmarshal(data, &tmp); err != nil {
@@ -288,30 +290,30 @@ func loadSettings() bool {
 		return false
 	}
 
-    if tmp.settings.Version == SETTINGS_VERSION {
-        gs = tmp.settings
-        // Normalize and retain whatever was in the file; migrate into runtime scope map.
-        gs.EnabledPlugins = make(map[string]any)
-        for k, v := range tmp.EnabledPlugins {
-            gs.EnabledPlugins[k] = v
-            s := scopeFromSettingValue(v)
-            if !s.empty() {
-                pluginMu.Lock()
-                pluginEnabledFor[k] = s
-                pluginMu.Unlock()
-            }
-        }
-        settingsLoaded = true
-    } else {
+	if tmp.settings.Version == SETTINGS_VERSION {
+		gs = tmp.settings
+		// Normalize and retain whatever was in the file; migrate into runtime scope map.
+		gs.EnabledPlugins = make(map[string]any)
+		for k, v := range tmp.EnabledPlugins {
+			gs.EnabledPlugins[k] = v
+			s := scopeFromSettingValue(v)
+			if !s.empty() {
+				pluginMu.Lock()
+				pluginEnabledFor[k] = s
+				pluginMu.Unlock()
+			}
+		}
+		settingsLoaded = true
+	} else {
 		gs = gsdef
 		applyQualityPreset("High")
 		settingsLoaded = false
 		return false
 	}
 
-    if gs.EnabledPlugins == nil {
-        gs.EnabledPlugins = make(map[string]any)
-    }
+	if gs.EnabledPlugins == nil {
+		gs.EnabledPlugins = make(map[string]any)
+	}
 
 	if gs.ChatTTSBlocklist == nil {
 		gs.ChatTTSBlocklist = append([]string(nil), gsdef.ChatTTSBlocklist...)
@@ -415,25 +417,25 @@ func updateBubbleVisibility() {
 }
 
 func saveSettings() {
-    pluginMu.RLock()
-    // Rebuild the persisted map from the current scope set.
-    gs.EnabledPlugins = make(map[string]any, len(pluginEnabledFor))
-    for k, s := range pluginEnabledFor {
-        if s.All {
-            gs.EnabledPlugins[k] = "all"
-            continue
-        }
-        if len(s.Chars) > 0 {
-            // Collect and sort for stable output
-            names := make([]string, 0, len(s.Chars))
-            for n := range s.Chars {
-                names = append(names, n)
-            }
-            sort.Strings(names)
-            gs.EnabledPlugins[k] = names
-        }
-    }
-    pluginMu.RUnlock()
+	pluginMu.RLock()
+	// Rebuild the persisted map from the current scope set.
+	gs.EnabledPlugins = make(map[string]any, len(pluginEnabledFor))
+	for k, s := range pluginEnabledFor {
+		if s.All {
+			gs.EnabledPlugins[k] = "all"
+			continue
+		}
+		if len(s.Chars) > 0 {
+			// Collect and sort for stable output
+			names := make([]string, 0, len(s.Chars))
+			for n := range s.Chars {
+				names = append(names, n)
+			}
+			sort.Strings(names)
+			gs.EnabledPlugins[k] = names
+		}
+	}
+	pluginMu.RUnlock()
 
 	data, err := json.MarshalIndent(gs, "", "  ")
 	if err != nil {

--- a/ui.go
+++ b/ui.go
@@ -2606,6 +2606,23 @@ func makeSettingsWindow() {
 	}
 	right.AddItem(nameBgSlider)
 
+	nameBorderCB, nameBorderEvents := eui.NewCheckbox()
+	nameBorderCB.Text = "Name Tag Label Colors"
+	nameBorderCB.Size = eui.Point{X: panelWidth - 10, Y: 24}
+	nameBorderCB.Checked = gs.NameTagLabelColors
+	nameBorderCB.Tooltip = "Show player label colors on name tag borders"
+	nameBorderEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			gs.NameTagLabelColors = ev.Checked
+			killNameTagCache()
+			settingsDirty = true
+		}
+	}
+	right.AddItem(nameBorderCB)
+
 	bubbleOpSlider, bubbleOpEvents := eui.NewSlider()
 	bubbleOpSlider.Label = "Bubble Opacity"
 	bubbleOpSlider.MinValue = 0


### PR DESCRIPTION
## Summary
- add setting to color name tag borders with player label colors
- add UI toggle for name tag label colors
- make player list label border thicker for better visibility

## Testing
- `go vet ./...` *(fails: inventory_error_test.go assignment mismatch)*
- `go build ./...`
- `go test ./...` *(fails: inventory_error_test.go assignment mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b56eef75b0832ab78b806fa18db378