### PR TITLE
Load plugins and spellcheck after Ebiten starts

### DIFF
--- a/spellcheck.go
+++ b/spellcheck.go
@@ -38,7 +38,7 @@ var commonWords = []string{
 	"feral", "tenebrion", "melabrion", "qual", "kizmia",
 }
 
-func init() {
+func loadSpellcheck() {
 	var err error
 	sc, err = spellchecker.New("abcdefghijklmnopqrstuvwxyz'", spellchecker.WithMaxErrors(1))
 	if err != nil {

--- a/ui.go
+++ b/ui.go
@@ -168,7 +168,6 @@ func initUI() {
 	}
 
 	loadHotkeys()
-	loadPlugins()
 
 	eui.SetUIScale(float32(gs.UIScale))
 


### PR DESCRIPTION
## Summary
- Defer plugin loading until after the game window initializes
- Load spellcheck dictionary asynchronously instead of at startup
- Remove blocking plugin load from UI initialization

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba47d1e5c0832abe4ef3fbfcd8bb7b