### PR TITLE
Add website link and Patreon section to about window

### DIFF
--- a/about_ui.go
+++ b/about_ui.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	_ "embed"
+	"encoding/json"
+	"image"
+	_ "image/png"
+	"net/http"
 	"strings"
 
+	ebiten "github.com/hajimehoshi/ebiten/v2"
+	"github.com/pkg/browser"
 	"gothoom/eui"
 )
 
@@ -14,14 +20,49 @@ var aboutWin *eui.WindowData
 var aboutList *eui.ItemData
 var aboutLines []string
 
+var patreonBox *eui.ItemData
+var patreonList *eui.ItemData
+
+const patreonsURL = "https://m45sci.xyz/u/dist/goThoom/patreons.json"
+
 func initAboutUI() {
 	if aboutWin != nil {
 		return
 	}
 	aboutWin, aboutList, _ = makeTextWindow("About", eui.HZoneCenter, eui.VZoneMiddleTop, false)
 	aboutWin.AutoSize = true
+
+	flow := aboutList.Parent
+
+	linkBtn, linkEvents := eui.NewButton()
+	linkBtn.Text = "goThoom Site"
+	linkBtn.Size.Y = 20
+	linkBtn.Fixed = true
+	linkEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			browser.OpenURL("https://m45sci.xyz/u/dist/goThoom")
+		}
+	}
+
+	patreonBox = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+	patreonBox.Size.Y = 80
+	header, _ := eui.NewText()
+	header.Text = "Patreon Supporters"
+	header.FontSize = 15
+	header.Fixed = true
+	header.Size.Y = 20
+	patreonList = &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_HORIZONTAL, Scrollable: true, Fixed: true}
+	patreonList.Size.Y = 60
+	patreonBox.AddItem(header)
+	patreonBox.AddItem(patreonList)
+
+	flow.PrependItem(patreonBox)
+	flow.PrependItem(linkBtn)
+
 	aboutLines = strings.Split(strings.ReplaceAll(aboutText, "\r\n", "\n"), "\n")
 	aboutWin.OnResize = func() { updateTextWindow(aboutWin, aboutList, nil, aboutLines, 15, "", monoFaceSource) }
+
+	go loadPatreons()
 }
 
 func openAboutWindow(anchor *eui.ItemData) {
@@ -44,4 +85,66 @@ func openAboutWindow(anchor *eui.ItemData) {
 		aboutWin.OnResize()
 	}
 	aboutWin.Refresh()
+}
+
+type patreonEntry struct {
+	Name   string `json:"name"`
+	Avatar string `json:"avatar"`
+}
+
+type patreonFile struct {
+	Patreons []patreonEntry `json:"patreons"`
+}
+
+func loadPatreons() {
+	resp, err := http.Get(patreonsURL)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+	var pf patreonFile
+	if err := json.NewDecoder(resp.Body).Decode(&pf); err != nil {
+		return
+	}
+	for _, p := range pf.Patreons {
+		url := p.Avatar
+		if url == "" {
+			continue
+		}
+		if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+			url = "https://m45sci.xyz/u/dist/goThoom/" + strings.TrimPrefix(url, "/")
+		}
+		imgResp, err := http.Get(url)
+		if err != nil {
+			continue
+		}
+		img, _, err := image.Decode(imgResp.Body)
+		imgResp.Body.Close()
+		if err != nil {
+			continue
+		}
+		w := img.Bounds().Dx()
+		h := img.Bounds().Dy()
+		imgItem, _ := eui.NewImageItem(w, h)
+		imgItem.Image = ebiten.NewImageFromImage(img)
+		imgItem.Size = eui.Point{X: float32(w), Y: float32(h)}
+		imgItem.Fixed = true
+		nameItem, _ := eui.NewText()
+		nameItem.Text = p.Name
+		nameItem.FontSize = 14
+		nameItem.Fixed = true
+		nameItem.Size.Y = 16
+		patItem := &eui.ItemData{ItemType: eui.ITEM_FLOW, FlowType: eui.FLOW_VERTICAL, Fixed: true}
+		patItem.AddItem(imgItem)
+		patItem.AddItem(nameItem)
+		patItem.Size.X = float32(w)
+		patItem.Size.Y = float32(h) + nameItem.Size.Y
+		patreonList.AddItem(patItem)
+	}
+	if aboutWin != nil {
+		aboutWin.Refresh()
+	}
 }


### PR DESCRIPTION
## Summary
- Add clickable link opening https://m45sci.xyz/u/dist/goThoom from the About window
- Display Patreon supporters from patreons.json with avatars and names

## Testing
- `go test ./...` *(fails: undefined: eui.EventInputFinished; undefined: eui.SetActiveSearchForTest)*

------
https://chatgpt.com/codex/tasks/task_e_68badb64b628832a8d7f476e0183bf7a