### PR TITLE
docs: note Docker build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ Piper voices are stored in `data/piper/voices`. The client and `build-scripts/do
    go build
    ```
 
+### Build with Docker
+
+A `Dockerfile` provides a reproducible cross-platform build environment.
+
+```bash
+./build-scripts/docker_dev_env.sh
+docker create --name gothoom-build gothoom-build-env
+mkdir -p dist
+docker cp gothoom-build:/out ./dist
+docker rm gothoom-build
+```
+
+The `dist/` directory will contain the compiled binaries.
+See [`docs/Docker.md`](docs/Docker.md) for details.
+
 ---
 
 ## Using the UI

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,0 +1,22 @@
+# Building with Docker
+
+The repository includes a `Dockerfile` for building goThoom in a reproducible environment.
+
+## Build the image and binaries
+
+```bash
+./build-scripts/docker_dev_env.sh
+```
+
+This builds an image tagged `gothoom-build-env` and compiles the binaries inside it.
+
+## Extract the build artifacts
+
+```bash
+docker create --name gothoom-build gothoom-build-env
+mkdir -p dist
+docker cp gothoom-build:/out ./dist
+docker rm gothoom-build
+```
+
+The built cross-platform binaries are now in `dist/` on the host.


### PR DESCRIPTION
## Summary
- document Docker-based build workflow in README
- add Docker build instructions under docs/

## Testing
- `go test ./...` *(fails: GLFW library not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68b6926fb4d0832a87f24d34a5236d65