### PR TITLE
Fix caps lock warning visibility and sizing

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -126,8 +126,10 @@ func setupCapsLockWarning(input *eui.ItemData, warn *eui.ItemData) {
 	if input == nil || warn == nil {
 		return
 	}
-	prev := 0
 	warn.Invisible = true
+	warn.FontSize = input.FontSize
+	warn.Size = input.Size
+	warn.Dirty = true
 	h := input.Handler
 	prevHandle := h.Handle
 	h.Handle = func(ev eui.UIEvent) {
@@ -138,18 +140,21 @@ func setupCapsLockWarning(input *eui.ItemData, warn *eui.ItemData) {
 			return
 		}
 		runes := []rune(ev.Text)
-		l := len(runes)
-		if l > prev {
-			r := runes[l-1]
-			shift := ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight)
-			show := unicode.IsLetter(r) && ((unicode.IsUpper(r) && !shift) || (unicode.IsLower(r) && shift))
-			inv := !show
-			if warn.Invisible != inv {
-				warn.Invisible = inv
+		if len(runes) == 0 {
+			if !warn.Invisible {
+				warn.Invisible = true
 				warn.Dirty = true
 			}
+			return
 		}
-		prev = l
+		r := runes[len(runes)-1]
+		shift := ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight)
+		show := unicode.IsLetter(r) && ((unicode.IsUpper(r) && !shift) || (unicode.IsLower(r) && shift))
+		inv := !show
+		if warn.Invisible != inv {
+			warn.Invisible = inv
+			warn.Dirty = true
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Hide password caps lock warning by default and size it to match the input
- Update warning logic so it refreshes whenever text changes and hides when cleared

## Testing
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory; Package alsa was not found; gtk+-3.0 not found)*
- `go test ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h missing; gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b58ed4a9fc832ab75f51f42f036184