### PR TITLE
Use accent color for chat mentions

### DIFF
--- a/chat_messages_ui.go
+++ b/chat_messages_ui.go
@@ -26,7 +26,7 @@ func updateChatWindow() {
 	if chatList != nil {
 		for i, msg := range msgs {
 			if chatHasPlayerTag(msg) {
-				chatList.Contents[i].TextColor = eui.ColorBlue
+				chatList.Contents[i].TextColor = eui.AccentColor()
 				chatList.Contents[i].ForceTextColor = true
 			} else {
 				chatList.Contents[i].ForceTextColor = false

--- a/eui/public.go
+++ b/eui/public.go
@@ -167,6 +167,11 @@ func SetCurrentStyleName(name string) { currentStyleName = name }
 // AccentSaturation returns the current accent color saturation value.
 func AccentSaturation() float64 { return accentSaturation }
 
+// AccentColor returns the current accent color.
+func AccentColor() Color {
+	return Color(hsvaToRGBA(accentHue, accentSaturation, accentValue, accentAlpha))
+}
+
 // ClearFocus removes focus from the provided item if it is currently focused.
 func ClearFocus(it *ItemData) {
 	if focusedItem == it {


### PR DESCRIPTION
## Summary
- expose current accent color from eui
- use theme accent color when highlighting @mentions

## Testing
- `go test ./...` *(fails: Package alsa was not found in the pkg-config search path)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba566beb18832aade343d4b6c5a91d