### PR TITLE
Clear search when search box closes

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -161,17 +161,17 @@ func Update() error {
 					break
 				}
 				if part == PART_SEARCH {
-					win.searchOpen = !win.searchOpen
 					if win.searchOpen {
+						win.closeSearch()
+					} else {
+						win.searchOpen = true
 						win.SearchText = ""
 						activeSearch = win
 						if win.OnSearch != nil {
-							win.OnSearch(win.SearchText)
+							win.OnSearch("")
 						}
-					} else if activeSearch == win {
-						activeSearch = nil
+						win.markDirty()
 					}
-					win.markDirty()
 					break
 				}
 				if part == PART_PIN {
@@ -210,11 +210,7 @@ func Update() error {
 						}
 						if click && dragPart == PART_NONE && downWin == win {
 							if win.searchCloseRect().containsPoint(mpos) {
-								win.searchOpen = false
-								if activeSearch == win {
-									activeSearch = nil
-								}
-								win.markDirty()
+								win.closeSearch()
 								break
 							}
 							if win.searchBoxRect().containsPoint(mpos) {
@@ -298,11 +294,7 @@ func Update() error {
 			}
 			if click && dragPart == PART_NONE && downWin == win {
 				if win.searchCloseRect().containsPoint(mpos) {
-					win.searchOpen = false
-					if activeSearch == win {
-						activeSearch = nil
-					}
-					win.markDirty()
+					win.closeSearch()
 					handled = true
 				} else if win.searchBoxRect().containsPoint(mpos) {
 					activeSearch = win

--- a/eui/searchbox_close_test.go
+++ b/eui/searchbox_close_test.go
@@ -1,0 +1,22 @@
+package eui
+
+import "testing"
+
+func TestCloseSearchClearsState(t *testing.T) {
+	win := &WindowData{Searchable: true, searchOpen: true, SearchText: "hi"}
+	activeSearch = win
+	var cb string
+	win.OnSearch = func(s string) { cb = s }
+
+	win.closeSearch()
+
+	if win.SearchText != "" {
+		t.Fatalf("expected empty SearchText, got %q", win.SearchText)
+	}
+	if cb != "" {
+		t.Fatalf("expected OnSearch callback with empty string, got %q", cb)
+	}
+	if activeSearch != nil {
+		t.Fatalf("expected activeSearch to be nil")
+	}
+}

--- a/eui/util.go
+++ b/eui/util.go
@@ -279,6 +279,19 @@ func (win *windowData) searchCloseRect() rect {
 	return rect{X0: sb.X1 - h, Y0: sb.Y0, X1: sb.X1, Y1: sb.Y1}
 }
 
+// closeSearch resets the search state and clears highlights.
+func (win *windowData) closeSearch() {
+	win.searchOpen = false
+	if activeSearch == win {
+		activeSearch = nil
+	}
+	win.SearchText = ""
+	if win.OnSearch != nil {
+		win.OnSearch("")
+	}
+	win.markDirty()
+}
+
 func (win *windowData) dragbarRect() rect {
 	if win.TitleHeight <= 0 && !win.Resizable {
 		return rect{}


### PR DESCRIPTION
## Summary
- reset search text and notify callbacks when closing a window's search box
- add unit test verifying search state is cleared

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ba6f389070832a915d18543ddc518a