### PR TITLE
Fix Lanczos upscale shader sampling

### DIFF
--- a/data/shaders/upscale_lanczos.kage
+++ b/data/shaders/upscale_lanczos.kage
@@ -1,11 +1,11 @@
 package main
 
 var (
-// SrcSize holds the width and height of the source image in pixels.
-// Kage does not expose this directly, so the Go side provides it.
-SrcSize vec2
-// SampleStep is the pixel distance between original texels in the source image.
-SampleStep float
+	// SrcSize holds the width and height of the source image in pixels.
+	// Kage does not expose this directly, so the Go side provides it.
+	SrcSize vec2
+	// SampleStep contains the normalized pixel offsets for the source image.
+	SampleStep vec2
 )
 
 const (
@@ -30,28 +30,28 @@ func lanczos(x float) float {
 }
 
 func Fragment(pos vec4, texCoord vec2, color vec4) vec4 {
-center := texCoord * SrcSize
-bx := floor(center.x)
-by := floor(center.y)
-var col vec4
-weight := float(0)
-for j := 0; j < 7; j++ {
-jy := float(j - 3)
-dy := center.y - (by + jy)
-wy := lanczos(dy)
-for i := 0; i < 7; i++ {
-ix := float(i - 3)
-dx := center.x - (bx + ix)
-wx := lanczos(dx)
-w := wx * wy
-src := vec2((bx+ix)*SampleStep, (by+jy)*SampleStep)
-s := imageSrc0UnsafeAt(src)
-col += s * w
-weight += w
-}
-}
-if weight > 0 {
-col /= weight
-}
-return col
+	center := texCoord * SrcSize
+	bx := floor(center.x)
+	by := floor(center.y)
+	var col vec4
+	weight := float(0)
+	for j := 0; j < 7; j++ {
+		jy := float(j - 3)
+		dy := center.y - (by + jy)
+		wy := lanczos(dy)
+		for i := 0; i < 7; i++ {
+			ix := float(i - 3)
+			dx := center.x - (bx + ix)
+			wx := lanczos(dx)
+			w := wx * wy
+			src := vec2((bx+ix)*SampleStep.x, (by+jy)*SampleStep.y)
+			s := imageSrc0UnsafeAt(src)
+			col += s * w
+			weight += w
+		}
+	}
+	if weight > 0 {
+		col /= weight
+	}
+	return col
 }

--- a/game.go
+++ b/game.go
@@ -1372,7 +1372,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		geo.Translate(tx, ty)
 		unis := map[string]any{
 			"SrcSize":    [2]float32{float32(offW), float32(offH)},
-			"SampleStep": float32(scaleDown),
+			"SampleStep": [2]float32{1 / float32(offW), 1 / float32(offH)},
 		}
 		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
 		sop.Images[0] = worldView


### PR DESCRIPTION
## Summary
- Provide per-axis sample step to the Lanczos shader for correct texel addressing
- Supply matching normalized sample step from the game when Lanczos upscaling is enabled

## Testing
- ⚠️ `go build ./...` *(fails: Package 'alsa' required by 'virtual:world' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c165d238c0832a83d46b7e550c07e7