### PR TITLE
bundle: add Go 1.25 toolchain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-This repo includes a Go client under `gothoom/`. To build or run the Go program you need Go version 1.24 or later.
+This repo includes a Go client under `gothoom/`. To build or run the Go program you need Go version 1.25. A Go 1.25 toolchain is bundled with the repository and should be used instead of the system `golang-go` package.
 Do not increment JSON versions in GT_Players.json or settings.json or characters.json. They will be done manually if needed.
 Any functions or variables or types exposed to the plugins need to also be put empty stubs into gt so the linters do not complain for users.
 Also I prefer to-the-point and simple solutions. We'll get complex if it is needed but I prefer to not over complicate things. "Keep it simple stupid"
@@ -8,19 +8,21 @@ Try to avoid completely over-thinking your replies and feel free to stop and ask
 
 ## Installing dependencies
 
-1. Skip slow downloads use the prebuilt dependency bundle:
+1. **Always** download and install the prebuilt dependency bundle:
    ```bash
    curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz
    tar -xzf gothoom_deps.tar.gz
    sudo apt-get install -y ./apt/*.deb
+   sudo tar -C /usr/local -xzf go/go1.25.0.linux-amd64.tar.gz
+   export PATH="/usr/local/go/bin:$PATH"
    go env -w GOMODCACHE="$(pwd)/go/mod"
    ```
-   The archive, produced by `scripts/build_dep_bundle.sh`, contains the
-   required Debian packages under `apt/` and a cached Go module tree under
-   `go/mod`. Extracting it and installing the packages avoids fetching
-   dependencies individually.
+   The archive, produced by `build-scripts/build_dep_bundle.sh`, contains the
+   required Debian packages under `apt/`, a Go 1.25 toolchain under `go/`,
+   and a cached Go module tree under `go/mod`. Extracting it and installing
+   these contents avoids fetching dependencies individually.
    
-3. Fetch Go module dependencies:
+2. Fetch Go module dependencies:
    ```bash
    cd gothoom
    go mod download
@@ -28,11 +30,11 @@ Try to avoid completely over-thinking your replies and feel free to stop and ask
 
 
 
-For convenience the `scripts` directory contains small helper scripts:
-`scripts/build_gothoom.sh` fetches dependencies, formats the sources and
-compiles the client. `scripts/run_gothoom.sh` launches the program.
-
-Both scripts expect to be executed from the repository root.
+The `build-scripts` directory provides helper scripts for development.
+`build-scripts/build_dep_bundle.sh` regenerates the dependency bundle,
+`build-scripts/build_binaries.sh` compiles release binaries, and
+`build-scripts/setup_dev_env.sh` bootstraps a development environment.
+Run these scripts from the repository root.
 
 ## Build steps
 1. Navigate to the `gothoom` directory if not already there:
@@ -44,14 +46,10 @@ Both scripts expect to be executed from the repository root.
    go build
    ```
    This produces the executable `gothoom` in the current directory.
-   You can also run `../scripts/build_gothoom.sh` from the repo root which
-   runs `go mod download` and `go build ./...` in one step.
 3. You can also run the program directly with:
    ```bash
    go run .
    ```
-   Alternatively run `../scripts/run_gothoom.sh` from the repo root.
-
 The module path is `gothoom` and the main package is located in this directory.
 
 The `mac_client` directory contains a reference implementation written in C and should *never* be modified. It is only for reference!
@@ -59,22 +57,6 @@ The `mac_client` directory contains a reference implementation written in C and 
 ## Quick Commands Reference
 
 Click and drag to move. Type \HELP <COMMAND>. The commands are: \ACTION, \AFFILIATIONS, \ANONCURSE, \ANONTHANK, \BAG, \BOOT, \BUG, \BUY, \CURSE, \DEPART, \DROP, \EQUIP, \EXAMINE, \GIVE, \HELP, \INFO, \KARMA, \MONEY, \NAME, \NARRATE, \NEWS, \OPTIONS, \PONDER, \POSE, \PRAY, \PULL, \PUSH, \REPORT, \SELL, \SHARE, \SHOW, \SKY, \SLEEP, \SPEAK, \STATUS, \SWEAR, \THANK, \THINK, \THINKCLAN, \THINKGROUP, \THINKTO, \TIP, \UNEQUIP, \UNSHARE, \USE, \USEITEM, \WHISPER, \WHO, \WHOCLAN, \YELL
-
-## Session notes
-The following dependencies were installed when building the Go client
-in this session:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y golang-go build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev
-```
-
-Example build and run commands used:
-
-```bash
-go build ./...
-go run .
-```
 
 Running the client without a display (i.e. no `$DISPLAY` variable) will exit
 with an X11 initialization error.

--- a/build-scripts/build_dep_bundle.sh
+++ b/build-scripts/build_dep_bundle.sh
@@ -5,19 +5,19 @@
 
 set -euo pipefail
 
-# Usage: scripts/build_dep_bundle.sh [output.tar.gz]
+# Usage: build-scripts/build_dep_bundle.sh [output.tar.gz]
 # Default output is gothoom_deps.tar.gz in the current directory.
 
 OUT_FILE="${1:-gothoom_deps.tar.gz}"
 WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
 APT_DIR="$WORK_DIR/apt"
 GO_DIR="$WORK_DIR/go"
 
 mkdir -p "$APT_DIR" "$GO_DIR"
 
-# Packages needed to build goThoom.
+# Packages needed to build goThoom. The Go toolchain is downloaded below.
 DEB_PACKAGES=(
-  golang-go
   build-essential
   libgl1-mesa-dev
   libglu1-mesa-dev
@@ -38,12 +38,18 @@ else
   echo "apt-get not found; skipping Debian package download" >&2
 fi
 
+# Include Go toolchain
+GO_VERSION="1.25.0"
+GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+echo "Downloading Go ${GO_VERSION}..."
+curl -L -o "$GO_DIR/$GO_TARBALL" "https://go.dev/dl/$GO_TARBALL"
+
 # Cache Go modules into a local mod cache inside the bundle.
 GO_CACHE="$GO_DIR/mod"
 mkdir -p "$GO_CACHE"
 
 echo "Downloading Go modules..."
-GOMODCACHE="$GO_CACHE" /usr/local/go/bin/go mod download
+GOMODCACHE="$GO_CACHE" go mod download
 
 
 # Copy useful data files


### PR DESCRIPTION
## Summary
- require using the bundled Go 1.25 dependency bundle and document how to install it
- reference `build-scripts` for development helpers instead of the old `scripts` directory
- clarify `build_dep_bundle.sh` usage and note it downloads the Go toolchain

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `shellcheck build-scripts/build_dep_bundle.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b574cae8b0832aaa4615927456ea4b