### PR TITLE
fix: replace undefined Lanczos sample accessor

### DIFF
--- a/snd_laz.go
+++ b/snd_laz.go
@@ -145,7 +145,7 @@ func ResampleLanczosInt16PadDB(src []int16, srcRate, dstRate int, padDB float64)
 			acc := int64(0)
 			j := 0
 			for k := -a + 1; k <= a; k++ {
-				s := int32(get(base + k))
+				s := int32(src[base+k+a])
 				acc += int64(wts[j]) * int64(s)
 				j++
 			}


### PR DESCRIPTION
## Summary
- avoid undefined `get` call in Lanczos resampler by indexing padded buffer directly

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e3075ba0832abf958d5fa117579e