### PR TITLE
Remove duplicate draw option helpers

### DIFF
--- a/draw_batch.go
+++ b/draw_batch.go
@@ -6,19 +6,6 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-// acquireDrawOpts returns a DrawImageOptions from the shared pool initialized
-// with nearest filtering and mipmaps disabled. Call releaseDrawOpts when done.
-func acquireDrawOpts() *ebiten.DrawImageOptions {
-	op := drawOptsPool.Get().(*ebiten.DrawImageOptions)
-	*op = ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
-	return op
-}
-
-// releaseDrawOpts returns a DrawImageOptions to the shared pool.
-func releaseDrawOpts(op *ebiten.DrawImageOptions) {
-	drawOptsPool.Put(op)
-}
-
 // rectBatch batches solid rectangle draws into a single DrawTriangles call.
 type rectBatch struct {
 	vs []ebiten.Vertex

--- a/game.go
+++ b/game.go
@@ -52,7 +52,9 @@ var inAspectResize bool
 var dimmedScreenBG = color.RGBA{0, 0, 0, 255}
 
 var (
-	drawOptsPool     = sync.Pool{New: func() any { return &ebiten.DrawImageOptions{} }}
+	// drawOptsPool pools DrawImageOptions to reduce allocations.
+	drawOptsPool = sync.Pool{New: func() any { return &ebiten.DrawImageOptions{} }}
+	// textDrawOptsPool pools DrawOptions to reduce allocations.
 	textDrawOptsPool = sync.Pool{New: func() any { return &text.DrawOptions{} }}
 )
 
@@ -183,12 +185,15 @@ func exactScale(scale float64, maxDenom int, eps float64) (float64, bool) {
 	return best, false
 }
 
+// acquireDrawOpts returns a DrawImageOptions from the shared pool initialized
+// with nearest filtering and mipmaps disabled. Call releaseDrawOpts when done.
 func acquireDrawOpts() *ebiten.DrawImageOptions {
 	op := drawOptsPool.Get().(*ebiten.DrawImageOptions)
-	*op = ebiten.DrawImageOptions{}
+	*op = ebiten.DrawImageOptions{Filter: ebiten.FilterNearest, DisableMipmaps: true}
 	return op
 }
 
+// releaseDrawOpts returns a DrawImageOptions to the shared pool.
 func releaseDrawOpts(op *ebiten.DrawImageOptions) {
 	drawOptsPool.Put(op)
 }

--- a/images.go
+++ b/images.go
@@ -70,11 +70,6 @@ var (
 	// pictBlendCache stores pre-rendered blended picture frames.
 	pictBlendCache = make(map[pictBlendKey]*ebiten.Image)
 
-	// drawOptsPool pools DrawImageOptions to reduce allocations.
-	drawOptsPool = sync.Pool{
-		New: func() any { return &ebiten.DrawImageOptions{} },
-	}
-
 	imageMu  sync.Mutex
 	clImages *climg.CLImages
 


### PR DESCRIPTION
## Summary
- consolidate drawOptsPool and its helpers in game.go to avoid redeclarations
- remove duplicate draw option helpers from draw_batch.go and images.go

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go build`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: the GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbd03648832a94b293b192f3a217