### PR TITLE
Reuse draw options in hand overlay

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1099,6 +1099,11 @@ func makeToolbar() {
 	}()
 }
 
+var (
+	overlayHandOpts = &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
+	overlayItemOpts = &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
+)
+
 func overlayItemOnHand(hand, item *ebiten.Image) *ebiten.Image {
 	if hand == nil {
 		return item
@@ -1118,13 +1123,17 @@ func overlayItemOnHand(hand, item *ebiten.Image) *ebiten.Image {
 	out := newImage(w, h)
 	offX := (w - hand.Bounds().Dx()) / 2
 	offY := (h - hand.Bounds().Dy()) / 2
-	opHand := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
+	opHand := overlayHandOpts
+	opHand.ColorScale.Reset()
 	opHand.ColorScale.ScaleAlpha(0.5)
+	opHand.GeoM.Reset()
 	opHand.GeoM.Translate(float64(offX), float64(offY))
 	out.DrawImage(hand, opHand)
 	offX = (w - iw) / 2
 	offY = (h - ih) / 2
-	opItem := &ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
+	opItem := overlayItemOpts
+	opItem.ColorScale.Reset()
+	opItem.GeoM.Reset()
 	opItem.GeoM.Translate(float64(offX), float64(offY))
 	out.DrawImage(item, opItem)
 	return out


### PR DESCRIPTION
## Summary
- cache `ebiten.DrawImageOptions` for hand/item overlay
- reset `ColorScale` and `GeoM` on reuse

## Testing
- `sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils` *(fails: Unable to locate packages)*
- `go test ./...` *(fails: Package 'alsa' not found, X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be55bf7510832a8614a3c949348f08