### PR TITLE
use TrimPrefix for prefix removal

### DIFF
--- a/chat_messages.go
+++ b/chat_messages.go
@@ -57,36 +57,34 @@ func getChatMessages() []string {
 }
 
 func isSelfChatMessage(msg string) bool {
-    if playerName == "" {
-        return false
-    }
-    m := strings.ToLower(strings.TrimSpace(msg))
-    name := strings.ToLower(playerName)
+	if playerName == "" {
+		return false
+	}
+	m := strings.ToLower(strings.TrimSpace(msg))
+	name := strings.ToLower(playerName)
 
-    // Emotes like "(Hero waves)"
-    if strings.HasPrefix(m, "("+name+" ") {
-        return true
-    }
-    // Spoken lines like "Hero says, ..." or "Hero yells, ..."
-    if strings.HasPrefix(m, name+" ") {
-        rest := strings.TrimSpace(m[len(name):])
-        if strings.HasPrefix(rest, "says,") ||
-            strings.HasPrefix(rest, "yells,") ||
-            strings.HasPrefix(rest, "whispers,") ||
-            strings.HasPrefix(rest, "exclaims,") {
-            return true
-        }
-    }
-    return false
+	// Emotes like "(Hero waves)"
+	if strings.HasPrefix(m, "("+name+" ") {
+		return true
+	}
+	// Spoken lines like "Hero says, ..." or "Hero yells, ..."
+	if strings.HasPrefix(m, name+" ") {
+		rest := strings.TrimSpace(m[len(name):])
+		if strings.HasPrefix(rest, "says,") ||
+			strings.HasPrefix(rest, "yells,") ||
+			strings.HasPrefix(rest, "whispers,") ||
+			strings.HasPrefix(rest, "exclaims,") {
+			return true
+		}
+	}
+	return false
 }
 
 // chatSpeaker extracts the leading player name from a chat message, folded to
 // canonical form. It returns an empty string if no name could be parsed.
 func chatSpeaker(msg string) string {
 	m := strings.TrimSpace(msg)
-	if strings.HasPrefix(m, "(") {
-		m = m[1:]
-	}
+	m = strings.TrimPrefix(m, "(")
 	if i := strings.IndexByte(m, ' '); i > 0 {
 		return utfFold(m[:i])
 	}

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -611,9 +611,7 @@ func parseMusicCommand(s string, raw []byte) bool {
 		}
 		return false
 	}
-	if strings.HasPrefix(s, "/music/") {
-		s = s[len("/music/"):]
-	}
+	s = strings.TrimPrefix(s, "/music/")
 
 	// Recognize and act on /stop (or /S) even if combined with play.
 	stop := false


### PR DESCRIPTION
## Summary
- use strings.TrimPrefix for chat speaker parsing
- simplify music command parsing with strings.TrimPrefix

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz && tar -xzf gothoom_deps.tar.gz && sudo apt-get install -y ./apt/*.deb && sudo tar -C /usr/local -xzf go/go1.25.0.linux-amd64.tar.gz && export PATH="/usr/local/go/bin:$PATH" && go env -w GOMODCACHE="$(pwd)/go/mod"` *(failed: libfontenc-dev : Depends: libfontenc1, libglu1-mesa-dev : Depends: libgl-dev, libxaw7-dev : Depends: libxaw7, libxcvt-dev : Depends: libxcvt0, libxfont-dev : Depends: libxfont2, libxkbfile-dev : Depends: libxkbfile1, libxmu-dev : Depends: libxt-dev, libxmuu-dev : Depends: libxmuu1, libxpm-dev : Depends: libxpm4, libxres-dev : Depends: libxres1, libxss-dev : Depends: libxss1, libxv-dev : Depends: libxv1, libxvmc-dev : Depends: libxvmc1, libxxf86dga-dev : Depends: libxxf86dga1, xorg-dev : Depends: libice-dev, xserver-xorg-dev : Depends: libpixman-1-dev, mesa-common-dev)*
- `go mod download`
- `go build` *(failed: compile: version "go1.24.3" does not match go tool version "go1.25.0")*
- `go test ./...` *(failed: no required module provides packages such as github.com/dchest/siphash, github.com/VictoriaMetrics/fastcache, github.com/allegro/bigcache, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5954e6e84832a86247039447ea597