### PR TITLE
Fix search close button

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -117,6 +117,7 @@ func Update() error {
 		sizeCh := posCh
 
 		var part dragType
+		handled := false
 		if dragPart != PART_NONE && dragWin == win {
 			part = dragPart
 		} else {
@@ -287,13 +288,36 @@ func Update() error {
 				}
 				break
 			}
+		} else if win.searchOpen {
+			if dragPart == PART_NONE && c == ebiten.CursorShapeDefault {
+				if win.searchBoxRect().containsPoint(mpos) {
+					c = ebiten.CursorShapeText
+				} else if win.searchCloseRect().containsPoint(mpos) {
+					c = ebiten.CursorShapePointer
+				}
+			}
+			if click && dragPart == PART_NONE && downWin == win {
+				if win.searchCloseRect().containsPoint(mpos) {
+					win.searchOpen = false
+					if activeSearch == win {
+						activeSearch = nil
+					}
+					win.markDirty()
+					handled = true
+				} else if win.searchBoxRect().containsPoint(mpos) {
+					activeSearch = win
+					handled = true
+				}
+			}
 		}
 
 		// Window items
 		prevWinHovered := win.Hovered
 		prevActiveWindow := activeWindow
 		win.Hovered = false
-		handled := win.clickWindowItems(mpos, click)
+		if !handled {
+			handled = win.clickWindowItems(mpos, click)
+		}
 		if win.Hovered != prevWinHovered {
 			win.markDirty()
 		}

--- a/eui/render.go
+++ b/eui/render.go
@@ -351,8 +351,19 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			top.ColorScale.ScaleWithColor(win.Theme.Window.TitleColor)
 			text.Draw(screen, win.SearchText, face, top)
 			cr := win.searchCloseRect()
-			strokeLine(screen, cr.X0+uiScale, cr.Y0+uiScale, cr.X1-uiScale, cr.Y1-uiScale, uiScale, win.Theme.Window.TitleColor, true)
-			strokeLine(screen, cr.X0+uiScale, cr.Y1-uiScale, cr.X1-uiScale, cr.Y0+uiScale, uiScale, win.Theme.Window.TitleColor, true)
+			xpad := (cr.X1 - cr.X0) / 3
+			strokeLine(screen,
+				cr.X0+xpad,
+				cr.Y0+xpad,
+				cr.X1-xpad,
+				cr.Y1-xpad,
+				uiScale, win.Theme.Window.TitleColor, true)
+			strokeLine(screen,
+				cr.X0+xpad,
+				cr.Y1-xpad,
+				cr.X1-xpad,
+				cr.Y0+xpad,
+				uiScale, win.Theme.Window.TitleColor, true)
 		}
 
 		//Close, Maximize, Search, and Pin icons


### PR DESCRIPTION
## Summary
- Make text search's close button work and update cursor handling
- Render search close icon with padding to match window close style

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68ba548ac44c832a8d4be4721db8f85d