### PR TITLE
remove atomic operations in chat tts

### DIFF
--- a/chat_tts_test.go
+++ b/chat_tts_test.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -127,7 +126,10 @@ func TestChatTTSDisableDropsQueued(t *testing.T) {
 		t.Fatalf("playChatTTS called after disabling")
 	}
 
-	if n := atomic.LoadInt32(&pendingTTS); n != 0 {
+	pendingTTSMu.Lock()
+	n := pendingTTS
+	pendingTTSMu.Unlock()
+	if n != 0 {
 		t.Fatalf("pendingTTS = %d, want 0", n)
 	}
 }


### PR DESCRIPTION
## Summary
- replace sync/atomic with mutex protected counter for chat TTS queue
- adjust tests to read pendingTTS with the mutex

## Testing
- `go test -run ChatTTS -count=1` *(fails: command did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68be66311a4c832aa9f5eebae93eb67f