### PR TITLE
Remove Debian package bundling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,24 +8,24 @@ Try to avoid completely over-thinking your replies and feel free to stop and ask
 
 ## Installing dependencies
 
-1. **Always** download and install the prebuilt dependency bundle:
+1. Install required system packages (if missing):
+   ```bash
+   sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev \
+     xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils
+   ```
+2. **Always** download and install the prebuilt dependency bundle:
    ```bash
    curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz
    tar -xzf gothoom_deps.tar.gz
-   sudo apt-get install -y ./apt/*.deb
    sudo tar -C /usr/local -xzf go/go1.25.0.linux-amd64.tar.gz
    export PATH="/usr/local/go/bin:$PATH"
    go env -w GOMODCACHE="$(pwd)/go/mod"
    ```
-   The archive, produced by `build-scripts/build_dep_bundle.sh`, contains the
-   required Debian packages under `apt/`, a Go 1.25 toolchain under `go/`,
-   and a cached Go module tree under `go/mod`. Extracting it and installing
-   these contents avoids fetching dependencies individually. The bundled
-   packages currently include `build-essential`, `libgl1-mesa-dev`,
-   `libglu1-mesa-dev`, `xorg-dev`, `libxrandr-dev`, `libasound2-dev`,
-   `libgtk-3-dev`, and `xdg-utils`.
+   The archive, produced by `build-scripts/build_dep_bundle.sh`, contains a
+   Go 1.25 toolchain under `go/` and a cached Go module tree under `go/mod`.
+   Extracting it avoids fetching Go artifacts individually.
    
-2. Fetch Go module dependencies:
+3. Fetch Go module dependencies:
    ```bash
    cd gothoom
    go mod download
@@ -40,8 +40,8 @@ The `build-scripts` directory provides helper scripts for development.
 Run these scripts from the repository root.
 
 ## Adding Dependencies
-- Always document new system packages here and add them to `DEB_PACKAGES` in `build-scripts/build_dep_bundle.sh`.
-- If the Go toolchain version changes, update `GO_VERSION` in `build_dep_bundle.sh` and rebuild the bundle.
+- Document any required system packages here.
+- If the Go toolchain version changes, update `GO_VERSION` in `build-scripts/build_dep_bundle.sh` and rebuild the bundle.
 - After updates, regenerate the archive by running `build-scripts/build_dep_bundle.sh` from the repo root and re-share `gothoom_deps.tar.gz`.
 
 ## Build steps

--- a/build-scripts/build_dep_bundle.sh
+++ b/build-scripts/build_dep_bundle.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Build a tarball containing goThoom's system and Go module dependencies.
-# The resulting archive can be unpacked on another machine to speed up
-# environment setup without hitting the network.
+# Build a tarball containing goThoom's Go toolchain, module cache, and
+# selected data files. The resulting archive can be unpacked on another
+# machine to speed up environment setup without hitting the network for Go
+# artifacts.
 
 set -euo pipefail
 
@@ -11,37 +12,12 @@ set -euo pipefail
 OUT_FILE="${1:-gothoom_deps.tar.gz}"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
-APT_DIR="$WORK_DIR/apt"
 GO_DIR="$WORK_DIR/go"
 
-mkdir -p "$APT_DIR" "$GO_DIR"
+mkdir -p "$GO_DIR"
 
-# Packages needed to build goThoom. The Go toolchain is downloaded below.
-# NOTE: Keep this list in sync with AGENTS.md (see "Adding Dependencies").
-# When adding a new system package, document it in AGENTS.md and add it here.
-DEB_PACKAGES=(
-  build-essential
-  libgl1-mesa-dev
-  libglu1-mesa-dev
-  xorg-dev
-  libxrandr-dev
-  libasound2-dev
-  libgtk-3-dev
-  xdg-utils
-)
-
-if command -v apt-get >/dev/null 2>&1; then
-  echo "Downloading Debian packages..."
-  apt-get update -qq
-  (
-    cd "$APT_DIR"
-    apt-get -y -o Dir::Cache::Archives="$APT_DIR" \
-      -o APT::Sandbox::User=root \
-      install --download-only "${DEB_PACKAGES[@]}"
-  )
-else
-  echo "apt-get not found; skipping Debian package download" >&2
-fi
+# System packages are not bundled; install them separately via your package
+# manager before using this archive.
 
 # Include Go toolchain
 # NOTE: If this version changes, update AGENTS.md instructions to match.


### PR DESCRIPTION
## Summary
- stop bundling `.deb` system packages in the dependency archive
- instruct developers to install system packages via apt and keep the bundle to Go toolchain + modules

## Testing
- `go mod download`
- `go test ./...` *(fails: spellcheck.go:16:12 pattern spellcheck_words.txt: no matching files found; fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b596f97970832aaa2006f217fda60f