### PR TITLE
embed scripts directory for plugin defaults

### DIFF
--- a/example_scripts/example.txt
+++ b/example_scripts/example.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/plugin.go
+++ b/plugin.go
@@ -118,8 +118,8 @@ func exportsForPlugin(owner string) interp.Exports {
 		m["RegisterCommand"] = reflect.ValueOf(func(name string, handler PluginCommandHandler) {
 			pluginRegisterCommand(owner, name, handler)
 		})
-        m["AddShortcut"] = reflect.ValueOf(func(short, full string) { pluginAddShortcut(owner, short, full) })
-        m["AddShortcuts"] = reflect.ValueOf(func(shortcuts map[string]string) { pluginAddShortcuts(owner, shortcuts) })
+		m["AddShortcut"] = reflect.ValueOf(func(short, full string) { pluginAddShortcut(owner, short, full) })
+		m["AddShortcuts"] = reflect.ValueOf(func(shortcuts map[string]string) { pluginAddShortcuts(owner, shortcuts) })
 		// Chat/Console (simple, no slices)
 		// Simple DSL aliases
 		m["Print"] = reflect.ValueOf(pluginConsole)
@@ -299,101 +299,100 @@ func exportsForPlugin(owner string) interp.Exports {
 	return ex
 }
 
-//go:embed example_scripts
-var pluginExamples embed.FS
+//go:embed scripts
+var pluginScripts embed.FS
 
 // userScriptsDir returns the preferred location for user-editable scripts.
 // Scripts now live alongside the executable in a top-level "scripts" folder
 // instead of under the data directory.
 func userScriptsDir() string {
-    exe, err := os.Executable()
-    if err != nil {
-        return "scripts"
-    }
-    return filepath.Join(filepath.Dir(exe), "scripts")
+	exe, err := os.Executable()
+	if err != nil {
+		return "scripts"
+	}
+	return filepath.Join(filepath.Dir(exe), "scripts")
 }
 
-// ensureExampleScripts creates the example_scripts directory next to the
-// executable and populates it with the embedded example plugin files if it is
-// missing.
-func ensureExampleScripts() {
-    exe, err := os.Executable()
-    if err != nil {
-        return
-    }
-    dir := filepath.Join(filepath.Dir(exe), "example_scripts")
-    if _, err := os.Stat(dir); err == nil {
-        return
-    } else if !os.IsNotExist(err) {
-        log.Printf("check example_scripts dir: %v", err)
-        return
-    }
-    if err := os.MkdirAll(dir, 0o755); err != nil {
-        log.Printf("create example_scripts dir: %v", err)
-        return
-    }
-    entries, err := pluginExamples.ReadDir("example_scripts")
-    if err != nil {
-        log.Printf("read embedded example scripts: %v", err)
-        return
-    }
-    for _, e := range entries {
-        if e.IsDir() {
-            continue
-        }
-        data, err := pluginExamples.ReadFile(path.Join("example_scripts", e.Name()))
-        if err != nil {
-            log.Printf("read embedded %s: %v", e.Name(), err)
-            continue
-        }
-        dst := filepath.Join(dir, e.Name())
-        if err := os.WriteFile(dst, data, 0o644); err != nil {
-            log.Printf("write %s: %v", dst, err)
-        }
-    }
+// ensureScriptsDir creates the scripts directory next to the executable and
+// populates it with the embedded scripts if it is missing.
+func ensureScriptsDir() {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	dir := filepath.Join(filepath.Dir(exe), "scripts")
+	if _, err := os.Stat(dir); err == nil {
+		return
+	} else if !os.IsNotExist(err) {
+		log.Printf("check scripts dir: %v", err)
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Printf("create scripts dir: %v", err)
+		return
+	}
+	entries, err := pluginScripts.ReadDir("scripts")
+	if err != nil {
+		log.Printf("read embedded scripts: %v", err)
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := pluginScripts.ReadFile(path.Join("scripts", e.Name()))
+		if err != nil {
+			log.Printf("read embedded %s: %v", e.Name(), err)
+			continue
+		}
+		dst := filepath.Join(dir, e.Name())
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			log.Printf("write %s: %v", dst, err)
+		}
+	}
 }
 
 // ensureDefaultScripts creates the user scripts directory and populates it
 // with example scripts when it is empty.
 func ensureDefaultScripts() {
-    dir := userScriptsDir()
-    if err := os.MkdirAll(dir, 0o755); err != nil {
-        log.Printf("create scripts dir: %v", err)
-        return
-    }
-    // Check if directory already has any .go script files
-    hasGo := false
-    if entries, err := os.ReadDir(dir); err == nil {
-        for _, e := range entries {
-            if !e.IsDir() {
-                hasGo = true
-                break
-            }
-        }
-    }
-    if hasGo {
-        return
-    }
-    // Write example plugin files
-    files := []string{
-        "default_shortcuts.go",
-        "README.txt",
-        "numpad_poser.go",
-    }
-    for _, src := range files {
-        sPath := path.Join("example_scripts", src)
-        data, err := pluginExamples.ReadFile(sPath)
-        if err != nil {
-            log.Printf("read embedded %s: %v", sPath, err)
-            continue
-        }
-        base := filepath.Base(sPath)
-        dst := filepath.Join(dir, base)
-        if err := os.WriteFile(dst, data, 0o644); err != nil {
-            log.Printf("write %s: %v", dst, err)
-            continue
-        }
-    }
+	dir := userScriptsDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Printf("create scripts dir: %v", err)
+		return
+	}
+	// Check if directory already has any .go script files
+	hasGo := false
+	if entries, err := os.ReadDir(dir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				hasGo = true
+				break
+			}
+		}
+	}
+	if hasGo {
+		return
+	}
+	// Write example plugin files
+	files := []string{
+		"default_shortcuts.go",
+		"README.txt",
+		"numpad_poser.go",
+	}
+	for _, src := range files {
+		sPath := path.Join("scripts", src)
+		data, err := pluginScripts.ReadFile(sPath)
+		if err != nil {
+			log.Printf("read embedded %s: %v", sPath, err)
+			continue
+		}
+		base := filepath.Base(sPath)
+		dst := filepath.Join(dir, base)
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			log.Printf("write %s: %v", dst, err)
+			continue
+		}
+	}
 }
 
 var pluginAllowedPkgs = []string{
@@ -850,7 +849,7 @@ func disablePlugin(owner, reason string) {
 	for _, hk := range pluginHotkeys(owner) {
 		pluginRemoveHotkey(owner, hk.Combo)
 	}
-    pluginRemoveShortcuts(owner)
+	pluginRemoveShortcuts(owner)
 	inputHandlersMu.Lock()
 	for i := len(pluginInputHandlers) - 1; i >= 0; i-- {
 		if pluginInputHandlers[i].owner == owner {
@@ -1391,7 +1390,7 @@ func pluginSource(owner string) string {
 }
 
 func refreshPluginMod() {
-    dirs := []string{userScriptsDir(), "scripts"}
+	dirs := []string{userScriptsDir(), "scripts"}
 	latest := time.Time{}
 	for _, dir := range dirs {
 		entries, err := os.ReadDir(dir)
@@ -1526,7 +1525,7 @@ func scanPlugins(pluginDirs []string, dup func(name, path string)) map[string]pl
 }
 
 func rescanPlugins() {
-    pluginDirs := []string{userScriptsDir(), "scripts"}
+	pluginDirs := []string{userScriptsDir(), "scripts"}
 	scanned := scanPlugins(pluginDirs, nil)
 
 	pluginMu.RLock()
@@ -1606,10 +1605,10 @@ func checkPluginMods() {
 }
 
 func loadPlugins() {
-    ensureExampleScripts()
-    ensureDefaultScripts()
+	ensureScriptsDir()
+	ensureDefaultScripts()
 
-    pluginDirs := []string{userScriptsDir(), "scripts"}
+	pluginDirs := []string{userScriptsDir(), "scripts"}
 	scanned := scanPlugins(pluginDirs, func(name, path string) {
 		log.Printf("plugin %s duplicate name %s", path, name)
 		consoleMessage("[plugin] duplicate name: " + name)


### PR DESCRIPTION
## Summary
- embed `scripts` directory in the binary
- ensure `scripts` folder is created and populated from embedded scripts when missing
- adjust plugin loader to use new `scripts` directory

## Testing
- `tar -xzf gothoom_deps.tar.gz` *(failed: Unexpected EOF in archive)*
- `go env -w GOMODCACHE="$(pwd)/go/mod"`
- `go mod download`
- `GOWORK=off go test ./...` *(failed: X11/extensions/Xrandr.h: No such file or directory; Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b593eaea98832a9cc8d9ab5ccca5e1