### PR TITLE
Stop movie recording on disconnect

### DIFF
--- a/login.go
+++ b/login.go
@@ -31,6 +31,9 @@ func handleDisconnect() {
 	loginMu.Unlock()
 
 	cancel()
+	if recorder != nil {
+		stopRecording()
+	}
 	// Reset session sources so we return to splash state
 	clmov = ""
 	pcapPath = ""

--- a/movie_recorder.go
+++ b/movie_recorder.go
@@ -128,3 +128,17 @@ func (m *movieRecorder) Close() error {
 	m.f = nil
 	return err
 }
+
+func stopRecording() {
+	if recorder == nil {
+		return
+	}
+	if err := recorder.Close(); err != nil {
+		logError("stop recording: %v", err)
+	}
+	recorder = nil
+	wroteLoginBlocks = false
+	if recordStatus != nil {
+		recordStatus.Text = ""
+	}
+}


### PR DESCRIPTION
## Summary
- stop active movie recorder when disconnecting
- guard recording UI access when recordStatus is nil

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5701511e0832a9f3609e11a649a94