### PR TITLE
Clear search focus for accent highlight

### DIFF
--- a/text_window.go
+++ b/text_window.go
@@ -295,6 +295,7 @@ func searchTextWindow(win *eui.WindowData, list *eui.ItemData, query string) {
 	var marks []float32
 	accent := eui.AccentColor()
 	for i, it := range list.Contents {
+		it.Focused = false
 		if q != "" && strings.Contains(strings.ToLower(it.Text), q) {
 			it.Filled = true
 			it.Color = accent


### PR DESCRIPTION
## Summary
- Reset focused state before applying search highlight so chat and console searches use the accent-colored fill like players and inventory

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz && tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./...` *(fails: Package alsa was not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c791724832a857121e69967f7a2