### PR TITLE
Reset fallen status when players are seen

### DIFF
--- a/player.go
+++ b/player.go
@@ -88,6 +88,12 @@ func updatePlayerAppearance(name string, pictID uint16, colors []byte, isNPC boo
 	// Seeing a player on screen implies they are present now.
 	p.LastSeen = time.Now()
 	p.Offline = false
+	if p.Dead {
+		p.Dead = false
+		p.FellWhere = ""
+		p.KillerName = ""
+		p.FellTime = time.Time{}
+	}
 	seenChanged := !p.Seen
 	p.Seen = true
 	prevSC := p.SameClan

--- a/player_update_test.go
+++ b/player_update_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+import "time"
+
+func TestUpdatePlayerAppearanceUnmarksDead(t *testing.T) {
+	players = map[string]*Player{
+		"Bob": {
+			Name:       "Bob",
+			Dead:       true,
+			FellWhere:  "somewhere",
+			KillerName: "killer",
+			FellTime:   time.Unix(1, 0),
+		},
+	}
+	updatePlayerAppearance("Bob", 1, nil, false)
+	p := players["Bob"]
+	if p.Dead || p.FellWhere != "" || p.KillerName != "" || !p.FellTime.IsZero() {
+		t.Fatalf("expected Bob to be marked alive, got %#v", p)
+	}
+}


### PR DESCRIPTION
## Summary
- clear a player's fallen state when they are rendered on screen
- add regression test for resetting fallen state upon sight

## Testing
- `xvfb-run -a go test -run TestUpdatePlayerAppearanceUnmarksDead -count=1`
- `xvfb-run -a go test ./...` *(fails: runtime error in chat_tts.go)*

------
https://chatgpt.com/codex/tasks/task_e_68bec021ae38832a9e9cc0db9a2e328b