### PR TITLE
Fix Lanczos upscaler mapping

### DIFF
--- a/data/shaders/upscale_lanczos.kage
+++ b/data/shaders/upscale_lanczos.kage
@@ -1,9 +1,9 @@
 package main
 
 var (
-	Scale  float
-	Step   float
-	Offset vec2
+// SrcSize holds the width and height of the source image in pixels.
+// Kage does not expose this directly, so the Go side provides it.
+SrcSize vec2
 )
 
 const (
@@ -28,28 +28,27 @@ func lanczos(x float) float {
 }
 
 func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
-	center := (pos.xy - Offset) * Step
-	bx := floor(center.x)
-	by := floor(center.y)
-	var col vec4
-	weight := float(0)
-       for j := 0; j < 7; j++ {
-               jy := float(j - 3)
-               dy := center.y - (by + jy)
-               wy := lanczos(dy)
-               for i := 0; i < 7; i++ {
-                       ix := float(i - 3)
-                       dx := center.x - (bx + ix)
-                       wx := lanczos(dx)
-                       w := wx * wy
-                       s := imageSrc0UnsafeAt(vec2(bx+ix, by+jy))
-                       col += s * w
-                       weight += w
-               }
-       }
-	if weight > 0 {
-		col /= weight
-	}
-        col += 0 * (Scale + Step) // keep uniforms referenced
-        return col
+center := texCoord * SrcSize
+bx := floor(center.x)
+by := floor(center.y)
+var col vec4
+weight := float(0)
+for j := 0; j < 7; j++ {
+jy := float(j - 3)
+dy := center.y - (by + jy)
+wy := lanczos(dy)
+for i := 0; i < 7; i++ {
+ix := float(i - 3)
+dx := center.x - (bx + ix)
+wx := lanczos(dx)
+w := wx * wy
+s := imageSrc0UnsafeAt(vec2(bx+ix, by+jy))
+col += s * w
+weight += w
+}
+}
+if weight > 0 {
+col /= weight
+}
+return col
 }

--- a/game.go
+++ b/game.go
@@ -1367,14 +1367,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	tx := (float64(bufW) - drawW) / 2
 	ty := (float64(bufH) - drawH) / 2
 	if gs.LanczosUpscale && scaleDown > 1 {
-		step := 1 / scaleDown
 		geo := ebiten.GeoM{}
 		geo.Scale(sx, sy)
 		geo.Translate(tx, ty)
 		unis := map[string]any{
-			"Scale":  float32(scaleDown),
-			"Step":   float32(step),
-			"Offset": [2]float32{float32(tx), float32(ty)},
+			"SrcSize": [2]float32{float32(offW), float32(offH)},
 		}
 		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
 		sop.Images[0] = worldView


### PR DESCRIPTION
## Summary
- use texCoord and provided source size to compute lanczos sample positions
- send source image size from DrawRectShader call and drop unused uniforms

## Testing
- `go build ./...`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fe0416c8832ab558bc3f6776176f