### PR TITLE
Ensure dependency bundle includes runtime tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,10 @@ Try to avoid completely over-thinking your replies and feel free to stop and ask
    The archive, produced by `build-scripts/build_dep_bundle.sh`, contains the
    required Debian packages under `apt/`, a Go 1.25 toolchain under `go/`,
    and a cached Go module tree under `go/mod`. Extracting it and installing
-   these contents avoids fetching dependencies individually.
+   these contents avoids fetching dependencies individually. The bundled
+   packages currently include `build-essential`, `libgl1-mesa-dev`,
+   `libglu1-mesa-dev`, `xorg-dev`, `libxrandr-dev`, `libasound2-dev`,
+   `libgtk-3-dev`, and `xdg-utils`.
    
 2. Fetch Go module dependencies:
    ```bash

--- a/build-scripts/build_dep_bundle.sh
+++ b/build-scripts/build_dep_bundle.sh
@@ -27,6 +27,7 @@ DEB_PACKAGES=(
   libxrandr-dev
   libasound2-dev
   libgtk-3-dev
+  xdg-utils
 )
 
 if command -v apt-get >/dev/null 2>&1; then
@@ -34,7 +35,9 @@ if command -v apt-get >/dev/null 2>&1; then
   apt-get update -qq
   (
     cd "$APT_DIR"
-     apt-get -o APT::Sandbox::User=root -qq download "${DEB_PACKAGES[@]}"
+    apt-get -y -o Dir::Cache::Archives="$APT_DIR" \
+      -o APT::Sandbox::User=root \
+      install --download-only "${DEB_PACKAGES[@]}"
   )
 else
   echo "apt-get not found; skipping Debian package download" >&2


### PR DESCRIPTION
## Summary
- include xdg-utils so xdg-open is available
- download apt dependencies with `apt-get install --download-only`
- document all bundled Debian packages

## Testing
- `go build`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5914fe500832a8016a99d877a195c