### PR TITLE
Add cross-platform build tooling to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:24.04
+
+# Base build tooling and libraries needed for cross-compiling the client on
+# Linux, macOS (via osxcross) and Windows.  This mirrors the dependencies used
+# by build-scripts/build_binaries.sh so the container can produce release
+# binaries for all platforms without further setup.
+RUN apt-get update && apt-get install -y \
+    build-essential g++-12 libstdc++-12-dev libc6-dev \
+    git cmake ninja-build clang llvm lldb pkg-config \
+    libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev \
+    libasound2-dev libgtk-3-dev xdg-utils \
+    libxml2-dev uuid-dev libssl-dev libbz2-dev zlib1g-dev \
+    cpio unzip zip xz-utils curl ca-certificates jq \
+    osslsigncode imagemagick && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -LO https://go.dev/dl/go1.25.0.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz \
+    && rm go1.25.0.linux-amd64.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /app
+
+RUN curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz \
+    && tar -xzf gothoom_deps.tar.gz \
+    && rm gothoom_deps.tar.gz
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Install osxcross with a macOS 13.3 SDK to enable darwin builds
+RUN build-scripts/install_osxcross.sh --root /osxcross --sdk-version 13.3 --no-deps
+ENV OSXCROSS_ROOT=/osxcross
+ENV PATH="$OSXCROSS_ROOT/target/bin:${PATH}"
+
+# Windows builds embed resources via go-winres
+RUN go install github.com/tc-hib/go-winres@latest
+
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     build-essential g++-12 libstdc++-12-dev libc6-dev \
     git cmake ninja-build clang llvm lldb pkg-config \
     libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev \
-    libasound2-dev libgtk-3-dev xdg-utils \
+    libasound2-dev alsa-utils libgtk-3-dev xdg-utils \
     libxml2-dev uuid-dev libssl-dev libbz2-dev zlib1g-dev \
     cpio unzip zip xz-utils curl ca-certificates jq \
     osslsigncode imagemagick && \

--- a/build-scripts/docker_dev_env.sh
+++ b/build-scripts/docker_dev_env.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the gothoom development environment Docker image including
+# toolchains for cross-compiling to Linux, Windows and macOS.
+cd "$(dirname "$0")/.."
+
+docker build -t gothoom-build-env .


### PR DESCRIPTION
## Summary
- expand Dockerfile to include build dependencies, osxcross with macOS 13.3 SDK, and go-winres
- note cross-compilation toolchains in helper script for building the container

## Testing
- `timeout 60 go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6712dd180832a85dde54512c06e8a