### PR TITLE
Add optional harp beep for game notifications

### DIFF
--- a/beep.go
+++ b/beep.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+type beepSpec struct {
+	program int
+	key     int
+}
+
+var (
+	beepMu    sync.Mutex
+	beepCache = make(map[beepSpec][]byte)
+)
+
+// playBeep renders and plays a short note using the given program and key.
+// The note is cached after the first render.
+func playBeep(program, key int) {
+	if gs.Mute || !gs.GameSound || audioContext == nil {
+		return
+	}
+
+	spec := beepSpec{program: program, key: key}
+	beepMu.Lock()
+	pcm, ok := beepCache[spec]
+	beepMu.Unlock()
+	if !ok {
+		notes := []Note{{Key: key, Velocity: 120, Start: 0, Duration: 200 * time.Millisecond}}
+		left, right, err := renderSong(program, notes)
+		if err != nil {
+			return
+		}
+		pcm = mixPCM(left, right)
+		beepMu.Lock()
+		beepCache[spec] = pcm
+		beepMu.Unlock()
+	}
+
+	p := audioContext.NewPlayerFromBytes(pcm)
+	vol := gs.MasterVolume * gs.GameVolume
+	if gs.Mute {
+		vol = 0
+	}
+	p.SetVolume(vol)
+
+	soundMu.Lock()
+	for sp := range soundPlayers {
+		if !sp.IsPlaying() {
+			sp.Close()
+			delete(soundPlayers, sp)
+		}
+	}
+	if maxSounds > 0 && len(soundPlayers) >= maxSounds {
+		soundMu.Unlock()
+		logDebug("playBeep too many sound players (%d)", len(soundPlayers))
+		p.Close()
+		return
+	}
+	soundPlayers[p] = struct{}{}
+	soundMu.Unlock()
+	p.Play()
+}

--- a/mention_sound.go
+++ b/mention_sound.go
@@ -1,51 +1,5 @@
 package main
 
-import (
-	"sync"
-	"time"
-)
-
-var (
-	mentionOnce sync.Once
-	mentionPCM  []byte
-)
-
 func playMentionSound() {
-	if gs.Mute || !gs.GameSound {
-		return
-	}
-	mentionOnce.Do(func() {
-		notes := []Note{{Key: 84, Velocity: 120, Start: 0, Duration: 200 * time.Millisecond}}
-		left, right, err := renderSong(0, notes)
-		if err != nil {
-			return
-		}
-		mentionPCM = mixPCM(left, right)
-	})
-	if audioContext == nil || mentionPCM == nil {
-		return
-	}
-	p := audioContext.NewPlayerFromBytes(mentionPCM)
-	vol := gs.MasterVolume * gs.GameVolume
-	if gs.Mute {
-		vol = 0
-	}
-	p.SetVolume(vol)
-
-	soundMu.Lock()
-	for sp := range soundPlayers {
-		if !sp.IsPlaying() {
-			sp.Close()
-			delete(soundPlayers, sp)
-		}
-	}
-	if maxSounds > 0 && len(soundPlayers) >= maxSounds {
-		soundMu.Unlock()
-		logDebug("playMentionSound too many sound players (%d)", len(soundPlayers))
-		p.Close()
-		return
-	}
-	soundPlayers[p] = struct{}{}
-	soundMu.Unlock()
-	p.Play()
+	playBeep(0, 84)
 }

--- a/notifications.go
+++ b/notifications.go
@@ -21,6 +21,10 @@ func showNotification(msg string) {
 	if !gs.Notifications || gameWin == nil {
 		return
 	}
+	if gs.NotificationBeep {
+		// middle C harp beep
+		playBeep(46, 60)
+	}
 	btn, events := eui.NewButton()
 	btn.Text = msg
 	btn.FontSize = float32(gs.ChatFontSize)

--- a/settings.go
+++ b/settings.go
@@ -104,6 +104,7 @@ var gsdef settings = settings{
 	NotifyShares:          true,
 	NotifyFriendOnline:    true,
 	NotifyCopyText:        true,
+	NotificationBeep:      false,
 	NotificationDuration:  6,
 	PluginSpamKill:        true,
 	PromptOnSaveRecording: true,
@@ -199,6 +200,7 @@ type settings struct {
 	NotifyShares          bool
 	NotifyFriendOnline    bool
 	NotifyCopyText        bool
+	NotificationBeep      bool
 	NotificationDuration  float64
 	PluginSpamKill        bool
 	PromptOnSaveRecording bool

--- a/ui.go
+++ b/ui.go
@@ -4189,6 +4189,7 @@ func makeNotificationsWindow() {
 	addCB("Shares", &gs.NotifyShares)
 	addCB("Friend online", &gs.NotifyFriendOnline)
 	addCB("Text copied", &gs.NotifyCopyText)
+	addCB("Beep", &gs.NotificationBeep)
 
 	durSlider, durEvents := eui.NewSlider()
 	durSlider.Label = "Display Duration (sec)"


### PR DESCRIPTION
## Summary
- add reusable `playBeep` helper for cached single-note audio
- reuse helper for mention alerts
- play middle C harp when notification beep enabled

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./...` *(fails: Package alsa not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba571b5388832a89e5015839295a50