### PR TITLE
docs: refresh readmes and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ An open-source (MIT) client for the classic **[Clan Lord](https://www.deltatao.c
 ### Text-to-speech voices
 Piper voices are stored in `data/piper/voices`. The client and `scripts/download_piper.sh` support voice archives in `.tar.gz` format and automatically extract and remove the archives. If a voice archive isn't available, the program falls back to downloading raw `.onnx` models with matching `.onnx.json` configs.
 
+## Build from source
+
+1. Install system packages:
+   ```bash
+   sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev \
+     xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils
+   ```
+2. Install Go 1.25 from [go.dev](https://go.dev/dl/).
+3. Fetch the resource bundle and extract it in the repo root:
+   ```bash
+   curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz
+   tar -xzf gothoom_deps.tar.gz
+   ```
+4. Download Go modules:
+   ```bash
+   go mod download
+   ```
+5. Build the client:
+   ```bash
+   go build
+   ```
+
 ---
 
 ## Using the UI

--- a/docs/CommandsHelp.md
+++ b/docs/CommandsHelp.md
@@ -2,6 +2,8 @@
 
 This reference captures the in‑game help responses for core commands. Text is taken verbatim from the client’s /help output (minor spacing preserved). Some responses are contextual and may vary.
 
+_Updated 2025._
+
 See also: Command Reference (external, very detailed)
 https://clump.clanlord.net/library/index.php?title=Command_Reference
 

--- a/eui/themes/README.md
+++ b/eui/themes/README.md
@@ -1,6 +1,6 @@
 # Themes
 
-This directory holds the built-in color palettes and style themes used by EUI. Themes are JSON files that control the appearance and spacing of all widgets. You can load them at runtime or create your own variants.
+This directory holds the built-in color palettes and style themes used by EUI. Themes are JSON files that control the appearance and spacing of all widgets. You can load them at runtime or create your own variants. Set `eui.AutoReload = true` to have changes picked up automatically while editing.
 
 ## Palettes
 

--- a/scripts/README.txt
+++ b/scripts/README.txt
@@ -4,10 +4,13 @@ This folder contains example script files for goThoom.
 
 Getting Started
 - Copy or edit any of the example .go files to get started.
+- Start each file with `//go:build plugin`.
 - Each script must define an Init() function. The client discovers and calls this function after loading the file.
 - Each script must define a unique PluginName, PluginAuthor and PluginCategory string. Changing Name or Author will make the script unable to access old saved data!
 - Place .go files in the scripts/ directory next to the game.
 - Hotkeys added by scripts appear in a "Plugin Hotkeys" section of the hotkeys window where you can enable or disable them.
+
+Run the client with `go run .` or the built binary and any scripts in this folder load automatically.
 
 API
 The interpreter allows only these packages: gt, bytes, encoding/json,


### PR DESCRIPTION
## Summary
- add concise build-from-source steps to the root README
- document update timestamp and auto-reload behavior in docs and themes guides
- clarify script requirements and loading instructions

## Testing
- `go test ./...` *(fails: GLFW library requires a display)*

------
https://chatgpt.com/codex/tasks/task_e_68b59af10b30832a9ac839ea466476c2