### PR TITLE
Fix Lanczos shader uniform usage

### DIFF
--- a/data/shaders/upscale_lanczos.kage
+++ b/data/shaders/upscale_lanczos.kage
@@ -1,52 +1,54 @@
 package main
 
 var (
-    Src   image
-    Scale float
-    Step  float
+	Scale float
+	Step  float
 )
 
-const radius = 3.0
+const (
+	radius = 3.0
+	pi     = 3.141592653589793
+)
 
 func sinc(x float) float {
-    x = abs(x)
-    if x < 1e-5 {
-        return 1
-    }
-    x *= pi
-    return sin(x) / x
+	x = abs(x)
+	if x < 1e-5 {
+		return 1
+	}
+	x *= pi
+	return sin(x) / x
 }
 
 func lanczos(x float) float {
-    if x <= -radius || x >= radius {
-        return 0
-    }
-    return sinc(x) * sinc(x/radius)
+	if x <= -radius || x >= radius {
+		return 0
+	}
+	return sinc(x) * sinc(x/radius)
 }
 
 func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
-    center := pos.xy * Step
-    bx := floor(center.x)
-    by := floor(center.y)
-    var col vec4
-    weight := float(0)
-    for j := 0; j < 5; j++ {
-        jy := float(j-2)
-        dy := center.y - (by + jy)
-        wy := lanczos(dy)
-        for i := 0; i < 5; i++ {
-            ix := float(i-2)
-            dx := center.x - (bx + ix)
-            wx := lanczos(dx)
-            w := wx * wy
-            s := imageSrc0UnsafeAt(vec2(bx+ix, by+jy))
-            col += s * w
-            weight += w
-        }
-    }
-    if weight > 0 {
-        col /= weight
-    }
-    col *= Scale * Step // keep uniforms referenced
-    return col
+	center := pos.xy * Step
+	bx := floor(center.x)
+	by := floor(center.y)
+	var col vec4
+	weight := float(0)
+	for j := 0; j < 5; j++ {
+		jy := float(j - 2)
+		dy := center.y - (by + jy)
+		wy := lanczos(dy)
+		for i := 0; i < 5; i++ {
+			ix := float(i - 2)
+			dx := center.x - (bx + ix)
+			wx := lanczos(dx)
+			w := wx * wy
+			s := imageSrc0UnsafeAt(vec2(bx+ix, by+jy))
+			col += s * w
+			weight += w
+		}
+	}
+	if weight > 0 {
+		col /= weight
+	}
+	col *= Scale * Step // keep uniforms referenced
+	return col
 }


### PR DESCRIPTION
## Summary
- drop unsupported `Src` uniform from Lanczos shader and rely on built-in image accessors
- define explicit `pi` constant for sinc calculations

## Testing
- `go build`
- `./gothoom` *(fails: ALSA and missing resources, but no panic)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f2946560832aa8801db43d4fd4ba