### PR TITLE
Use accent color for search scrollbar markers

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -835,12 +835,13 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			}
 			sbW := currentStyle.BorderPad.Slider * 2
 			if len(item.ScrollMarks) > 0 {
+				markCol := AccentColor().ToRGBA()
 				for _, m := range item.ScrollMarks {
 					if m < 0 || m > 1 {
 						continue
 					}
 					y := drawRect.Y0 + m*size.Y
-					drawFilledRect(subImg, drawRect.X1-sbW, y, sbW, uiScale, NewColor(255, 255, 0, 255).ToRGBA(), false)
+					drawFilledRect(subImg, drawRect.X1-sbW, y, sbW, uiScale, markCol, false)
 				}
 			}
 			col := NewColor(96, 96, 96, 192)


### PR DESCRIPTION
## Summary
- use theme accent color for search result markers on scrollbars

## Testing
- `go test ./...` *(fails: missing Xrandr headers and ALSA/GTK libs)*

------
https://chatgpt.com/codex/tasks/task_e_68ba69167d3c832aa1c93131d1ba7d9b