### PR TITLE
Fix joystick binding event constant

### DIFF
--- a/joystick.go
+++ b/joystick.go
@@ -77,7 +77,7 @@ func makeJoystickWindow() {
 	bindInput.Label = "Binding (action:button)"
 	bindInput.Size = eui.Point{X: 260, Y: 24}
 	bindEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventInputFinished {
+		if ev.Type == eui.EventInputChanged {
 			parts := strings.SplitN(ev.Text, ":", 2)
 			if len(parts) == 2 {
 				if b, err := strconv.Atoi(parts[1]); err == nil {


### PR DESCRIPTION
## Summary
- adapt joystick binding input to use `EventInputChanged`

## Testing
- `go build`
- `go test ./...` *(fails: undefined: eui.SetActiveSearchForTest)*

------
https://chatgpt.com/codex/tasks/task_e_68baed5cb3f4832a891c54151dc9c3c7