### PR TITLE
Document custom themes and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ Approximately 45,000 lines of Go code.
 - On first run, the client **auto-fetches missing game assets** (images, sounds) into `data/`. No manual wrangling.
 
 ### Optional extras
-- Drop a `background.png` and/or `splash.png` into `data/` for a custom look.
+- **Background and splash images** – place `background.png` and/or `splash.png` in `data/` to override the default visuals.
+- **Sound font** – drop a `soundfont.sf2` file into `data/` to change the music instrument set. The Download Files window can fetch a suitable one.
+- **TTS voices** – voice archives (`.tar.gz`) or `.onnx` models with matching `.onnx.json` configs belong in `data/piper/voices`. Use `build-scripts/download_piper.sh` or the Download Files window to grab voices from online collections.
+
+### Custom themes and styles
+Themes live in `themes/palettes` and styles in `themes/styles`. On first run the client writes an `Example.json` palette and style plus a README explaining the format. Copy these files, adjust the colors or geometry, and select your new theme in Settings. With `eui.AutoReload = true` changes on disk are picked up automatically.
 
 ### Text-to-speech voices
 Piper voices are stored in `data/piper/voices`. The client and `build-scripts/download_piper.sh` support voice archives in `.tar.gz` format and automatically extract and remove the archives. If a voice archive isn't available, the program falls back to downloading raw `.onnx` models with matching `.onnx.json` configs.

--- a/eui/init_default.go
+++ b/eui/init_default.go
@@ -11,4 +11,5 @@ func init() {
 	if err := LoadStyle(currentStyleName); err != nil {
 		log.Printf("LoadStyle error: %v", err)
 	}
+	ensureThemeDocs()
 }

--- a/eui/theme_docs.go
+++ b/eui/theme_docs.go
@@ -1,0 +1,48 @@
+package eui
+
+import (
+	"embed"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+//go:embed themes/README.md
+var themeReadme []byte
+
+func ensureThemeDocs() {
+	// README
+	path := filepath.Join("themes", "README.md")
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll("themes", 0755); err == nil {
+			if err := os.WriteFile(path, themeReadme, 0644); err != nil {
+				log.Printf("write theme README: %v", err)
+			}
+		}
+	}
+
+	// example palette
+	palette := filepath.Join("themes", "palettes", "Example.json")
+	if _, err := os.Stat(palette); errors.Is(err, os.ErrNotExist) {
+		if data, err := embeddedThemes.ReadFile("themes/palettes/Example.json"); err == nil {
+			if err := os.MkdirAll(filepath.Dir(palette), 0755); err == nil {
+				if err := os.WriteFile(palette, data, 0644); err != nil {
+					log.Printf("write example palette: %v", err)
+				}
+			}
+		}
+	}
+
+	// example style
+	style := filepath.Join("themes", "styles", "Example.json")
+	if _, err := os.Stat(style); errors.Is(err, os.ErrNotExist) {
+		if data, err := embeddedStyles.ReadFile("themes/styles/Example.json"); err == nil {
+			if err := os.MkdirAll(filepath.Dir(style), 0755); err == nil {
+				if err := os.WriteFile(style, data, 0644); err != nil {
+					log.Printf("write example style: %v", err)
+				}
+			}
+		}
+	}
+}

--- a/eui/themes/README.md
+++ b/eui/themes/README.md
@@ -90,3 +90,11 @@ Use `eui.ListThemes()` and `eui.ListStyles()` to get these names at runtime.
 3. Save the file under the appropriate directory with a new name.
 4. Call `eui.LoadTheme("YourTheme")` and `eui.LoadStyle("YourStyle")` to apply them. Enabling `eui.AutoReload` helps when iterating on your design.
 
+On first run the client writes an `Example.json` palette and style alongside this README. Copy and modify them to get started quickly.
+
+## Other Customizations
+
+- **Background and splash images** – place `background.png` and/or `splash.png` in the `data/` directory to override the startup visuals.
+- **Sound font** – drop a `soundfont.sf2` file into `data/` to replace the default music instrument set. The Download Files window can fetch a recommended one or you can supply any General MIDI sound font.
+- **TTS voices** – download Piper voices ( `.tar.gz` archives or `.onnx` with matching `.onnx.json`) and place them in `data/piper/voices`. Use the Download Files window for English voices or fetch others from online voice collections.
+

--- a/eui/themes/palettes/Example.json
+++ b/eui/themes/palettes/Example.json
@@ -1,0 +1,23 @@
+{
+  "Comment": "Example theme for customization",
+  "Colors": {
+    "background": "#202020",
+    "panel": "#303030",
+    "accent": "#ffd700"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "ActiveColor": "accent"
+  },
+  "Button": { "TextColor": "accent", "Color": "panel", "HoverColor": "accent" },
+  "Text": { "TextColor": "accent", "Color": "panel" },
+  "Checkbox": { "TextColor": "accent", "Color": "panel" },
+  "Radio": { "TextColor": "accent", "Color": "panel" },
+  "Input": { "TextColor": "accent", "Color": "panel" },
+  "Slider": { "TextColor": "accent", "Color": "panel", "SliderFilled": "accent" },
+  "Dropdown": { "TextColor": "accent", "Color": "panel", "SelectedColor": "accent" },
+  "Tab": { "TextColor": "accent", "Color": "panel", "SelectedColor": "accent" },
+  "RecommendedStyle": "Example"
+}

--- a/eui/themes/styles/Example.json
+++ b/eui/themes/styles/Example.json
@@ -1,0 +1,7 @@
+{
+  "TextPadding": 8,
+  "Fillet": { "Button": 6, "Input": 6, "Tab": 6 },
+  "Border": { "Button": 1, "Input": 1, "Tab": 1 },
+  "Filled": { "Button": true, "Input": true, "Tab": true },
+  "Outlined": { "Button": true, "Input": true, "Tab": true }
+}


### PR DESCRIPTION
## Summary
- embed themes README and example palette/style and ensure they're written to disk on startup
- add Example theme and style JSON files
- document how to customize themes, background/splash images, sound font, and TTS voices

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go build ./eui` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6404e140832a92d1b81e6a1280ba