### PR TITLE
Add search highlighting for console and chat

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -22,6 +22,7 @@ func updateChatWindow() {
 
 	msgs := getChatMessages()
 	updateTextWindow(chatWin, chatList, nil, msgs, gs.ChatFontSize, "", nil)
+	searchTextWindow(chatWin, chatList, chatWin.SearchText)
 	if chatList != nil {
 		// Auto-scroll list to bottom on new messages
 		if scrollit {
@@ -39,6 +40,8 @@ func makeChatWindow() error {
 		return nil
 	}
 	chatWin, chatList, _ = newTextWindow("Chat", eui.HZoneRight, eui.VZoneBottom, false, updateChatWindow)
+	chatWin.Searchable = true
+	chatWin.OnSearch = func(s string) { searchTextWindow(chatWin, chatList, s) }
 	updateChatWindow()
 	chatWin.Refresh()
 	return nil

--- a/console_ui.go
+++ b/console_ui.go
@@ -26,6 +26,7 @@ func updateConsoleWindow() {
 
 	msgs := getConsoleMessages()
 	updateTextWindow(consoleWin, messagesFlow, inputFlow, msgs, gs.ConsoleFontSize, inputMsg, nil)
+	searchTextWindow(consoleWin, messagesFlow, consoleWin.SearchText)
 	if inputFlow != nil && len(inputFlow.Contents) > 0 {
 		inputItem := inputFlow.Contents[0]
 		inputItem.Focused = inputActive
@@ -47,6 +48,8 @@ func makeConsoleWindow() {
 		return
 	}
 	consoleWin, messagesFlow, inputFlow = newTextWindow("Console", eui.HZoneLeft, eui.VZoneBottom, true, updateConsoleWindow)
+	consoleWin.Searchable = true
+	consoleWin.OnSearch = func(s string) { searchTextWindow(consoleWin, messagesFlow, s) }
 	consoleMessage("Starting...")
 	updateConsoleWindow()
 }

--- a/eui/render.go
+++ b/eui/render.go
@@ -822,8 +822,17 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			if maxScroll > 0 {
 				pos = (item.Scroll.Y / maxScroll) * (size.Y - barH)
 			}
-			col := NewColor(96, 96, 96, 192)
 			sbW := currentStyle.BorderPad.Slider * 2
+			if len(item.ScrollMarks) > 0 {
+				for _, m := range item.ScrollMarks {
+					if m < 0 || m > 1 {
+						continue
+					}
+					y := drawRect.Y0 + m*size.Y
+					drawFilledRect(subImg, drawRect.X1-sbW, y, sbW, uiScale, NewColor(255, 255, 0, 255).ToRGBA(), false)
+				}
+			}
+			col := NewColor(96, 96, 96, 192)
 			drawFilledRect(subImg, drawRect.X1-sbW, drawRect.Y0+pos, sbW, barH, col.ToRGBA(), false)
 		} else if item.FlowType == FLOW_HORIZONTAL && req.X > size.X {
 			barW := size.X * size.X / req.X
@@ -1548,9 +1557,9 @@ func drawParallelogram(dst *ebiten.Image, x, y, w, h, slant float32, col color.C
 	for i := range vs {
 		vs[i].ColorR, vs[i].ColorG, vs[i].ColorB, vs[i].ColorA = colorToVec4(col)
 	}
-    // Use the cached 1x1 white sub-image to avoid allocating
-    // and to keep this path on unmanaged images when configured.
-    dst.DrawTriangles(vs, is, whiteSubImage, &ebiten.DrawTrianglesOptions{})
+	// Use the cached 1x1 white sub-image to avoid allocating
+	// and to keep this path on unmanaged images when configured.
+	dst.DrawTriangles(vs, is, whiteSubImage, &ebiten.DrawTrianglesOptions{})
 }
 
 func colorToVec4(c color.Color) (r, g, b, a float32) {

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -123,9 +123,10 @@ type itemData struct {
 
 	Hovered, Checked, Focused,
 	Disabled, Invisible bool
-	Clicked  time.Time
-	FlowType flowType
-	Scroll   point
+	Clicked     time.Time
+	FlowType    flowType
+	Scroll      point
+	ScrollMarks []float32
 
 	// Dropdown specific
 	Options    []string

--- a/text_window.go
+++ b/text_window.go
@@ -285,3 +285,26 @@ func showSpellSuggestions(t *eui.ItemData) {
 		}
 	}
 }
+
+// searchTextWindow highlights rows in the list containing the query string and
+// adds markers to the scrollbar for quick navigation. It clears highlights when
+// the query is empty.
+func searchTextWindow(win *eui.WindowData, list *eui.ItemData, query string) {
+	q := strings.ToLower(query)
+	total := len(list.Contents)
+	var marks []float32
+	for i, it := range list.Contents {
+		if q != "" && strings.Contains(strings.ToLower(it.Text), q) {
+			it.Filled = true
+			it.Color = eui.NewColor(255, 255, 0, 255)
+			marks = append(marks, float32(i)/float32(total))
+		} else {
+			it.Filled = false
+			it.Color = eui.Color{}
+		}
+	}
+	list.ScrollMarks = marks
+	if win != nil {
+		win.Refresh()
+	}
+}


### PR DESCRIPTION
## Summary
- add search box and highlight logic to console and chat windows
- render yellow highlights and scrollbar markers for matches
- support per-item scrollbar marks in EUI

## Testing
- `go test ./...` *(fails: compile version "go1.24.3" does not match go tool version "go1.25.0")*

------
https://chatgpt.com/codex/tasks/task_e_68ba4f2790c4832a9690cbbc1a991297