### PR TITLE
Preserve aspect ratio for avatars

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1370,10 +1370,13 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		if item.Image != nil {
 			iw, ih := item.Image.Bounds().Dx(), item.Image.Bounds().Dy()
 			op := &ebiten.DrawImageOptions{Filter: ebiten.FilterLinear, DisableMipmaps: true}
-			if int(maxSize.X) != iw || int(maxSize.Y) != ih {
-				op.GeoM.Scale(float64(maxSize.X)/float64(iw), float64(maxSize.Y)/float64(ih))
+			scale := math.Min(float64(maxSize.X)/float64(iw), float64(maxSize.Y)/float64(ih))
+			if scale != 1.0 {
+				op.GeoM.Scale(scale, scale)
 			}
-			op.GeoM.Translate(float64(offset.X), float64(offset.Y))
+			nw := float64(iw) * scale
+			nh := float64(ih) * scale
+			op.GeoM.Translate(float64(offset.X)+(float64(maxSize.X)-nw)/2, float64(offset.Y)+(float64(maxSize.Y)-nh)/2)
 			if item.Disabled {
 				// Lightly dim disabled images to indicate inactive/offline state.
 				op.ColorScale.Scale(0.35, 0.35, 0.35, 1.0)
@@ -1384,10 +1387,13 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, base poin
 		if item.Image != nil {
 			iw, ih := item.Image.Bounds().Dx(), item.Image.Bounds().Dy()
 			op := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
-			if int(maxSize.X) != iw || int(maxSize.Y) != ih {
-				op.GeoM.Scale(float64(maxSize.X)/float64(iw), float64(maxSize.Y)/float64(ih))
+			scale := math.Min(float64(maxSize.X)/float64(iw), float64(maxSize.Y)/float64(ih))
+			if scale != 1.0 {
+				op.GeoM.Scale(scale, scale)
 			}
-			op.GeoM.Translate(float64(offset.X), float64(offset.Y))
+			nw := float64(iw) * scale
+			nh := float64(ih) * scale
+			op.GeoM.Translate(float64(offset.X)+(float64(maxSize.X)-nw)/2, float64(offset.Y)+(float64(maxSize.Y)-nh)/2)
 			if item.Disabled {
 				// Lightly dim disabled images to indicate inactive/offline state.
 				op.ColorScale.Scale(0.35, 0.35, 0.35, 1.0)


### PR DESCRIPTION
## Summary
- ensure image items scale uniformly to maintain aspect ratio

## Testing
- `go test ./...` *(fails: undefined: eui.SetActiveSearchForTest)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c1b12c0832abefdea4dd4838fd9