### PR TITLE
Use accent color helper

### DIFF
--- a/inventory_ui.go
+++ b/inventory_ui.go
@@ -95,8 +95,7 @@ func updateInventoryWindow() {
 		return
 	}
 
-	accent := eui.Color{}
-	_ = accent.UnmarshalJSON([]byte("\"accent\""))
+	accent := eui.AccentColor()
 
 	prevScroll := inventoryList.Scroll
 

--- a/players_ui.go
+++ b/players_ui.go
@@ -44,8 +44,7 @@ func updatePlayersWindow() {
 		return
 	}
 
-	accent := eui.Color{}
-	_ = accent.UnmarshalJSON([]byte("\"accent\""))
+	accent := eui.AccentColor()
 
 	prevScroll := playersList.Scroll
 

--- a/text_window.go
+++ b/text_window.go
@@ -293,8 +293,7 @@ func searchTextWindow(win *eui.WindowData, list *eui.ItemData, query string) {
 	q := strings.ToLower(query)
 	total := len(list.Contents)
 	var marks []float32
-	accent := eui.Color{}
-	_ = accent.UnmarshalJSON([]byte("\"accent\""))
+	accent := eui.AccentColor()
 	for i, it := range list.Contents {
 		if q != "" && strings.Contains(strings.ToLower(it.Text), q) {
 			it.Filled = true


### PR DESCRIPTION
## Summary
- Use `eui.AccentColor` for selections in player and inventory lists
- Apply the accent helper when highlighting search results

## Testing
- `go test ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba648f0b6c832abbdfc3eb9328a50b