### PR TITLE
Use pooled int16 buffers for resampling

### DIFF
--- a/snd_laz.go
+++ b/snd_laz.go
@@ -22,7 +22,12 @@ const taps = 2 * a
 const cutoff = 0.95
 
 // Precomputed table: [phase][tap] in Q15
-var lzW [phases][taps]int16
+var (
+	lzW          [phases][taps]int16
+	int16BufPool = sync.Pool{
+		New: func() any { return make([]int16, 0, 48000) },
+	}
+)
 
 func init() { initLanczosTable() }
 
@@ -74,8 +79,24 @@ func initLanczosTable() {
 	}
 }
 
+func getInt16Buf(n int) []int16 {
+	buf := int16BufPool.Get().([]int16)
+	if cap(buf) < n {
+		buf = make([]int16, n)
+	}
+	return buf[:n]
+}
+
+func putInt16Buf(buf []int16) {
+	int16BufPool.Put(buf[:0])
+}
+
 // ResampleLanczosInt16PadDB resamples mono int16 from srcRate→dstRate using
 // Lanczos-3 (band-limited) with a *built-in dB pad* applied BEFORE int16 quantization.
+//
+// The returned slice is taken from an internal sync.Pool. Callers must treat it as
+// temporary and return it with putInt16Buf once finished. Copy the data if it needs
+// to be retained beyond the immediate scope.
 // padDB: negative for attenuation (e.g. -3, -6). Non-negative is clamped to 0 dB.
 func ResampleLanczosInt16PadDB(src []int16, srcRate, dstRate int, padDB float64) []int16 {
 	if len(src) == 0 || srcRate == dstRate {
@@ -89,7 +110,7 @@ func ResampleLanczosInt16PadDB(src []int16, srcRate, dstRate int, padDB float64)
 	if n <= 0 {
 		return nil
 	}
-	dst := make([]int16, n)
+	dst := getInt16Buf(n)
 
 	// Q32.32 phase step
 	step := (uint64(srcRate) << 32) / uint64(dstRate)

--- a/sound.go
+++ b/sound.go
@@ -502,6 +502,7 @@ func loadSound(id uint16) []byte {
 	} else {
 		samples = PadDB(samples, dbPad)
 	}
+	defer putInt16Buf(samples) // return pooled buffer
 
 	applyFadeInOut(samples, dstRate)
 


### PR DESCRIPTION
## Summary
- add sync.Pool for reusable int16 buffers
- use pooled buffers in `ResampleLanczosInt16PadDB`
- ensure callers release buffers after use

## Testing
- `sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils` *(fails: Unable to locate package libgl1-mesa-dev)*
- `curl -LO https://go.dev/dl/go1.25.0.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz && export PATH="/usr/local/go/bin:$PATH" && go version`
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz && tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./...` *(fails: compile: version "go1.24.3" does not match go tool version "go1.25.0")*

------
https://chatgpt.com/codex/tasks/task_e_68c0e08669d4832a8f6ed3ebec17391c