### PR TITLE
Use accent color for search highlights

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1107,7 +1107,10 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		//Text
 	} else if item.ItemType == ITEM_INPUT {
 
-		itemColor := style.Color
+		itemColor := item.Color
+		if itemColor == (Color{}) {
+			itemColor = style.Color
+		}
 		if item.Focused {
 			itemColor = style.ClickColor
 		} else if item.Hovered {
@@ -1393,7 +1396,10 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		}
 	} else if item.ItemType == ITEM_TEXT {
 
-		itemColor := style.Color
+		itemColor := item.Color
+		if itemColor == (Color{}) {
+			itemColor = style.Color
+		}
 		if item.Focused {
 			itemColor = style.ClickColor
 		} else if item.Hovered {


### PR DESCRIPTION
## Summary
- Render text items with their custom Color value so search results use the accent color in chat and console windows

## Testing
- `go test ./eui/...` *(fails: Package 'alsa' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6df345dc832aa53a6a5ca07d9fb3