### PR TITLE
Include pict IDs and mode in gameStateBlock

### DIFF
--- a/game.go
+++ b/game.go
@@ -2577,7 +2577,8 @@ func udpReadLoop(ctx context.Context, conn net.Conn) {
 			if !wroteLoginBlocks {
 				if tag == 2 { // first draw state
 					if len(loginGameState) > 0 {
-						recorder.AddBlock(gameStateBlock(loginGameState), flagGameState)
+						l := len(loginGameState)
+						recorder.AddBlock(gameStateBlock(0, 0, 0, l, l, l, loginGameState), flagGameState)
 					}
 					if len(loginMobileData) > 0 {
 						recorder.AddBlock(loginMobileData, flagMobileData)
@@ -2659,7 +2660,8 @@ loop:
 			if !wroteLoginBlocks {
 				if tag == 2 { // first draw state
 					if len(loginGameState) > 0 {
-						recorder.AddBlock(gameStateBlock(loginGameState), flagGameState)
+						l := len(loginGameState)
+						recorder.AddBlock(gameStateBlock(0, 0, 0, l, l, l, loginGameState), flagGameState)
 					}
 					if len(loginMobileData) > 0 {
 						recorder.AddBlock(loginMobileData, flagMobileData)

--- a/movie_recorder.go
+++ b/movie_recorder.go
@@ -78,9 +78,14 @@ func (m *movieRecorder) AddBlock(data []byte, flag uint16) {
 	m.preFlags |= flag
 }
 
-func gameStateBlock(payload []byte) []byte {
+func gameStateBlock(leftPictID, rightPictID, mode, maxSize, curSize, expectedSize int, payload []byte) []byte {
 	buf := make([]byte, 24+len(payload))
-	binary.BigEndian.PutUint32(buf[12:], uint32(len(payload)))
+	binary.BigEndian.PutUint32(buf[0:], uint32(leftPictID))
+	binary.BigEndian.PutUint32(buf[4:], uint32(rightPictID))
+	binary.BigEndian.PutUint32(buf[8:], uint32(mode))
+	binary.BigEndian.PutUint32(buf[12:], uint32(maxSize))
+	binary.BigEndian.PutUint32(buf[16:], uint32(curSize))
+	binary.BigEndian.PutUint32(buf[20:], uint32(expectedSize))
 	copy(buf[24:], payload)
 	return buf
 }


### PR DESCRIPTION
## Summary
- extend gameStateBlock with pict IDs and state metadata fields
- pass new parameters from login block recording

## Testing
- `golangci-lint run` *(fails: the Go language version used to build golangci-lint is lower than the targeted Go version)*
- `go vet $(go list ./... | grep '^gothoom')` *(fails: missing modules in go/mod)*
- `go build ./...` *(fails: missing X11/ALSA/GTK development packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d8bf768832abce9bab694ed5145