### PR TITLE
Account for draw offset in Lanczos upscale shader

### DIFF
--- a/data/shaders/upscale_lanczos.kage
+++ b/data/shaders/upscale_lanczos.kage
@@ -1,8 +1,9 @@
 package main
 
 var (
-	Scale float
-	Step  float
+	Scale  float
+	Step   float
+	Offset vec2
 )
 
 const (
@@ -27,7 +28,7 @@ func lanczos(x float) float {
 }
 
 func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
-	center := pos.xy * Step
+	center := (pos.xy - Offset) * Step
 	bx := floor(center.x)
 	by := floor(center.y)
 	var col vec4

--- a/game.go
+++ b/game.go
@@ -1372,8 +1372,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		geo.Scale(sx, sy)
 		geo.Translate(tx, ty)
 		unis := map[string]any{
-			"Scale": float32(scaleDown),
-			"Step":  float32(step),
+			"Scale":  float32(scaleDown),
+			"Step":   float32(step),
+			"Offset": [2]float32{float32(tx), float32(ty)},
 		}
 		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
 		sop.Images[0] = worldView


### PR DESCRIPTION
## Summary
- introduce `Offset` uniform in Lanczos shader to remove translation from sampling
- compute translation offsets in `game.go` and pass them as shader uniforms

## Testing
- `go mod download`
- `go build` *(terminated due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fa50dcf4832ab7030031e32501d1