### PR TITLE
Add accent color picker and use accent highlights

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -93,6 +93,9 @@ func updateInventoryWindow() {
 		return
 	}
 
+	accent := eui.Color{}
+	_ = accent.UnmarshalJSON([]byte("\"accent\""))
+
 	prevScroll := inventoryList.Scroll
 
 	// Build a unique list of items while counting duplicates and tracking
@@ -305,9 +308,7 @@ func updateInventoryWindow() {
 		}
 		if idCopy == selectedInvID && idxCopy == selectedInvIdx {
 			row.Filled = true
-			if inventoryWin != nil && inventoryWin.Theme != nil {
-				row.Color = inventoryWin.Theme.Button.SelectedColor
-			}
+			row.Color = accent
 		}
 		click := func() { handleInventoryClick(idCopy, idxCopy) }
 		icon.Action = click

--- a/players_ui.go
+++ b/players_ui.go
@@ -44,6 +44,9 @@ func updatePlayersWindow() {
 		return
 	}
 
+	accent := eui.Color{}
+	_ = accent.UnmarshalJSON([]byte("\"accent\""))
+
 	// Gather current players and filter to non-NPCs with names.
 	ps := getPlayers()
 	// Sort: online (recently seen and not explicitly offline) first,
@@ -185,9 +188,7 @@ func updatePlayersWindow() {
 		// Highlight if selected.
 		if p.Name == selectedPlayerName {
 			row.Filled = true
-			if playersWin != nil && playersWin.Theme != nil {
-				row.Color = playersWin.Theme.Button.SelectedColor
-			}
+			row.Color = accent
 		}
 
 		iconSize := int(rowUnits + 0.5)

--- a/text_window.go
+++ b/text_window.go
@@ -293,10 +293,12 @@ func searchTextWindow(win *eui.WindowData, list *eui.ItemData, query string) {
 	q := strings.ToLower(query)
 	total := len(list.Contents)
 	var marks []float32
+	accent := eui.Color{}
+	_ = accent.UnmarshalJSON([]byte("\"accent\""))
 	for i, it := range list.Contents {
 		if q != "" && strings.Contains(strings.ToLower(it.Text), q) {
 			it.Filled = true
-			it.Color = eui.NewColor(255, 255, 0, 255)
+			it.Color = accent
 			marks = append(marks, float32(i)/float32(total))
 		} else {
 			it.Filled = false

--- a/ui.go
+++ b/ui.go
@@ -2590,6 +2590,8 @@ func makeSettingsWindow() {
 		}
 	}
 
+	var accentWheel *eui.ItemData
+
 	themeDD, themeEvents := eui.NewDropdown()
 	themeDD.Label = "Color Theme"
 	if opts, err := eui.ListThemes(); err == nil {
@@ -2621,11 +2623,33 @@ func makeSettingsWindow() {
 				settingsDirty = true
 				settingsWin.Refresh()
 				updateDimmedScreenBG()
+				if accentWheel != nil {
+					var ac eui.Color
+					_ = ac.UnmarshalJSON([]byte("\"accent\""))
+					accentWheel.WheelColor = ac
+				}
 			}
 		}
 	}
+
+	accentWheel, accentEvents := eui.NewColorWheel()
+	accentWheel.Size = eui.Point{X: panelWidth, Y: 40}
+	var ac eui.Color
+	_ = ac.UnmarshalJSON([]byte("\"accent\""))
+	accentWheel.WheelColor = ac
+	accentEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventColorChanged {
+			settingsWin.Refresh()
+		}
+	}
+
 	left.AddItem(themeDD)
 	left.AddItem(styleDD)
+	accLabel, _ := eui.NewText()
+	accLabel.Text = "Accent Color"
+	accLabel.Size = eui.Point{X: panelWidth, Y: 20}
+	left.AddItem(accLabel)
+	left.AddItem(accentWheel)
 
 	label, _ = eui.NewText()
 	label.Text = "\nControls:"


### PR DESCRIPTION
## Summary
- add Accent Color swatch in settings for quick accent tweaking
- highlight search results, selected players, and inventory items with Accent color

## Testing
- `go test ./...` *(fails: Package alsa not found; X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5584e194832a87bfbdcce4cc408e