### PR TITLE
Handle 32-bit movie revisions

### DIFF
--- a/movie.go
+++ b/movie.go
@@ -40,7 +40,8 @@ func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
 		return nil, fmt.Errorf("bad signature")
 	}
 	version := binary.BigEndian.Uint16(data[4:6])
-	revision := binary.BigEndian.Uint16(data[16:18])
+	revision := binary.BigEndian.Uint32(data[16:20])
+	movieRevision = int32(revision)
 	// Arindal movies store version numbers 100x larger.
 	if version > 50000 {
 		version /= 100
@@ -88,11 +89,11 @@ func parseMovie(path string, clientVersion int) ([]movieFrame, error) {
 			if end > len(data) {
 				break
 			}
-			parseGameState(data[start:end], version, revision)
+			parseGameState(data[start:end], version, uint16(revision))
 			pos = end
 		}
 		if flags&flagMobileData != 0 {
-			pos = parseMobileTable(data, pos, version, revision)
+			pos = parseMobileTable(data, pos, version, uint16(revision))
 		}
 		if flags&flagPictureTable != 0 {
 			if pos+2 > len(data) {

--- a/movie_revision_test.go
+++ b/movie_revision_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Test that parseMovie records the full 32-bit revision from the header.
+func TestParseMovieRevision(t *testing.T) {
+	_, file, _, _ := runtime.Caller(0)
+	src := filepath.Join(filepath.Dir(file), "clmovFiles", "test.clMov")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Overwrite revision bytes with a distinctive value.
+	binary.BigEndian.PutUint32(data[16:20], 0x01020304)
+	tmp := filepath.Join(t.TempDir(), "rev.clMov")
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	movieRevision = 0
+	if _, err := parseMovie(tmp, 0); err != nil {
+		t.Fatalf("parseMovie: %v", err)
+	}
+	if movieRevision != 0x01020304 {
+		t.Fatalf("movieRevision = 0x%x, want 0x01020304", movieRevision)
+	}
+}


### PR DESCRIPTION
## Summary
- read full 32-bit revision from .clMov headers and store it
- add a regression test for parsing movie revisions

## Testing
- `go test ./...` *(fails: Package 'alsa', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba447579cc832a8743ad19faf33a65