### PR TITLE
Allow custom server messages via testhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,55 @@ Tip: The input bar auto-expands as you type and has a context menu for quick pas
 goThoom can load optional scripts at startup using [yaegi](https://github.com/traefik/yaegi), a Go interpreter.
 Place `.go` files inside the `scripts/` directory.
 
+### Testing server messages
+
+Use the `/testhooks` command to inject fake server messages for debugging or
+script development. Run `/testhooks help` to see available message names.
+
+```
+/testhooks MESSAGE [NAME] DATA
+```
+
+`MESSAGE` is a server message name like `share` or `info`. Supply `NAME`
+for messages referencing a mobile, and put the message body in `DATA`. Running
+`/testhooks` without arguments emits a few sample messages.
+
+Available message types:
+
+| Name | Tag | Description |
+|------|-----|-------------|
+| bard | ba | bard message |
+| backend | be | back-end command |
+| clan | cn | clan name |
+| config | cf | config |
+| nodisplay | dd | do not display |
+| demo | de | demo notice |
+| depart | dp | depart |
+| download | dl | download |
+| error | er | error message |
+| gm | gm | game master |
+| fallen | hf | has fallen |
+| notfallen | nf | no longer fallen |
+| info | in | info |
+| inventory | iv | inventory |
+| karma | ka | karma |
+| karmarecv | kr | karma received |
+| logoff | lf | log off |
+| logon | lg | log on |
+| location | lo | location |
+| multi | ml | multilingual |
+| monster | mn | monster name |
+| music | mu | music |
+| news | nw | news |
+| player | pn | player name |
+| share | sh | share |
+| unshare | su | unshare |
+| textlog | tl | text log only |
+| think | th | think |
+| mono | tt | monospaced style |
+| who | wh | who list |
+| youkilled | yk | you killed |
+
 ---
 ## Build from source
 

--- a/game.go
+++ b/game.go
@@ -861,34 +861,36 @@ func (g *Game) Update() error {
 					}()
 				} else {
 					// Try built-in or plugin-registered commands first
-					if strings.HasPrefix(txt, "/") {
-						if strings.EqualFold(txt, "/testhooks") {
-							consoleMessage("> " + txt)
-							testScriptHooks()
-						} else {
-							parts := strings.SplitN(strings.TrimPrefix(txt, "/"), " ", 2)
-							name := strings.ToLower(parts[0])
-							args := ""
-							if len(parts) > 1 {
-								args = parts[1]
-							}
-							if handler, ok := pluginCommands[name]; ok && handler != nil {
-								owner := pluginCommandOwners[name]
-								if !pluginDisabled[owner] {
-									consoleMessage("> " + txt)
-									go handler(args)
-								} else {
-									// Disabled plugin commands should fall through so the
-									// server still receives the user's input.
-									pendingCommand = txt
-								}
-							} else {
-								pendingCommand = txt
-							}
-						}
-					} else {
-						pendingCommand = txt
-					}
+                                        if strings.HasPrefix(txt, "/") {
+                                                lower := strings.ToLower(txt)
+                                                if strings.HasPrefix(lower, "/testhooks") {
+                                                        consoleMessage("> " + txt)
+                                                        arg := strings.TrimSpace(txt[len("/testhooks"):])
+                                                        testScriptHooks(arg)
+                                                } else {
+                                                        parts := strings.SplitN(strings.TrimPrefix(txt, "/"), " ", 2)
+                                                        name := strings.ToLower(parts[0])
+                                                        args := ""
+                                                        if len(parts) > 1 {
+                                                                args = parts[1]
+                                                        }
+                                                        if handler, ok := pluginCommands[name]; ok && handler != nil {
+                                                                owner := pluginCommandOwners[name]
+                                                                if !pluginDisabled[owner] {
+                                                                        consoleMessage("> " + txt)
+                                                                        go handler(args)
+                                                                } else {
+                                                                        // Disabled plugin commands should fall through so the
+                                                                        // server still receives the user's input.
+                                                                        pendingCommand = txt
+                                                                }
+                                                        } else {
+                                                                pendingCommand = txt
+                                                        }
+                                                }
+                                        } else {
+                                                pendingCommand = txt
+                                        }
 					// consoleMessage("> " + txt)
 				}
 				inputHistory = append(inputHistory, txt)

--- a/script_hookstest.go
+++ b/script_hookstest.go
@@ -1,13 +1,113 @@
 package main
 
