### PR TITLE
Implement players data refresh state machine

### DIFF
--- a/game.go
+++ b/game.go
@@ -605,6 +605,7 @@ func (g *Game) Update() error {
 	checkPluginMods()
 	updateNotifications()
 	updateThinkMessages()
+	requestPlayersData()
 
 	mx, my := eui.PointerPosition()
 	origX, origY, worldScale := worldDrawInfo()

--- a/network.go
+++ b/network.go
@@ -144,13 +144,6 @@ func sendPlayerInput(connection net.Conn, mouseX, mouseY int16, mouseDown bool, 
 	}
 
 	nextCommand()
-	// Before reading the pending command, give background queues
-	// a chance to schedule maintenance commands.
-	if pendingCommand == "" {
-		if !maybeEnqueueInfo() {
-			_ = maybeEnqueueWho()
-		}
-	}
 	cmd := pendingCommand
 	cmdBytes := encodeMacRoman(cmd)
 	packet := make([]byte, 20+len(cmdBytes)+1)

--- a/players_refresh.go
+++ b/players_refresh.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"time"
+)
+
+// players maintenance state machine handling /be-who, /be-share and /be-info.
+// It also tracks LastSeen times to refresh the UI when players age out.
+
+// internal phases
+const (
+	phaseWho = iota
+	phaseShare
+	phaseInfo
+)
+
+var (
+	playersPhase   = phaseWho
+	playersLastCmd time.Time
+	playersOffline = map[string]bool{}
+	whoRequested   bool
+)
+
+const playersOfflineThreshold = 5 * time.Minute
+
+// requestPlayersData progresses the maintenance state machine and
+// updates playersDirty when LastSeen crosses the offline threshold.
+func requestPlayersData() {
+	now := time.Now()
+
+	// track offline transitions
+	changed := false
+	playersMu.RLock()
+	for name, p := range players {
+		offline := time.Since(p.LastSeen) > playersOfflineThreshold
+		if prev, ok := playersOffline[name]; !ok || prev != offline {
+			playersOffline[name] = offline
+			changed = true
+		}
+	}
+	playersMu.RUnlock()
+	if changed {
+		playersDirty = true
+	}
+
+	if pendingCommand != "" {
+		return
+	}
+	if time.Since(playersLastCmd) < time.Second {
+		return
+	}
+
+	switch playersPhase {
+	case phaseWho:
+		if whoActive {
+			if maybeEnqueueWho() {
+				playersLastCmd = now
+			}
+			return
+		}
+		if !whoRequested {
+			pendingCommand = "/be-who"
+			whoLastRequest = now
+			playersLastCmd = now
+			whoRequested = true
+			return
+		}
+		// who scan finished
+		playersPhase = phaseShare
+		whoRequested = false
+	case phaseShare:
+		pendingCommand = "/be-share"
+		playersLastCmd = now
+		playersPhase = phaseInfo
+	case phaseInfo:
+		if maybeEnqueueInfo() {
+			playersLastCmd = now
+		} else if !whoActive {
+			playersPhase = phaseWho
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add players_refresh state machine to cycle /be-who, /be-share, and /be-info requests
- hook requestPlayersData into main loop and remove old network command enqueuing

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b9e6c469f4832aa0f2425b72e57051