### PR TITLE
Preserve players list scroll on refresh

### DIFF
--- a/players_ui.go
+++ b/players_ui.go
@@ -47,6 +47,8 @@ func updatePlayersWindow() {
 	accent := eui.Color{}
 	_ = accent.UnmarshalJSON([]byte("\"accent\""))
 
+	prevScroll := playersList.Scroll
+
 	// Gather current players and filter to non-NPCs with names.
 	ps := getPlayers()
 	// Sort: online (recently seen and not explicitly offline) first,
@@ -287,6 +289,7 @@ func updatePlayersWindow() {
 	}
 	playersList.Size.X = clientWAvail
 	playersList.Size.Y = clientHAvail
+	playersList.Scroll = prevScroll
 	playersWin.Refresh()
 }
 


### PR DESCRIPTION
## Summary
- Preserve players window scroll position across refreshes

## Testing
- `go test ./...` *(fails: Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5c4baf5c832aad5d2bdff4a01718