### PR TITLE
Respect potato mode for unmanaged images

### DIFF
--- a/eui/potato.go
+++ b/eui/potato.go
@@ -28,5 +28,5 @@ func newImage(w, h int) *ebiten.Image {
 }
 
 func newImageFast(w, h int) *ebiten.Image {
-	return ebiten.NewImageWithOptions(image.Rect(0, 0, w, h), &ebiten.NewImageOptions{Unmanaged: true})
+	return newImage(w, h)
 }

--- a/lighting_shader.go
+++ b/lighting_shader.go
@@ -3,7 +3,6 @@ package main
 import (
 	_ "embed"
 	"gothoom/climg"
-	"image"
 	"math"
 	"os"
 
@@ -121,9 +120,8 @@ type darkSource struct {
 
 func ensureLightingTmp(w, h int) {
 	if lightingTmp == nil || lightingTmp.Bounds().Dx() != w || lightingTmp.Bounds().Dy() != h {
-		// Use unmanaged image for the lighting intermediate to reduce
-		// driver sync and improve throughput on this path.
-		lightingTmp = ebiten.NewImageWithOptions(image.Rect(0, 0, w, h), &ebiten.NewImageOptions{Unmanaged: true})
+		// Allocate the intermediate image, respecting potato mode for unmanaged images.
+		lightingTmp = newImage(w, h)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Avoid forcing unmanaged images in newImageFast; now delegates to potato-aware allocator
- Allocate lighting shader intermediate via potato-aware helper

## Testing
- `go build`
- `go test ./...` *(fails: X11 DISPLAY environment variable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bec2c54854832abbedf53bffcf20cf