### PR TITLE
Infer caps lock usage for password inputs

### DIFF
--- a/game.go
+++ b/game.go
@@ -604,7 +604,6 @@ func (g *Game) Update() error {
 	checkPluginMods()
 	updateNotifications()
 	updateThinkMessages()
-	updateCapsLockWarning()
 
 	mx, my := eui.PointerPosition()
 	origX, origY, worldScale := worldDrawInfo()

--- a/ui.go
+++ b/ui.go
@@ -1,19 +1,20 @@
 package main
 
 import (
-    "context"
-    "crypto/md5"
-    "encoding/hex"
-    "fmt"
-    "math"
-    "os"
-    "path/filepath"
-    "regexp"
-    "sort"
-    "strconv"
-    "strings"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"gothoom/eui"
 
@@ -121,21 +122,34 @@ var ttsTestPhrase = "The quick brown fox jumps over the lazy dog"
 // can avoid spamming the server when the Players window is toggled rapidly.
 var lastWhoRequest time.Time
 
-func updateCapsLockWarning() {
-	caps := ebiten.IsKeyPressed(ebiten.KeyCapsLock)
-	if passWin != nil && passWin.IsOpen() && passCapsWarn != nil {
-		inv := !caps
-		if passCapsWarn.Invisible != inv {
-			passCapsWarn.Invisible = inv
-			passCapsWarn.Dirty = true
-		}
+func setupCapsLockWarning(input *eui.ItemData, warn *eui.ItemData) {
+	if input == nil || warn == nil {
+		return
 	}
-	if addCharWin != nil && addCharWin.IsOpen() && addCharPassWarn != nil {
-		inv := !caps
-		if addCharPassWarn.Invisible != inv {
-			addCharPassWarn.Invisible = inv
-			addCharPassWarn.Dirty = true
+	prev := 0
+	warn.Invisible = true
+	h := input.Handler
+	prevHandle := h.Handle
+	h.Handle = func(ev eui.UIEvent) {
+		if prevHandle != nil {
+			prevHandle(ev)
 		}
+		if ev.Type != eui.EventInputChanged {
+			return
+		}
+		runes := []rune(ev.Text)
+		l := len(runes)
+		if l > prev {
+			r := runes[l-1]
+			shift := ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight)
+			show := unicode.IsLetter(r) && ((unicode.IsUpper(r) && !shift) || (unicode.IsLower(r) && shift))
+			inv := !show
+			if warn.Invisible != inv {
+				warn.Invisible = inv
+				warn.Dirty = true
+			}
+		}
+		prev = l
 	}
 }
 
@@ -1167,14 +1181,14 @@ func stopRecording() {
 	if hudWin != nil {
 		hudWin.Refresh()
 	}
-    if recordPath != "" {
-        saved := recordPath
-        consoleMessage(fmt.Sprintf("saved movie: %s", filepath.Base(saved)))
-        if gs.PromptOnSaveRecording {
-            showRecordingSaveDialog(saved)
-        }
-        recordPath = ""
-    }
+	if recordPath != "" {
+		saved := recordPath
+		consoleMessage(fmt.Sprintf("saved movie: %s", filepath.Base(saved)))
+		if gs.PromptOnSaveRecording {
+			showRecordingSaveDialog(saved)
+		}
+		recordPath = ""
+	}
 }
 
 func toggleRecording() {
@@ -1191,6 +1205,7 @@ func toggleRecording() {
 
 var dlMutex sync.Mutex
 var status dataFilesStatus
+
 // ===== Recording save/rename/compress dialog =====
 var recordSaveWin *eui.WindowData
 var recordSaveInput *eui.ItemData
@@ -1198,121 +1213,121 @@ var recordSaveCompressCB *eui.ItemData
 var recordSaveDontShowCB *eui.ItemData
 
 func showRecordingSaveDialog(path string) {
-    dir := filepath.Dir(path)
-    base := filepath.Base(path)
-    if recordSaveWin == nil {
-        recordSaveWin = eui.NewWindow()
-        recordSaveWin.Title = "Save Recording"
-        recordSaveWin.Closable = true
-        recordSaveWin.Resizable = false
-        recordSaveWin.AutoSize = true
-        recordSaveWin.Movable = true
-        recordSaveWin.NoScroll = true
-        recordSaveWin.SetZone(eui.HZoneCenter, eui.VZoneMiddleTop)
-    }
-    recordSaveWin.Contents = nil
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	if recordSaveWin == nil {
+		recordSaveWin = eui.NewWindow()
+		recordSaveWin.Title = "Save Recording"
+		recordSaveWin.Closable = true
+		recordSaveWin.Resizable = false
+		recordSaveWin.AutoSize = true
+		recordSaveWin.Movable = true
+		recordSaveWin.NoScroll = true
+		recordSaveWin.SetZone(eui.HZoneCenter, eui.VZoneMiddleTop)
+	}
+	recordSaveWin.Contents = nil
 
-    flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
-    info, _ := eui.NewText()
-    info.Text = "Rename the .clMov file and optionally create a .zip archive (about half smaller)."
-    info.Size = eui.Point{X: 420, Y: 36}
-    info.FontSize = 10
-    flow.AddItem(info)
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	info, _ := eui.NewText()
+	info.Text = "Rename the .clMov file and optionally create a .zip archive (about half smaller)."
+	info.Size = eui.Point{X: 420, Y: 36}
+	info.FontSize = 10
+	flow.AddItem(info)
 
-    row := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
-    lbl, _ := eui.NewText()
-    lbl.Text = "Filename:"
-    lbl.Size = eui.Point{X: 64, Y: 24}
-    lbl.FontSize = 12
-    row.AddItem(lbl)
-    recordSaveInput, _ = eui.NewInput()
-    recordSaveInput.Size = eui.Point{X: 340, Y: 24}
-    recordSaveInput.FontSize = 12
-    recordSaveInput.Text = base
-    row.AddItem(recordSaveInput)
-    flow.AddItem(row)
+	row := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true}
+	lbl, _ := eui.NewText()
+	lbl.Text = "Filename:"
+	lbl.Size = eui.Point{X: 64, Y: 24}
+	lbl.FontSize = 12
+	row.AddItem(lbl)
+	recordSaveInput, _ = eui.NewInput()
+	recordSaveInput.Size = eui.Point{X: 340, Y: 24}
+	recordSaveInput.FontSize = 12
+	recordSaveInput.Text = base
+	row.AddItem(recordSaveInput)
+	flow.AddItem(row)
 
-    recordSaveCompressCB, _ = eui.NewCheckbox()
-    recordSaveCompressCB.Text = ".zip compress (about half smaller)"
-    recordSaveCompressCB.Checked = true
-    recordSaveCompressCB.Size = eui.Point{X: 420, Y: 24}
-    flow.AddItem(recordSaveCompressCB)
+	recordSaveCompressCB, _ = eui.NewCheckbox()
+	recordSaveCompressCB.Text = ".zip compress (about half smaller)"
+	recordSaveCompressCB.Checked = true
+	recordSaveCompressCB.Size = eui.Point{X: 420, Y: 24}
+	flow.AddItem(recordSaveCompressCB)
 
-    recordSaveDontShowCB, _ = eui.NewCheckbox()
-    recordSaveDontShowCB.Text = "Don't show this again"
-    recordSaveDontShowCB.Size = eui.Point{X: 420, Y: 24}
-    flow.AddItem(recordSaveDontShowCB)
+	recordSaveDontShowCB, _ = eui.NewCheckbox()
+	recordSaveDontShowCB.Text = "Don't show this again"
+	recordSaveDontShowCB.Size = eui.Point{X: 420, Y: 24}
+	flow.AddItem(recordSaveDontShowCB)
 
-    // Buttons
-    btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true, Alignment: eui.ALIGN_RIGHT}
-    btnRow.Size = eui.Point{X: 420, Y: 28}
-    cancelBtn, cancelEv := eui.NewButton()
-    cancelBtn.Text = "Skip"
-    cancelBtn.Size = eui.Point{X: 80, Y: 24}
-    cancelEv.Handle = func(ev eui.UIEvent) {
-        if ev.Type == eui.EventClick {
-            if recordSaveWin != nil {
-                recordSaveWin.Close()
-            }
-        }
-    }
-    saveBtn, saveEv := eui.NewButton()
-    saveBtn.Text = "Save"
-    saveBtn.Size = eui.Point{X: 80, Y: 24}
-    saveEv.Handle = func(ev eui.UIEvent) {
-        if ev.Type != eui.EventClick {
-            return
-        }
-        // Apply don't-show preference
-        if recordSaveDontShowCB != nil && recordSaveDontShowCB.Checked {
-            gs.PromptOnSaveRecording = false
-            settingsDirty = true
-            saveSettings()
-        }
-        // Resolve new path
-        name := base
-        if recordSaveInput != nil && strings.TrimSpace(recordSaveInput.Text) != "" {
-            name = strings.TrimSpace(recordSaveInput.Text)
-        }
-        // Ensure extension
-        if !strings.EqualFold(filepath.Ext(name), ".clmov") {
-            name += ".clMov"
-        }
-        newPath := filepath.Join(dir, name)
-        // Rename if changed
-        if newPath != path {
-            if err := os.Rename(path, newPath); err != nil {
-                logError("rename recording: %v", err)
-                consoleMessage("rename failed: " + err.Error())
-            } else {
-                consoleMessage("renamed to: " + filepath.Base(newPath))
-                path = newPath
-            }
-        }
-        // Compress if requested (to .zip using archive/zip)
-        if recordSaveCompressCB != nil && recordSaveCompressCB.Checked {
-            go func(src string) {
-                outName := filepath.Base(src) + ".zip"
-                dst := filepath.Join(filepath.Dir(src), outName)
-                if err := compressZip(src, dst); err != nil {
-                    logError("zip compress: %v", err)
-                    consoleMessage("compress failed: " + err.Error())
-                } else {
-                    consoleMessage("compressed: " + outName)
-                }
-            }(path)
-        }
-        if recordSaveWin != nil {
-            recordSaveWin.Close()
-        }
-    }
-    btnRow.AddItem(cancelBtn)
-    btnRow.AddItem(saveBtn)
-    flow.AddItem(btnRow)
+	// Buttons
+	btnRow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Fixed: true, Alignment: eui.ALIGN_RIGHT}
+	btnRow.Size = eui.Point{X: 420, Y: 28}
+	cancelBtn, cancelEv := eui.NewButton()
+	cancelBtn.Text = "Skip"
+	cancelBtn.Size = eui.Point{X: 80, Y: 24}
+	cancelEv.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			if recordSaveWin != nil {
+				recordSaveWin.Close()
+			}
+		}
+	}
+	saveBtn, saveEv := eui.NewButton()
+	saveBtn.Text = "Save"
+	saveBtn.Size = eui.Point{X: 80, Y: 24}
+	saveEv.Handle = func(ev eui.UIEvent) {
+		if ev.Type != eui.EventClick {
+			return
+		}
+		// Apply don't-show preference
+		if recordSaveDontShowCB != nil && recordSaveDontShowCB.Checked {
+			gs.PromptOnSaveRecording = false
+			settingsDirty = true
+			saveSettings()
+		}
+		// Resolve new path
+		name := base
+		if recordSaveInput != nil && strings.TrimSpace(recordSaveInput.Text) != "" {
+			name = strings.TrimSpace(recordSaveInput.Text)
+		}
+		// Ensure extension
+		if !strings.EqualFold(filepath.Ext(name), ".clmov") {
+			name += ".clMov"
+		}
+		newPath := filepath.Join(dir, name)
+		// Rename if changed
+		if newPath != path {
+			if err := os.Rename(path, newPath); err != nil {
+				logError("rename recording: %v", err)
+				consoleMessage("rename failed: " + err.Error())
+			} else {
+				consoleMessage("renamed to: " + filepath.Base(newPath))
+				path = newPath
+			}
+		}
+		// Compress if requested (to .zip using archive/zip)
+		if recordSaveCompressCB != nil && recordSaveCompressCB.Checked {
+			go func(src string) {
+				outName := filepath.Base(src) + ".zip"
+				dst := filepath.Join(filepath.Dir(src), outName)
+				if err := compressZip(src, dst); err != nil {
+					logError("zip compress: %v", err)
+					consoleMessage("compress failed: " + err.Error())
+				} else {
+					consoleMessage("compressed: " + outName)
+				}
+			}(path)
+		}
+		if recordSaveWin != nil {
+			recordSaveWin.Close()
+		}
+	}
+	btnRow.AddItem(cancelBtn)
+	btnRow.AddItem(saveBtn)
+	flow.AddItem(btnRow)
 
-    recordSaveWin.AddItem(flow)
-    recordSaveWin.AddWindow(true)
-    recordSaveWin.MarkOpen()
+	recordSaveWin.AddItem(flow)
+	recordSaveWin.AddWindow(true)
+	recordSaveWin.MarkOpen()
 }
 
 // handleDownloadAssetError presents error options when a required asset fails to load.
@@ -1858,8 +1873,8 @@ func makeAddCharacterWindow() {
 	addCharPassWarn, _ = eui.NewText()
 	addCharPassWarn.Text = "Caps Lock is ON"
 	addCharPassWarn.TextColor = eui.ColorRed
-	addCharPassWarn.Invisible = !ebiten.IsKeyPressed(ebiten.KeyCapsLock)
 	flow.AddItem(addCharPassWarn)
+	setupCapsLockWarning(passInput, addCharPassWarn)
 	rememberCB, rememberEvents := eui.NewCheckbox()
 	rememberCB.Text = "Remember Password"
 	rememberCB.Size = eui.Point{X: 200, Y: 24}
@@ -1967,8 +1982,8 @@ func makePasswordWindow() {
 	passCapsWarn, _ = eui.NewText()
 	passCapsWarn.Text = "Caps Lock is ON"
 	passCapsWarn.TextColor = eui.ColorRed
-	passCapsWarn.Invisible = !ebiten.IsKeyPressed(ebiten.KeyCapsLock)
 	flow.AddItem(passCapsWarn)
+	setupCapsLockWarning(input, passCapsWarn)
 
 	btnFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL}
 


### PR DESCRIPTION
## Summary
- add setupCapsLockWarning helper to show a warning when typed letter case doesn't match shift state
- use inferred caps lock warning on add character and login password prompts
- remove old caps-lock polling from game loop

## Testing
- ⚠️ `go vet .` *(missing X11/ALSA/GTK development libraries: Xrandr.h, alsa.pc, gtk+-3.0.pc)*
- ⚠️ `go build` *(missing X11/ALSA/GTK development libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68b58b900b8c832aad6426a164e01a71