### PR TITLE
Add idle warning notification

### DIFF
--- a/console.go
+++ b/console.go
@@ -2,6 +2,7 @@ package main
 
 const (
 	maxMessages = 1000
+	sndTink     = 58 // notification sound
 )
 
 var consoleLog = messageLog{max: maxMessages}
@@ -10,7 +11,10 @@ func consoleMessage(msg string) {
 	if msg == "" {
 		return
 	}
-
+	if msg == "You have been idle for too long." {
+		showNotification(msg)
+		playSound([]uint16{sndTink})
+	}
 	consoleLog.Add(msg)
 	appendConsoleLog(msg)
 


### PR DESCRIPTION
## Summary
- play a tink sound and show a notification when the server warns about idling

## Testing
- `go test ./...` *(fails: Package alsa not found; Xrandr.h missing; gtk+-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba526e01d4832a8dfaa85c331bd697