### PR TITLE
Add notification volume slider

### DIFF
--- a/beep.go
+++ b/beep.go
@@ -39,7 +39,7 @@ func playBeep(program, key int) {
 	}
 
 	p := audioContext.NewPlayerFromBytes(pcm)
-	vol := gs.MasterVolume * gs.GameVolume
+	vol := gs.MasterVolume * gs.NotificationVolume
 	if gs.Mute {
 		vol = 0
 	}
@@ -60,6 +60,11 @@ func playBeep(program, key int) {
 	}
 	soundPlayers[p] = struct{}{}
 	soundMu.Unlock()
+
+	notifPlayersMu.Lock()
+	notifPlayers[p] = struct{}{}
+	notifPlayersMu.Unlock()
+
 	p.Play()
 }
 
@@ -84,7 +89,7 @@ func playHarpNotes(keys ...int) {
 	}
 	pcm := mixPCM(left, right)
 	p := audioContext.NewPlayerFromBytes(pcm)
-	vol := gs.MasterVolume * gs.GameVolume
+	vol := gs.MasterVolume * gs.NotificationVolume
 	if gs.Mute {
 		vol = 0
 	}
@@ -105,5 +110,10 @@ func playHarpNotes(keys ...int) {
 	}
 	soundPlayers[p] = struct{}{}
 	soundMu.Unlock()
+
+	notifPlayersMu.Lock()
+	notifPlayers[p] = struct{}{}
+	notifPlayersMu.Unlock()
+
 	p.Play()
 }

--- a/settings.go
+++ b/settings.go
@@ -104,6 +104,7 @@ var gsdef settings = settings{
 	NotifyShares:          true,
 	NotifyFriendOnline:    true,
 	NotifyCopyText:        true,
+	NotificationVolume:    0.6,
 	NotificationBeep:      false,
 	NotificationDuration:  6,
 	PluginSpamKill:        true,
@@ -200,6 +201,7 @@ type settings struct {
 	NotifyShares          bool
 	NotifyFriendOnline    bool
 	NotifyCopyText        bool
+	NotificationVolume    float64
 	NotificationBeep      bool
 	NotificationDuration  float64
 	PluginSpamKill        bool

--- a/ui.go
+++ b/ui.go
@@ -109,10 +109,12 @@ var (
 	gameMixSlider     *eui.ItemData
 	musicMixSlider    *eui.ItemData
 	ttsMixSlider      *eui.ItemData
+	notifMixSlider    *eui.ItemData
 	mixMuteBtn        *eui.ItemData
 	gameMixCB         *eui.ItemData
 	musicMixCB        *eui.ItemData
 	ttsMixCB          *eui.ItemData
+	notifMixCB        *eui.ItemData
 )
 
 var ttsTestPhrase = "The quick brown fox jumps over the lazy dog"
@@ -976,6 +978,25 @@ func makeMixerWindow() {
 				} else {
 					disableTTS()
 				}
+			}
+		})
+
+	addSpacer()
+
+	notifMixSlider, notifMixCB = makeMix(gs.NotificationVolume, gs.NotificationBeep, "Notif",
+		func(ev eui.UIEvent) {
+			if ev.Type == eui.EventSliderChanged {
+				gs.NotificationVolume = float64(ev.Value)
+				settingsDirty = true
+				updateSoundVolume()
+			}
+		},
+		func(ev eui.UIEvent) {
+			if ev.Type == eui.EventCheckboxChanged {
+				gs.NotificationBeep = ev.Checked
+				notifMixSlider.Disabled = !ev.Checked
+				settingsDirty = true
+				updateSoundVolume()
 			}
 		})
 
@@ -4191,6 +4212,9 @@ func makeNotificationsWindow() {
 			if ev.Type == eui.EventCheckboxChanged {
 				*val = ev.Checked
 				settingsDirty = true
+				if val == &gs.NotificationBeep {
+					updateSoundVolume()
+				}
 			}
 		}
 		flow.AddItem(cb)


### PR DESCRIPTION
## Summary
- allow configuring notification sound level
- track notification audio players separately
- expose notification volume control in the mixer UI

## Testing
- `go test ./...` *(fails: Package alsa not found; Xrandr.h missing)*
- `sudo apt-get update && sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils` *(failed: waiting for headers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba61a5714c832a865966d543a0ba17