### PR TITLE
ensure user accent color overrides theme

### DIFF
--- a/eui/accent_color_test.go
+++ b/eui/accent_color_test.go
@@ -1,0 +1,16 @@
+package eui
+
+import "testing"
+
+// Test that setting the accent color updates the named "accent" color reference.
+func TestSetAccentColorUpdatesNamedColor(t *testing.T) {
+	namedColors = map[string]Color{}
+	SetAccentColor(NewColor(255, 0, 0, 255))
+	var c Color
+	if err := c.UnmarshalJSON([]byte("\"accent\"")); err != nil {
+		t.Fatalf("failed to unmarshal accent: %v", err)
+	}
+	if c != AccentColor() {
+		t.Fatalf("named accent %v does not match accent color %v", c, AccentColor())
+	}
+}

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -200,10 +200,16 @@ func SaveTheme(name string) error {
 // to all windows and widgets.
 func SetAccentColor(c Color) {
 	accentHue, _, accentValue, accentAlpha = rgbaToHSVA(color.RGBA(c))
+	if namedColors != nil {
+		namedColors["accent"] = AccentColor()
+	}
 }
 
 // SetAccentSaturation updates the saturation component of the accent color and
 // reapplies it to the current theme.
 func SetAccentSaturation(s float64) {
 	accentSaturation = clamp(s, 0, 1)
+	if namedColors != nil {
+		namedColors["accent"] = AccentColor()
+	}
 }


### PR DESCRIPTION
## Summary
- update `SetAccentColor`/`SetAccentSaturation` to sync named "accent" color with user selection
- add regression test for accent color mapping

## Testing
- `go test ./eui` *(fails: X11/extensions/Xrandr.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ba5c1ac614832a8a10a77debcc1db0