### PR TITLE
Add macro engine with parsing and execution context

### DIFF
--- a/macro/context.go
+++ b/macro/context.go
@@ -1,0 +1,51 @@
+package macro
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Context provides execution state for running macros.
+type Context struct {
+	vars   map[string]string
+	labels map[string]int
+	pc     int
+	rand   *rand.Rand
+}
+
+// NewContext creates a new execution context.
+func NewContext() *Context {
+	return &Context{
+		vars:   make(map[string]string),
+		labels: make(map[string]int),
+		rand:   rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Var returns a variable value.
+func (c *Context) Var(name string) string { return c.vars[name] }
+
+// Execute runs the given commands.
+func (c *Context) Execute(cmds []Command) error {
+	c.pc = 0
+	c.labels = make(map[string]int)
+	// first pass: register labels
+	for i, cmd := range cmds {
+		if l, ok := cmd.(Label); ok {
+			c.labels[l.Name] = i
+		}
+	}
+	for c.pc < len(cmds) {
+		cmd := cmds[c.pc]
+		c.pc++
+		if err := cmd.Exec(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sleep waits the given duration in milliseconds. Separated for tests.
+func (c *Context) sleep(ms int) {
+	time.Sleep(time.Duration(ms) * time.Millisecond)
+}

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -1,0 +1,153 @@
+package macro
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Type represents the macro type.
+type Type int
+
+const (
+	Expr     Type = iota // expression macro using regular expressions
+	Replace              // simple replacement macro
+	Function             // function macro executing commands
+	Key                  // key macro binding a key combination to a function
+)
+
+// Attribute is a bitmask of macro attributes mirrored from MacroDefs_cl.h.
+type Attribute uint32
+
+const (
+	AIgnoreCase Attribute = 1 << iota // aIgnoreCase - match case insensitive
+	AAnyClick                         // aAnyClick - key macro triggers on any mouse button
+	AKeyUp                            // aKeyUp - key macro triggers on key up
+)
+
+// Macro describes a single macro definition.
+type Macro struct {
+	Name        string
+	Type        Type
+	Trigger     string
+	Replacement string
+	Func        string // for key macros: function to invoke
+	Attr        Attribute
+	Commands    []Command // for function macros
+	pattern     *regexp.Regexp
+}
+
+// prepare compiles pattern for expression or replacement macros.
+func (m *Macro) prepare() error {
+	if m.Type == Expr || m.Type == Replace {
+		pat := m.Trigger
+		if m.Type == Replace {
+			pat = regexp.QuoteMeta(pat)
+		}
+		if m.Attr&AIgnoreCase != 0 {
+			pat = "(?i)" + pat
+		}
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			return err
+		}
+		m.pattern = re
+	}
+	return nil
+}
+
+// Expand applies the macro to the given input text.
+func (m *Macro) Expand(s string) string {
+	switch m.Type {
+	case Replace:
+		if m.Attr&AIgnoreCase != 0 {
+			return m.pattern.ReplaceAllStringFunc(s, func(_ string) string { return m.Replacement })
+		}
+		return strings.ReplaceAll(s, m.Trigger, m.Replacement)
+	case Expr:
+		if m.pattern == nil {
+			return s
+		}
+		return m.pattern.ReplaceAllString(s, m.Replacement)
+	default:
+		return s
+	}
+}
+
+// ParseAttribute converts an attribute string to the bit flag.
+func ParseAttribute(s string) (Attribute, error) {
+	switch s {
+	case "aIgnoreCase":
+		return AIgnoreCase, nil
+	case "aAnyClick":
+		return AAnyClick, nil
+	case "aKeyUp":
+		return AKeyUp, nil
+	case "":
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unknown attribute %q", s)
+	}
+}
+
+// Command represents a single executable macro command.
+type Command interface {
+	Exec(*Context) error
+}
+
+// Pause pauses execution for the specified milliseconds.
+type Pause struct{ Duration int }
+
+func (p Pause) Exec(ctx *Context) error {
+	ctx.sleep(p.Duration)
+	return nil
+}
+
+// Set assigns a variable in the context.
+type Set struct{ Name, Value string }
+
+func (s Set) Exec(ctx *Context) error {
+	ctx.vars[s.Name] = s.Value
+	return nil
+}
+
+// Label marks a location in the command list.
+type Label struct{ Name string }
+
+func (l Label) Exec(ctx *Context) error {
+	ctx.labels[l.Name] = ctx.pc
+	return nil
+}
+
+// Goto jumps to a label.
+type Goto struct{ Label string }
+
+func (g Goto) Exec(ctx *Context) error {
+	idx, ok := ctx.labels[g.Label]
+	if !ok {
+		return fmt.Errorf("label %s not found", g.Label)
+	}
+	ctx.pc = idx
+	return nil
+}
+
+// If compares a variable and jumps to a label if it matches.
+type If struct{ Var, Value, Label string }
+
+func (i If) Exec(ctx *Context) error {
+	if ctx.vars[i.Var] == i.Value {
+		return Goto{Label: i.Label}.Exec(ctx)
+	}
+	return nil
+}
+
+// Random chooses a label at random.
+type Random struct{ Labels []string }
+
+func (r Random) Exec(ctx *Context) error {
+	if len(r.Labels) == 0 {
+		return nil
+	}
+	n := ctx.rand.Intn(len(r.Labels))
+	return Goto{Label: r.Labels[n]}.Exec(ctx)
+}

--- a/macro/macro_test.go
+++ b/macro/macro_test.go
@@ -1,0 +1,40 @@
+package macro
+
+import "testing"
+
+func TestReplaceMacro(t *testing.T) {
+	m, err := Parse("replace hi => hello {aIgnoreCase}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	reg := NewRegistry()
+	reg.Register(m)
+	got := reg.Expand("HI there")
+	if got != "hello there" {
+		t.Fatalf("expand got %q", got)
+	}
+}
+
+func TestFunctionExecution(t *testing.T) {
+	src := `func greet {
+set name world
+label start
+if name world done
+goto start
+label done
+set greeting hello
+}`
+	m, err := Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	reg := NewRegistry()
+	reg.Register(m)
+	ctx := NewContext()
+	if err := reg.Invoke("greet", ctx); err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if ctx.Var("greeting") != "hello" {
+		t.Fatalf("var not set, got %q", ctx.Var("greeting"))
+	}
+}

--- a/macro/parse.go
+++ b/macro/parse.go
@@ -1,0 +1,179 @@
+package macro
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Parse parses a macro definition from a string.
+func Parse(src string) (*Macro, error) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return nil, fmt.Errorf("empty macro")
+	}
+	fields := strings.Fields(src)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("invalid macro")
+	}
+	switch strings.ToLower(fields[0]) {
+	case "expr", "expression":
+		return parseReplace(Expr, src)
+	case "repl", "replace":
+		return parseReplace(Replace, src)
+	case "func", "function":
+		return parseFunction(src)
+	case "key":
+		return parseKey(src)
+	default:
+		return nil, fmt.Errorf("unknown macro type %q", fields[0])
+	}
+}
+
+func parseReplace(t Type, src string) (*Macro, error) {
+	// format: type trigger => replacement {attr1,attr2}
+	// split attributes
+	attrs := Attribute(0)
+	if i := strings.Index(src, "{"); i >= 0 {
+		j := strings.LastIndex(src, "}")
+		if j < 0 || j < i {
+			return nil, fmt.Errorf("missing closing }")
+		}
+		parts := strings.Split(src[i+1:j], ",")
+		for _, p := range parts {
+			a, err := ParseAttribute(strings.TrimSpace(p))
+			if err != nil {
+				return nil, err
+			}
+			attrs |= a
+		}
+		src = strings.TrimSpace(src[:i])
+	}
+	seg := strings.Split(src, "=>")
+	if len(seg) != 2 {
+		return nil, fmt.Errorf("missing => in macro")
+	}
+	header := strings.TrimSpace(seg[0])
+	parts := strings.Fields(header)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("missing trigger in macro")
+	}
+	trigger := strings.Join(parts[1:], " ")
+	repl := strings.TrimSpace(seg[1])
+	m := &Macro{Type: t, Trigger: trigger, Replacement: repl, Attr: attrs}
+	if err := m.prepare(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func parseFunction(src string) (*Macro, error) {
+	// format: func name {\n commands \n}
+	i := strings.Index(src, "{")
+	j := strings.LastIndex(src, "}")
+	if i < 0 || j < 0 || j < i {
+		return nil, fmt.Errorf("function macro must have braces")
+	}
+	header := strings.TrimSpace(src[:i])
+	fields := strings.Fields(header)
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("function macro missing name")
+	}
+	name := fields[1]
+	body := src[i+1 : j]
+	cmds, err := parseCommands(body)
+	if err != nil {
+		return nil, err
+	}
+	return &Macro{Type: Function, Name: name, Commands: cmds}, nil
+}
+
+func parseKey(src string) (*Macro, error) {
+	// format: key combo => func {attrs}
+	attrs := Attribute(0)
+	if i := strings.Index(src, "{"); i >= 0 {
+		j := strings.LastIndex(src, "}")
+		if j < 0 || j < i {
+			return nil, fmt.Errorf("missing closing }")
+		}
+		parts := strings.Split(src[i+1:j], ",")
+		for _, p := range parts {
+			a, err := ParseAttribute(strings.TrimSpace(p))
+			if err != nil {
+				return nil, err
+			}
+			attrs |= a
+		}
+		src = strings.TrimSpace(src[:i])
+	}
+	seg := strings.Split(src, "=>")
+	if len(seg) != 2 {
+		return nil, fmt.Errorf("missing => in key macro")
+	}
+	left := strings.TrimSpace(seg[0])
+	right := strings.TrimSpace(seg[1])
+	fields := strings.Fields(left)
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("key macro missing combo")
+	}
+	combo := fields[1]
+	return &Macro{Type: Key, Trigger: combo, Func: right, Attr: attrs}, nil
+}
+
+func parseCommands(body string) ([]Command, error) {
+	var cmds []Command
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	line := 0
+	for scanner.Scan() {
+		line++
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" || strings.HasPrefix(text, "#") {
+			continue
+		}
+		fields := strings.Fields(text)
+		switch strings.ToLower(fields[0]) {
+		case "pause":
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("pause needs duration on line %d", line)
+			}
+			v, err := strconv.Atoi(fields[1])
+			if err != nil {
+				return nil, err
+			}
+			cmds = append(cmds, Pause{Duration: v})
+		case "set":
+			if len(fields) < 3 {
+				return nil, fmt.Errorf("set needs name and value on line %d", line)
+			}
+			cmds = append(cmds, Set{Name: fields[1], Value: strings.Join(fields[2:], " ")})
+		case "label":
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("label needs name on line %d", line)
+			}
+			cmds = append(cmds, Label{Name: fields[1]})
+		case "goto":
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("goto needs label on line %d", line)
+			}
+			cmds = append(cmds, Goto{Label: fields[1]})
+		case "if":
+			// format: if var value label
+			if len(fields) != 4 {
+				return nil, fmt.Errorf("if needs var value label on line %d", line)
+			}
+			cmds = append(cmds, If{Var: fields[1], Value: fields[2], Label: fields[3]})
+		case "random":
+			if len(fields) < 2 {
+				return nil, fmt.Errorf("random needs labels on line %d", line)
+			}
+			cmds = append(cmds, Random{Labels: fields[1:]})
+		default:
+			return nil, fmt.Errorf("unknown command %q on line %d", fields[0], line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return cmds, nil
+}

