### PR TITLE
Add theme style selection

### DIFF
--- a/game.go
+++ b/game.go
@@ -2391,7 +2391,9 @@ func initGame() {
 		}
 	}
 	eui.LoadTheme(theme)
-	eui.LoadStyle("RoundHybrid")
+	if gs.Style != "" {
+		eui.LoadStyle(gs.Style)
+	}
 	initUI()
 	updateDimmedScreenBG()
 	updateCharacterButtons()

--- a/settings.go
+++ b/settings.go
@@ -186,6 +186,7 @@ type settings struct {
 	MaxNightLevel         int
 	ForceNightLevel       int
 	Theme                 string
+	Style                 string
 	MessagesToConsole     bool
 	ChatTTS               bool
 	ChatTTSVolume         float64

--- a/ui.go
+++ b/ui.go
@@ -2563,6 +2563,33 @@ func makeSettingsWindow() {
 	}
 	left.AddItem(pinLocCB)
 
+	styleDD, styleEvents := eui.NewDropdown()
+	styleDD.Label = "Style Theme"
+	if opts, err := eui.ListStyles(); err == nil {
+		styleDD.Options = opts
+		cur := eui.CurrentStyleName()
+		for i, n := range opts {
+			if n == cur {
+				styleDD.Selected = i
+				break
+			}
+		}
+	}
+	styleDD.Size = eui.Point{X: panelWidth, Y: 24}
+	styleEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventDropdownSelected {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			name := styleDD.Options[ev.Index]
+			if err := eui.LoadStyle(name); err == nil {
+				gs.Style = name
+				settingsDirty = true
+				settingsWin.Refresh()
+			}
+		}
+	}
+
 	themeDD, themeEvents := eui.NewDropdown()
 	themeDD.Label = "Color Theme"
 	if opts, err := eui.ListThemes(); err == nil {
@@ -2584,6 +2611,13 @@ func makeSettingsWindow() {
 			name := themeDD.Options[ev.Index]
 			if err := eui.LoadTheme(name); err == nil {
 				gs.Theme = name
+				gs.Style = eui.CurrentStyleName()
+				for i, n := range styleDD.Options {
+					if n == gs.Style {
+						styleDD.Selected = i
+						break
+					}
+				}
 				settingsDirty = true
 				settingsWin.Refresh()
 				updateDimmedScreenBG()
@@ -2591,6 +2625,7 @@ func makeSettingsWindow() {
 		}
 	}
 	left.AddItem(themeDD)
+	left.AddItem(styleDD)
 
 	label, _ = eui.NewText()
 	label.Text = "\nControls:"


### PR DESCRIPTION
## Summary
- add Style field to settings and load style from saved preference
- allow picking style themes in settings and apply recommended style on theme change
- initialize game with persisted style override

## Testing
- `go test ./...` *(fails: Package gtk+-3.0 not found; Xrandr headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4fe428b0832a84ecf7bbfc435e79