### PR TITLE
Allow PadDB to amplify with positive dB

### DIFF
--- a/snd_laz.go
+++ b/snd_laz.go
@@ -234,7 +234,7 @@ func PadDB(samples []int16, padDB float64) []int16 {
 		return out
 	}
 
-	scale := math.Pow(10, -padDB/20.0)
+	scale := math.Pow(10, padDB/20.0)
 	out := make([]int16, len(samples))
 
 	for i, s := range samples {

--- a/snd_laz_test.go
+++ b/snd_laz_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestPadDBAmplificationAndAttenuation(t *testing.T) {
+	input := []int16{1000, -1000}
+
+	neg := PadDB(input, -6)
+	pos := PadDB(input, 6)
+
+	if absInt(neg[0]) >= absInt(input[0]) || absInt(neg[1]) >= absInt(input[1]) {
+		t.Fatalf("negative pad did not reduce amplitude: %v", neg)
+	}
+
+	if absInt(pos[0]) <= absInt(input[0]) || absInt(pos[1]) <= absInt(input[1]) {
+		t.Fatalf("positive pad did not increase amplitude: %v", pos)
+	}
+
+	// Also verify scaling amounts roughly match expected values
+	expNeg := int16(float64(input[0]) * math.Pow(10, -6/20.0))
+	expPos := int16(float64(input[0]) * math.Pow(10, 6/20.0))
+	if neg[0] != expNeg {
+		t.Errorf("expected %d for -6dB, got %d", expNeg, neg[0])
+	}
+	if pos[0] != expPos {
+		t.Errorf("expected %d for +6dB, got %d", expPos, pos[0])
+	}
+}
+
+func absInt(v int16) int16 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}


### PR DESCRIPTION
## Summary
- allow PadDB to amplify samples by using `math.Pow(10, padDB/20.0)` for scale
- test PadDB to ensure negative dB attenuates and positive dB amplifies

## Testing
- `go test ./...` (fails: The GLFW library is not initialized: the DISPLAY environment variable is missing)

------
https://chatgpt.com/codex/tasks/task_e_68c0f1fc3d90832a9bd90800e0014730