### PR TITLE
test: parse recorded movies

### DIFF
--- a/movie_recorder_test.go
+++ b/movie_recorder_test.go
@@ -60,13 +60,16 @@ func TestRecordRoundTrip(t *testing.T) {
 	if err := mr.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	rec, err := os.ReadFile(tmp)
-	if err != nil {
-		t.Fatalf("ReadFile(tmp): %v", err)
-	}
-	if !bytes.Equal(orig, rec) {
-		t.Fatalf("recording mismatch: %d vs %d bytes", len(orig), len(rec))
-	}
+        rec, err := os.ReadFile(tmp)
+        if err != nil {
+                t.Fatalf("ReadFile(tmp): %v", err)
+        }
+        if !bytes.Equal(orig, rec) {
+                t.Fatalf("recording mismatch: %d vs %d bytes", len(orig), len(rec))
+        }
+        if _, err := parseMovie(tmp, 0); err != nil {
+                t.Fatalf("parseMovie(tmp): %v", err)
+        }
 }
 
 func TestGameStateBlock(t *testing.T) {


### PR DESCRIPTION
## Summary
- verify that recorded CL movie files can be parsed again

## Testing
- `xvfb-run -a go test -run TestRecordRoundTrip -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68bf6fbfd554832a892b7ba075a97e4b