--- a/macro/registry.go
+++ b/macro/registry.go
@@ -1,0 +1,54 @@
+package macro
+
+import "sync"
+
+// Registry stores macros and allows invocation.
+type Registry struct {
+	mu     sync.RWMutex
+	macros map[string]*Macro
+}
+
+// NewRegistry creates a macro registry.
+func NewRegistry() *Registry {
+	return &Registry{macros: make(map[string]*Macro)}
+}
+
+// Register adds a macro to the registry.
+func (r *Registry) Register(m *Macro) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if m.Name == "" {
+		m.Name = m.Trigger
+	}
+	r.macros[m.Name] = m
+}
+
+// Invoke runs a function or key macro by name.
+func (r *Registry) Invoke(name string, ctx *Context) error {
+	r.mu.RLock()
+	m, ok := r.macros[name]
+	r.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	switch m.Type {
+	case Function:
+		return ctx.Execute(m.Commands)
+	case Key:
+		return r.Invoke(m.Func, ctx)
+	default:
+		return nil
+	}
+}
+
+// Expand applies all replacement/expression macros to the string.
+func (r *Registry) Expand(s string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, m := range r.macros {
+		if m.Type == Replace || m.Type == Expr {
+			s = m.Expand(s)
+		}
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- implement macro package with expression, replacement, function, and key macro types
- support macro attributes like aIgnoreCase, aAnyClick, and aKeyUp
- add execution context with variables, labels, goto, conditionals, pause, and random jump
- expose registry for registering/invoking macros and text expansion

## Testing
- `go test ./macro -run Test -count=1`
- `go test ./...` *(fails: pattern spellcheck_words.txt: no matching files found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fb4126dc832a94ce021a98c594b4