### PR TITLE
Support Lanczos upscaling from nearest-neighbor sources

### DIFF
--- a/data/shaders/upscale_lanczos.kage
+++ b/data/shaders/upscale_lanczos.kage
@@ -4,6 +4,8 @@ var (
 // SrcSize holds the width and height of the source image in pixels.
 // Kage does not expose this directly, so the Go side provides it.
 SrcSize vec2
+// SampleStep is the pixel distance between original texels in the source image.
+SampleStep float
 )
 
 const (
@@ -42,7 +44,8 @@ ix := float(i - 3)
 dx := center.x - (bx + ix)
 wx := lanczos(dx)
 w := wx * wy
-s := imageSrc0UnsafeAt(vec2(bx+ix, by+jy))
+src := vec2((bx+ix)*SampleStep, (by+jy)*SampleStep)
+s := imageSrc0UnsafeAt(src)
 col += s * w
 weight += w
 }

--- a/game.go
+++ b/game.go
@@ -1371,7 +1371,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		geo.Scale(sx, sy)
 		geo.Translate(tx, ty)
 		unis := map[string]any{
-			"SrcSize": [2]float32{float32(offW), float32(offH)},
+			"SrcSize":    [2]float32{float32(offW), float32(offH)},
+			"SampleStep": float32(scaleDown),
 		}
 		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
 		sop.Images[0] = worldView


### PR DESCRIPTION
## Summary
- allow Lanczos shader to read from nearest-neighbor upscaled textures by sampling with a configurable stride
- pass scale factor to shader when Lanczos upscaling is enabled

## Testing
- `go build ./...`
- `go test ./...` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c15e92bbb0832ab6c1a2d7899434f5