### PR TITLE
Stop WASD from issuing /move command

### DIFF
--- a/game.go
+++ b/game.go
@@ -1002,7 +1002,9 @@ func (g *Game) Update() error {
 		if keyWalk {
 			keyStopFrames = 0
 		} else {
-			enqueueCommand("/move stop")
+			inputMu.Lock()
+			latestInput = inputState{mouseX: 0, mouseY: 0, mouseDown: true}
+			inputMu.Unlock()
 			keyStopFrames--
 		}
 	}


### PR DESCRIPTION
## Summary
- stop sending `/move stop` and send a 0,0 mouse-down frame when releasing WASD keys

## Testing
- `go vet ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go build ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go test ./...` *(fails: pattern spellcheck_words.txt: no matching files found)*
- `go mod download` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b57bcbdc84832a8d875b160fd7051a