### PR TITLE
Batch plugin overlay draws

### DIFF
--- a/draw_batch.go
+++ b/draw_batch.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// acquireDrawOpts returns a DrawImageOptions from the shared pool initialized
+// with nearest filtering and mipmaps disabled. Call releaseDrawOpts when done.
+func acquireDrawOpts() *ebiten.DrawImageOptions {
+	op := drawOptsPool.Get().(*ebiten.DrawImageOptions)
+	*op = ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
+	return op
+}
+
+// releaseDrawOpts returns a DrawImageOptions to the shared pool.
+func releaseDrawOpts(op *ebiten.DrawImageOptions) {
+	drawOptsPool.Put(op)
+}
+
+// rectBatch batches solid rectangle draws into a single DrawTriangles call.
+type rectBatch struct {
+	vs []ebiten.Vertex
+	is []uint16
+}
+
+// Add appends a rectangle at the given destination coordinates and size using
+// the provided RGBA color.
+func (b *rectBatch) Add(x, y, w, h float32, clr color.RGBA) {
+	start := uint16(len(b.vs))
+	r, g, bcol, a := float32(clr.R)/255, float32(clr.G)/255, float32(clr.B)/255, float32(clr.A)/255
+	b.vs = append(b.vs,
+		ebiten.Vertex{DstX: x, DstY: y, SrcX: 0, SrcY: 0, ColorR: r, ColorG: g, ColorB: bcol, ColorA: a},
+		ebiten.Vertex{DstX: x + w, DstY: y, SrcX: 1, SrcY: 0, ColorR: r, ColorG: g, ColorB: bcol, ColorA: a},
+		ebiten.Vertex{DstX: x, DstY: y + h, SrcX: 0, SrcY: 1, ColorR: r, ColorG: g, ColorB: bcol, ColorA: a},
+		ebiten.Vertex{DstX: x + w, DstY: y + h, SrcX: 1, SrcY: 1, ColorR: r, ColorG: g, ColorB: bcol, ColorA: a},
+	)
+	b.is = append(b.is, start, start+1, start+2, start+1, start+3, start+2)
+}
+
+// Draw flushes the accumulated rectangles onto dst and resets the batch.
+func (b *rectBatch) Draw(dst *ebiten.Image) {
+	if len(b.is) == 0 {
+		return
+	}
+	dst.DrawTriangles(b.vs, b.is, whiteImage, nil)
+	b.vs = b.vs[:0]
+	b.is = b.is[:0]
+}


### PR DESCRIPTION
## Summary
- Batch plugin overlay rectangles into a single draw call
- Reuse pooled DrawImageOptions for overlay images and name tag backgrounds
- Sort overlay operations to encourage internal Ebiten batching

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bec51e903c832a947b20aed70659e1