### PR TITLE
Add bundle link and patrons section

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
       <div class="brand">goThoom</div>
       <nav class="nav">
         <a class="btn" href="https://github.com/Distortions81/goThoom/releases" target="_blank" rel="noopener">Downloads</a>
+        <a class="btn" href="https://m45sci.xyz/u/dist/goThoom" target="_blank" rel="noopener">Bundle</a>
         <a class="btn" href="https://discord.gg/CJ42npkVNd" target="_blank" rel="noopener">Discord</a>
         <a class="btn" href="https://github.com/Distortions81/goThoom" target="_blank" rel="noopener">GitHub</a>
         <a class="btn" href="https://www.patreon.com/c/goThoom" target="_blank" rel="noopener">Patreon</a>
@@ -111,6 +112,14 @@
       <p>
         Connect with other players on <a href="https://discord.gg/CJ42npkVNd" target="_blank" rel="noopener">Discord</a>, track development and contribute on <a href="https://github.com/Distortions81/goThoom" target="_blank" rel="noopener">GitHub</a>, or support ongoing progress via <a href="https://www.patreon.com/c/goThoom" target="_blank" rel="noopener">Patreon</a>.
       </p>
+    </section>
+
+    <section class="card" style="margin-top:40px;">
+      <h2>Patrons</h2>
+      <p>Supporters who help keep goThoom development going:</p>
+      <ul class="list" id="patrons">
+        <!-- Patreon names will be added here -->
+      </ul>
     </section>
 
     <footer>


### PR DESCRIPTION
## Summary
- link to prebuilt bundle in navigation bar
- reserve section for Patreon supporter names

## Testing
- `go build && echo build OK`


------
https://chatgpt.com/codex/tasks/task_e_68bad92af084832a999919dc77cb0318