### PR TITLE
Add README badges and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - run: curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz
+      - run: tar -xzf gothoom_deps.tar.gz
+      - run: go mod download
+      - run: go vet ./...
+      - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # goThoom
 
+[![CI](https://github.com/m45sci/goThoom/actions/workflows/ci.yml/badge.svg)](https://github.com/m45sci/goThoom/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/m45sci/goThoom.svg)](https://pkg.go.dev/github.com/m45sci/goThoom)
+[![Go Report Card](https://goreportcard.com/badge/github.com/m45sci/goThoom)](https://goreportcard.com/report/github.com/m45sci/goThoom)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/m45sci/goThoom)](https://github.com/m45sci/goThoom/releases)
+
 An open-source (MIT) client for the classic **[Clan Lord](https://www.deltatao.com/clanlord/)** MMORPG
 
 <img width="125" height="125" alt="goThoom" src="https://github.com/user-attachments/assets/b036f99a-668b-408e-8a43-524a0659a260" />


### PR DESCRIPTION
## Summary
- add standard badges to README
- add GitHub Actions workflow running vet and tests

## Testing
- `go vet ./...` *(fails: uses unkeyed fields and copies lock values)*
- `go test ./...` *(fails: GLFW requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68b59b5dac84832aa4b2c574b7500902