### PR TITLE
Remove Go toolchain from dependency bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-This repo includes a Go client under `gothoom/`. To build or run the Go program you need Go version 1.25. A Go 1.25 toolchain is bundled with the repository and should be used instead of the system `golang-go` package.
+This repo includes a Go client under `gothoom/`. To build or run the Go program you need Go version 1.25 from the official Go distribution; avoid the system `golang-go` package.
 Do not increment JSON versions in GT_Players.json or settings.json or characters.json. They will be done manually if needed.
 Any functions or variables or types exposed to the plugins need to also be put empty stubs into gt so the linters do not complain for users.
 Also I prefer to-the-point and simple solutions. We'll get complex if it is needed but I prefer to not over complicate things. "Keep it simple stupid"
@@ -13,19 +13,22 @@ Try to avoid completely over-thinking your replies and feel free to stop and ask
    sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev \
      xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils
    ```
-2. **Always** download and install the prebuilt dependency bundle:
+2. Install Go 1.25:
+   ```bash
+   curl -LO https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
+   sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
+   export PATH="/usr/local/go/bin:$PATH"
+   ```
+3. **Always** download and extract the prebuilt dependency bundle:
    ```bash
    curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz
    tar -xzf gothoom_deps.tar.gz
-   sudo tar -C /usr/local -xzf go/go1.25.0.linux-amd64.tar.gz
-   export PATH="/usr/local/go/bin:$PATH"
-   go env -w GOMODCACHE="$(pwd)/go/mod"
    ```
-   The archive, produced by `build-scripts/build_dep_bundle.sh`, contains a
-   Go 1.25 toolchain under `go/` and a cached Go module tree under `go/mod`.
-   Extracting it avoids fetching Go artifacts individually.
-   
-3. Fetch Go module dependencies:
+   The archive, produced by `build-scripts/build_dep_bundle.sh`, contains
+   resource files used by the client. Extracting it avoids fetching them
+   individually.
+
+4. Fetch Go module dependencies:
    ```bash
    cd gothoom
    go mod download
@@ -41,7 +44,8 @@ Run these scripts from the repository root.
 
 ## Adding Dependencies
 - Document any required system packages here.
-- If the Go toolchain version changes, update `GO_VERSION` in `build-scripts/build_dep_bundle.sh` and rebuild the bundle.
+- Update `build-scripts/build_dep_bundle.sh` if additional data files need to
+  be bundled and regenerate the archive with the script.
 - After updates, regenerate the archive by running `build-scripts/build_dep_bundle.sh` from the repo root and re-share `gothoom_deps.tar.gz`.
 
 ## Build steps

--- a/build-scripts/build_dep_bundle.sh
+++ b/build-scripts/build_dep_bundle.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# Build a tarball containing goThoom's Go toolchain, module cache, and
-# selected data files. The resulting archive can be unpacked on another
-# machine to speed up environment setup without hitting the network for Go
-# artifacts.
+# Build a tarball containing selected data files. The resulting archive can
+# be unpacked on another machine to speed up environment setup without
+# hitting the network for these assets.
 
 set -euo pipefail
 
@@ -12,27 +11,9 @@ set -euo pipefail
 OUT_FILE="${1:-gothoom_deps.tar.gz}"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
-GO_DIR="$WORK_DIR/go"
-
-mkdir -p "$GO_DIR"
 
 # System packages are not bundled; install them separately via your package
 # manager before using this archive.
-
-# Include Go toolchain
-# NOTE: If this version changes, update AGENTS.md instructions to match.
-GO_VERSION="1.25.0"
-GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
-echo "Downloading Go ${GO_VERSION}..."
-curl -L -o "$GO_DIR/$GO_TARBALL" "https://go.dev/dl/$GO_TARBALL"
-
-# Cache Go modules into a local mod cache inside the bundle.
-GO_CACHE="$GO_DIR/mod"
-mkdir -p "$GO_CACHE"
-
-echo "Downloading Go modules..."
-GOMODCACHE="$GO_CACHE" /usr/local/go/bin/go mod download
-
 
 # Copy useful data files
 DATA_SRC="data"


### PR DESCRIPTION
## Summary
- strip Go toolchain and module cache from build_dep_bundle.sh, leaving only resource files
- update AGENTS instructions to install Go separately and clarify bundle contents

## Testing
- `go test ./...` *(fails: spellcheck_words.txt not found; Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b598a3d7d4832a940ff3cd3e474ade