### PR TITLE
Add joystick settings and window

### DIFF
--- a/joystick.go
+++ b/joystick.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"gothoom/eui"
+)
+
+var joystickWin *eui.WindowData
+
+func makeJoystickWindow() {
+	if joystickWin != nil {
+		return
+	}
+	joystickWin = eui.NewWindow()
+	joystickWin.Title = "Joystick"
+	joystickWin.Closable = true
+	joystickWin.Movable = true
+	joystickWin.Resizable = true
+	joystickWin.AutoSize = true
+	joystickWin.NoScroll = true
+	joystickWin.SetZone(eui.HZoneCenter, eui.VZoneMiddleTop)
+
+	root := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	root.Size = eui.Point{X: 300, Y: 200}
+	joystickWin.AddItem(root)
+
+	ids := ebiten.AppendGamepadIDs(nil)
+	names := make([]string, len(ids))
+	for i, id := range ids {
+		names[i] = ebiten.GamepadName(id)
+	}
+
+	controllerDD, controllerEvents := eui.NewDropdown()
+	controllerDD.Options = names
+	controllerDD.Size = eui.Point{X: 260, Y: 24}
+	root.AddItem(controllerDD)
+
+	axesText, _ := eui.NewText()
+	buttonsText, _ := eui.NewText()
+
+	updateInfo := func(idx int) {
+		if idx < 0 || idx >= len(ids) {
+			axesText.Text = ""
+			buttonsText.Text = ""
+			return
+		}
+		id := ids[idx]
+		axesText.Text = fmt.Sprintf("Axes: %d", ebiten.GamepadAxisCount(id))
+		buttonsText.Text = fmt.Sprintf("Buttons: %d", ebiten.GamepadButtonCount(id))
+	}
+	updateInfo(0)
+	controllerEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventDropdownSelected {
+			updateInfo(ev.Index)
+		}
+	}
+
+	root.AddItem(axesText)
+	root.AddItem(buttonsText)
+
+	enableCB, enableEvents := eui.NewCheckbox()
+	enableCB.Text = "Enable Joystick"
+	enableCB.Checked = gs.JoystickEnabled
+	enableEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.JoystickEnabled = ev.Checked
+			settingsDirty = true
+		}
+	}
+	root.AddItem(enableCB)
+
+	bindInput, bindEvents := eui.NewInput()
+	bindInput.Label = "Binding (action:button)"
+	bindInput.Size = eui.Point{X: 260, Y: 24}
+	bindEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventInputFinished {
+			parts := strings.SplitN(ev.Text, ":", 2)
+			if len(parts) == 2 {
+				if b, err := strconv.Atoi(parts[1]); err == nil {
+					if gs.JoystickBindings == nil {
+						gs.JoystickBindings = make(map[string]ebiten.GamepadButton)
+					}
+					gs.JoystickBindings[parts[0]] = ebiten.GamepadButton(b)
+					settingsDirty = true
+				}
+			}
+		}
+	}
+	root.AddItem(bindInput)
+
+	joystickWin.AddWindow(false)
+}

--- a/settings.go
+++ b/settings.go
@@ -112,6 +112,8 @@ var gsdef settings = settings{
 	TimestampFormat:       "3:04PM",
 	LastUpdateCheck:       time.Time{},
 	NotifiedVersion:       0,
+	JoystickBindings:      map[string]ebiten.GamepadButton{},
+	JoystickEnabled:       false,
 
 	GameWindow:      WindowState{Open: true},
 	InventoryWindow: WindowState{Open: true},
@@ -214,6 +216,9 @@ type settings struct {
 	WindowTiling          bool
 	WindowSnapping        bool
 	ShowPinToLocations    bool
+
+	JoystickEnabled  bool
+	JoystickBindings map[string]ebiten.GamepadButton
 
 	WindowWidth  int
 	WindowHeight int
@@ -328,6 +333,10 @@ func loadSettings() bool {
 
 	if gs.ChatTTSBlocklist == nil {
 		gs.ChatTTSBlocklist = append([]string(nil), gsdef.ChatTTSBlocklist...)
+	}
+
+	if gs.JoystickBindings == nil {
+		gs.JoystickBindings = make(map[string]ebiten.GamepadButton)
 	}
 
 	if gs.DenoiseAmount < 0 || gs.DenoiseAmount > 1 {

--- a/ui.go
+++ b/ui.go
@@ -192,6 +192,7 @@ func initUI() {
 	makeShortcutsWindow()
 	makeHotkeysWindow()
 	makeTriggersWindow()
+	makeJoystickWindow()
 	makePluginsWindow()
 	makeMixerWindow()
 	makeToolbar()
@@ -2896,6 +2897,19 @@ func makeSettingsWindow() {
 		}
 	}
 	left.AddItem(bubbleBtn)
+
+	joystickBtn, joystickEvents := eui.NewButton()
+	joystickBtn.Text = "Joystick"
+	joystickBtn.Size = eui.Point{X: panelWidth, Y: 24}
+	joystickEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			SettingsLock.Lock()
+			defer SettingsLock.Unlock()
+
+			joystickWin.ToggleNear(ev.Item)
+		}
+	}
+	left.AddItem(joystickBtn)
 
 	label, _ = eui.NewText()
 	label.Text = "\nStatus Bar Options:"


### PR DESCRIPTION
## Summary
- Add joystick button in Settings to open new joystick window
- Implement joystick window listing controllers and bindings
- Persist joystick bindings and enable flag in settings

## Testing
- `go test ./...` *(fails: compile: version "go1.24.3" does not match go tool version "go1.25.0")*

------
https://chatgpt.com/codex/tasks/task_e_68bad93e5d24832a9c446881281eb907