### PR TITLE
Specify joystick window text size

### DIFF
--- a/joystick.go
+++ b/joystick.go
@@ -40,7 +40,11 @@ func makeJoystickWindow() {
 	root.AddItem(controllerDD)
 
 	axesText, _ := eui.NewText()
+	axesText.FontSize = 12
+	axesText.Size = eui.Point{X: 260, Y: 24}
 	buttonsText, _ := eui.NewText()
+	buttonsText.FontSize = 12
+	buttonsText.Size = eui.Point{X: 260, Y: 24}
 
 	updateInfo := func(idx int) {
 		if idx < 0 || idx >= len(ids) {


### PR DESCRIPTION
## Summary
- prevent joystick window labels from clipping by defining font size and width

## Testing
- `go build`
- `go test ./...` *(fails: undefined: eui.SetActiveSearchForTest)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b8d3114832ab1a15059f36adef9