### PR TITLE
Customize notification tones

### DIFF
--- a/notifications.go
+++ b/notifications.go
@@ -17,13 +17,18 @@ var notifications []*notification
 
 // showNotification displays msg in the Clan Lord window if notifications are
 // enabled. Messages disappear after a timeout or when clicked.
-func showNotification(msg string) {
+// Optional note keys can be provided to customize the notification sound.
+func showNotification(msg string, keys ...int) {
 	if !gs.Notifications || gameWin == nil {
 		return
 	}
 	if gs.NotificationBeep {
-		// middle C harp beep
-		playBeep(46, 60)
+		if len(keys) == 0 {
+			// middle C harp beep
+			playBeep(46, 60)
+		} else {
+			playHarpNotes(keys...)
+		}
 	}
 	btn, events := eui.NewButton()
 	btn.Text = msg

--- a/text_parsers.go
+++ b/text_parsers.go
@@ -369,7 +369,7 @@ func parseFallenText(raw []byte, s string) bool {
 				playersDirty = true
 			}
 			if gs.NotifyFallen {
-				showNotification(playerName + " has fallen")
+				showNotification(playerName+" has fallen", 72, 69, 65)
 			}
 			return true
 		}
@@ -389,7 +389,7 @@ func parseFallenText(raw []byte, s string) bool {
 				playersDirty = true
 			}
 			if gs.NotifyNotFallen {
-				showNotification(playerName + " is no longer fallen")
+				showNotification(playerName+" is no longer fallen", 60, 64, 67)
 			}
 			return true
 		}
@@ -419,7 +419,7 @@ func parseFallenText(raw []byte, s string) bool {
 		playersDirty = true
 		notifyPlayerHandlers(playerCopy)
 		if gs.NotifyFallen {
-			showNotification(name + " has fallen")
+			showNotification(name+" has fallen", 72, 69, 65)
 		}
 		return true
 	}
@@ -449,7 +449,7 @@ func parseFallenText(raw []byte, s string) bool {
 			playersDirty = true
 		}
 		if gs.NotifyNotFallen {
-			showNotification(name + " is no longer fallen")
+			showNotification(name+" is no longer fallen", 60, 64, 67)
 		}
 		return true
 	}
@@ -503,7 +503,7 @@ func parsePresenceText(raw []byte, s string) bool {
 			notifyPlayerHandlers(playerCopy)
 		}
 		if friend && gs.NotifyFriendOnline {
-			showNotification(name + " is online")
+			showNotification(name+" is online", 84, 84)
 		}
 		return true
 	}


### PR DESCRIPTION
## Summary
- add `playHarpNotes` to play short harp note sequences
- allow `showNotification` to use custom note sequences
- use descending, ascending, and double high-C tones for fallen, not fallen, and friend online alerts

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `go test ./...` *(fails: chat_tts_substitute.go:4:2: "embed" imported and not used)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5dc5a890832aa0930e70212433e5