### PR TITLE
Consume keystrokes in active search boxes

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -537,56 +537,56 @@ func Update() error {
 			activeSearch.markDirty()
 			activeSearch = nil
 		}
-	}
-
-	if inpututil.IsKeyJustPressed(ebiten.KeyEnter) || inpututil.IsKeyJustPressed(ebiten.KeyKPEnter) {
-		if activeWindow != nil && activeWindow.Open && activeWindow.DefaultButton != nil {
-			btn := activeWindow.DefaultButton
-			if !btn.Disabled && !btn.Invisible {
-				activeItem = btn
-				btn.Clicked = time.Now()
-				if btn.Handler != nil {
-					btn.Handler.Emit(UIEvent{Item: btn, Type: EventClick})
+	} else {
+		if inpututil.IsKeyJustPressed(ebiten.KeyEnter) || inpututil.IsKeyJustPressed(ebiten.KeyKPEnter) {
+			if activeWindow != nil && activeWindow.Open && activeWindow.DefaultButton != nil {
+				btn := activeWindow.DefaultButton
+				if !btn.Disabled && !btn.Invisible {
+					activeItem = btn
+					btn.Clicked = time.Now()
+					if btn.Handler != nil {
+						btn.Handler.Emit(UIEvent{Item: btn, Type: EventClick})
+					}
+					btn.markDirty()
 				}
-				btn.markDirty()
 			}
 		}
-	}
 
-	if inpututil.IsKeyJustPressed(ebiten.KeyTab) {
-		if activeWindow != nil && activeWindow.Open {
-			var inputs []*itemData
-			collectInputs(activeWindow.Contents, &inputs)
-			if len(inputs) > 0 {
-				idx := -1
-				for i, it := range inputs {
-					if it == focusedItem {
-						idx = i
-						break
+		if inpututil.IsKeyJustPressed(ebiten.KeyTab) {
+			if activeWindow != nil && activeWindow.Open {
+				var inputs []*itemData
+				collectInputs(activeWindow.Contents, &inputs)
+				if len(inputs) > 0 {
+					idx := -1
+					for i, it := range inputs {
+						if it == focusedItem {
+							idx = i
+							break
+						}
 					}
-				}
-				next := 0
-				if ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight) {
-					if idx == -1 {
-						next = len(inputs) - 1
+					next := 0
+					if ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight) {
+						if idx == -1 {
+							next = len(inputs) - 1
+						} else {
+							next = (idx - 1 + len(inputs)) % len(inputs)
+						}
 					} else {
-						next = (idx - 1 + len(inputs)) % len(inputs)
+						if idx == -1 {
+							next = 0
+						} else {
+							next = (idx + 1) % len(inputs)
+						}
 					}
-				} else {
-					if idx == -1 {
-						next = 0
-					} else {
-						next = (idx + 1) % len(inputs)
+					if focusedItem != nil {
+						focusedItem.Focused = false
+						focusedItem.markDirty()
 					}
-				}
-				if focusedItem != nil {
-					focusedItem.Focused = false
+					focusedItem = inputs[next]
+					focusedItem.CursorPos = len([]rune(focusedItem.Text))
+					focusedItem.Focused = true
 					focusedItem.markDirty()
 				}
-				focusedItem = inputs[next]
-				focusedItem.CursorPos = len([]rune(focusedItem.Text))
-				focusedItem.Focused = true
-				focusedItem.markDirty()
 			}
 		}
 	}
@@ -1542,4 +1542,9 @@ func scrollContextMenus(mpos point, delta point) bool {
 		}
 	}
 	return false
+}
+
+// SearchActive reports whether a window search box currently has focus.
+func SearchActive() bool {
+	return activeSearch != nil
 }

--- a/eui/search_test.go
+++ b/eui/search_test.go
@@ -1,0 +1,11 @@
+//go:build test
+
+package eui
+
+// SetActiveSearchForTest sets the active search window for tests.
+func SetActiveSearchForTest(win *WindowData) {
+	activeSearch = win
+	if win != nil {
+		win.searchOpen = true
+	}
+}

--- a/input_ui.go
+++ b/input_ui.go
@@ -86,6 +86,9 @@ func pointInItems(items []*eui.ItemData, fx, fy float32) bool {
 // typingInUI reports whether any EUI text input other than the console input bar
 // currently has focus.
 func typingInUI() bool {
+	if eui.SearchActive() {
+		return true
+	}
 	var inputItem *eui.ItemData
 	if inputFlow != nil && len(inputFlow.Contents) > 0 {
 		inputItem = inputFlow.Contents[0]

--- a/input_ui_test.go
+++ b/input_ui_test.go
@@ -66,3 +66,17 @@ func TestTypingInUI(t *testing.T) {
 		t.Fatalf("typingInUI should detect focused input")
 	}
 }
+
+func TestTypingInUISearch(t *testing.T) {
+	for _, w := range eui.Windows() {
+		w.Close()
+	}
+	win := eui.NewWindow()
+	win.Searchable = true
+	win.MarkOpen()
+	eui.SetActiveSearchForTest(win)
+	if !typingInUI() {
+		t.Fatalf("typingInUI should detect active search")
+	}
+	eui.SetActiveSearchForTest(nil)
+}


### PR DESCRIPTION
## Summary
- Ensure window search boxes capture keystrokes and block default button or tab actions
- Expose search focus state and have UI typing checks respect it
- Test that active search fields count as typing input

## Testing
- `go test ./...` *(fails: missing X11 and ALSA development packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ba69ce6a78832aa2b82be4f15de1a6