### PR TITLE
Queue input states until processed to avoid lost taps

### DIFF
--- a/game.go
+++ b/game.go
@@ -180,6 +180,7 @@ type inputState struct {
 
 var (
 	latestInput inputState
+	inputQueue  []inputState
 	inputMu     sync.Mutex
 )
 
@@ -993,9 +994,7 @@ func (g *Game) Update() error {
 		x, y = prev.mouseX, prev.mouseY
 	}
 
-	inputMu.Lock()
-	latestInput = inputState{mouseX: x, mouseY: y, mouseDown: walk}
-	inputMu.Unlock()
+	queueInput(inputState{mouseX: x, mouseY: y, mouseDown: walk})
 
 	updateHotkeyRecording()
 	checkHotkeys()
@@ -1011,6 +1010,25 @@ func stopWalkIfOutside(click, inGame bool) {
 
 func continueHeldWalk(prev inputState, inGame, buttonPressed bool, heldTime int, click bool) bool {
 	return (heldTime > 1 && !click && inGame) || (prev.mouseDown && buttonPressed)
+}
+
+func queueInput(s inputState) {
+	inputMu.Lock()
+	switch len(inputQueue) {
+	case 0:
+		if latestInput != s {
+			inputQueue = append(inputQueue, s)
+		}
+	case 1:
+		if inputQueue[0] != s {
+			inputQueue = append(inputQueue, s)
+		}
+	default:
+		if inputQueue[len(inputQueue)-1] != s {
+			inputQueue[len(inputQueue)-1] = s
+		}
+	}
+	inputMu.Unlock()
 }
 
 func updateGameWindowSize() {
@@ -2519,10 +2537,21 @@ func sendInputLoop(ctx context.Context, udpConn, tcpConn net.Conn) {
 			continue
 		}
 		inputMu.Lock()
-		s := latestInput
-		if keyStopFrames > 0 {
-			s = inputState{mouseX: 0, mouseY: 0, mouseDown: true}
-			keyStopFrames--
+		var s inputState
+		if len(inputQueue) > 0 {
+			s = inputQueue[0]
+			latestInput = s
+			inputQueue = inputQueue[1:]
+			if keyStopFrames > 0 && len(inputQueue) == 0 && !s.mouseDown {
+				s = inputState{mouseX: 0, mouseY: 0, mouseDown: true}
+				keyStopFrames--
+			}
+		} else {
+			s = latestInput
+			if keyStopFrames > 0 {
+				s = inputState{mouseX: 0, mouseY: 0, mouseDown: true}
+				keyStopFrames--
+			}
 		}
 		inputMu.Unlock()
 


### PR DESCRIPTION
## Summary
- queue input state changes and consume them per game frame
- drain input queue in send loop to preserve rapid clicks and key taps

## Testing
- `sudo apt-get install -y ./apt/*.deb` *(failed: unmet dependencies)*
- `go vet .` *(failed: missing X11/ALSA dev packages)*
- `go build` *(failed: missing ALSA/GTK development files)*
- `golangci-lint run` *(failed: built with older Go version)*

------
https://chatgpt.com/codex/tasks/task_e_68b58c07df78832a9866f59f5a1c5c9a