### PR TITLE
Detect duplicate entries in /be-who scans

### DIFF
--- a/bep.go
+++ b/bep.go
@@ -196,6 +196,9 @@ func parseBackendShare(data []byte) {
 
 // parseBackendWho parses "be-wh" messages listing players.
 func parseBackendWho(data []byte) {
+	if !whoActive {
+		clearBeWhoFlags()
+	}
 	batchCount := 0
 	newCount := 0
 	for len(data) > 0 {
@@ -230,6 +233,10 @@ func parseBackendWho(data []byte) {
 		// Update player record and enqueue info request if needed.
 		playersMu.Lock()
 		p, ok := players[name]
+		if ok && p.beWho {
+			playersMu.Unlock()
+			break
+		}
 		if !ok {
 			p = &Player{Name: name}
 			players[name] = p
@@ -271,7 +278,7 @@ func parseBackendWho(data []byte) {
 		playersPersistDirty = true
 	}
 	// Consider requesting another who batch if this looks like a partial page
-	considerNextWhoBatch(batchCount, newCount)
+	considerNextWhoBatch(batchCount)
 }
 
 // parseNames extracts a slice of names from a sequence of "-pn name -pn" entries.

--- a/player.go
+++ b/player.go
@@ -148,3 +148,11 @@ func notifyPlayerHandlers(p Player) {
 		go fn(p)
 	}
 }
+
+func clearBeWhoFlags() {
+	playersMu.Lock()
+	for _, p := range players {
+		p.beWho = false
+	}
+	playersMu.Unlock()
+}

--- a/who_scan.go
+++ b/who_scan.go
@@ -14,15 +14,15 @@ var (
 
 // considerNextWhoBatch decides if we should ask for another page.
 // The classic client expects batches of up to 20; continue when we saw a full
-// batch and it added at least one new name.
-func considerNextWhoBatch(batchCount, newCount int) {
-	if batchCount >= 20 && newCount > 0 {
+// batch. Duplicate detection in parseBackendWho ends the scan early.
+func considerNextWhoBatch(batchCount int) {
+	if batchCount >= 20 {
 		whoActive = true
 		// Schedule another request soon; the actual command emission happens
 		// in pickQueuedCommand() to coalesce with other command traffic.
 		return
 	}
-	// Fewer than 20 or no new names: end the scan.
+	// Fewer than 20: end the scan.
 	whoActive = false
 }
 


### PR DESCRIPTION
## Summary
- reset `BeWho` on all players before a scan
- stop parsing `/be-who` batches when a player already has `BeWho`
- drop new player tracking from who batch logic

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz && tar -xzf gothoom_deps.tar.gz && sudo apt-get install -y ./apt/*.deb` *(failed: libasound2-dev : Depends: libasound2 (= 1.2.6.1-1ubuntu1) but it is not installable)*
- `go build` *(failed: X11/extensions/Xrandr.h: No such file or directory)*
- `go test ./...` *(failed: no required module provides package github.com/dchest/siphash)*

------
https://chatgpt.com/codex/tasks/task_e_68b5928a6798832a84f9f1b6bbbcc4c5