+import (
+	"encoding/binary"
+	"strings"
+)
+
+type hookMsg struct {
+	name string
+	tag  string
+	desc string
+}
+
+var hookTypes = []hookMsg{
+	{"bard", "ba", "bard message"},
+	{"backend", "be", "back-end command"},
+	{"clan", "cn", "clan name"},
+	{"config", "cf", "config"},
+	{"nodisplay", "dd", "do not display"},
+	{"demo", "de", "demo notice"},
+	{"depart", "dp", "depart"},
+	{"download", "dl", "download"},
+	{"error", "er", "error message"},
+	{"gm", "gm", "game master"},
+	{"fallen", "hf", "has fallen"},
+	{"notfallen", "nf", "no longer fallen"},
+	{"info", "in", "info"},
+	{"inventory", "iv", "inventory"},
+	{"karma", "ka", "karma"},
+	{"karmarecv", "kr", "karma received"},
+	{"logoff", "lf", "log off"},
+	{"logon", "lg", "log on"},
+	{"location", "lo", "location"},
+	{"multi", "ml", "multilingual"},
+	{"monster", "mn", "monster name"},
+	{"music", "mu", "music"},
+	{"news", "nw", "news"},
+	{"player", "pn", "player name"},
+	{"share", "sh", "share"},
+	{"unshare", "su", "unshare"},
+	{"textlog", "tl", "text log only"},
+	{"think", "th", "think"},
+	{"mono", "tt", "monospaced style"},
+	{"who", "wh", "who list"},
+	{"youkilled", "yk", "you killed"},
+}
+
+var hookLookup = func() map[string]string {
+	m := make(map[string]string, len(hookTypes)*2)
+	for _, h := range hookTypes {
+		m[h.name] = h.tag
+		m[h.tag] = h.tag
+	}
+	return m
+}()
+
+func testHooksHelp() {
+	consoleMessage("usage: /testhooks <message> [name] <data>")
+	consoleMessage("messages:")
+	for _, h := range hookTypes {
+		consoleMessage("  " + h.name + " - " + h.desc)
+	}
+}
+
 // testScriptHooks emits sample chat and console messages to exercise script trigger hooks.
-func testScriptHooks() {
-	// NPC chat with a blank name
-	chatMessage(" says, testing NPC chat")
-	// System console message
-	consoleMessage("System: testing message")
-	// Simulated share message using info text format
-	msg := append([]byte("You are sharing experiences with "), pnTag("Tester")...)
-	msg = append(msg, '.')
-	handleInfoText(append(bepp("sh", msg), '\r'))
+// With arguments, it crafts a server message with the given type, optional name,
+// and data. Use /testhooks help to list message names.
+func testScriptHooks(args string) {
+	if args == "" {
+		// NPC chat with a blank name
+		chatMessage(" says, testing NPC chat")
+		// System console message
+		consoleMessage("System: testing message")
+		// Simulated share message using info text format
+		msg := append([]byte("You are sharing experiences with "), pnTag("Tester")...)
+		msg = append(msg, '.')
+		handleInfoText(append(bepp("sh", msg), '\r'))
+		consoleMessage("run /testhooks help for message types")
+		return
+	}
+	if strings.ToLower(args) == "help" {
+		testHooksHelp()
+		return
+	}
+	parts := strings.SplitN(args, " ", 3)
+	if len(parts) < 2 {
+		testHooksHelp()
+		return
+	}
+	key := strings.ToLower(parts[0])
+	typ, ok := hookLookup[key]
+	if !ok {
+		consoleMessage("unknown message type: " + key)
+		testHooksHelp()
+		return
+	}
+	var name, data string
+	if len(parts) == 2 {
+		data = parts[1]
+	} else {
+		name = parts[1]
+		data = parts[2]
+	}
+	payload := encodeMacRoman(data)
+	if name != "" {
+		payload = append(append(pnTag(name), ' '), payload...)
+	}
+	msg := bepp(typ, payload)
+	m := make([]byte, 16+len(msg))
+	binary.BigEndian.PutUint16(m[0:2], 0)
+	copy(m[16:], msg)
+	processServerMessage(m)
 }


### PR DESCRIPTION
## Summary
- Accept message names instead of raw BEPP tags for `/testhooks` and list known types with `/testhooks help`
- Document named message usage for `/testhooks`
- Document available `/testhooks` message types in README

## Testing
- `curl -LO https://m45sci.xyz/u/dist/goThoom/gothoom_deps.tar.gz`
- `tar -xzf gothoom_deps.tar.gz`
- `go mod download`
- `go test ./...` *(fails: Package alsa not found; X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c634e83878832aa992aebd9145ba40