### PR TITLE
Add script event debug mode

### DIFF
--- a/game.go
+++ b/game.go
@@ -861,36 +861,37 @@ func (g *Game) Update() error {
 					}()
 				} else {
 					// Try built-in or plugin-registered commands first
-                                        if strings.HasPrefix(txt, "/") {
-                                                lower := strings.ToLower(txt)
-                                                if strings.HasPrefix(lower, "/testhooks") {
-                                                        consoleMessage("> " + txt)
-                                                        arg := strings.TrimSpace(txt[len("/testhooks"):])
-                                                        testScriptHooks(arg)
-                                                } else {
-                                                        parts := strings.SplitN(strings.TrimPrefix(txt, "/"), " ", 2)
-                                                        name := strings.ToLower(parts[0])
-                                                        args := ""
-                                                        if len(parts) > 1 {
-                                                                args = parts[1]
-                                                        }
-                                                        if handler, ok := pluginCommands[name]; ok && handler != nil {
-                                                                owner := pluginCommandOwners[name]
-                                                                if !pluginDisabled[owner] {
-                                                                        consoleMessage("> " + txt)
-                                                                        go handler(args)
-                                                                } else {
-                                                                        // Disabled plugin commands should fall through so the
-                                                                        // server still receives the user's input.
-                                                                        pendingCommand = txt
-                                                                }
-                                                        } else {
-                                                                pendingCommand = txt
-                                                        }
-                                                }
-                                        } else {
-                                                pendingCommand = txt
-                                        }
+					if strings.HasPrefix(txt, "/") {
+						lower := strings.ToLower(txt)
+						if strings.HasPrefix(lower, "/testhooks") {
+							consoleMessage("> " + txt)
+							arg := strings.TrimSpace(txt[len("/testhooks"):])
+							testScriptHooks(arg)
+						} else {
+							parts := strings.SplitN(strings.TrimPrefix(txt, "/"), " ", 2)
+							name := strings.ToLower(parts[0])
+							args := ""
+							if len(parts) > 1 {
+								args = parts[1]
+							}
+							if handler, ok := pluginCommands[name]; ok && handler != nil {
+								owner := pluginCommandOwners[name]
+								if !pluginDisabled[owner] {
+									consoleMessage("> " + txt)
+									pluginLogEvent(owner, "Command", args)
+									go handler(args)
+								} else {
+									// Disabled plugin commands should fall through so the
+									// server still receives the user's input.
+									pendingCommand = txt
+								}
+							} else {
+								pendingCommand = txt
+							}
+						}
+					} else {
+						pendingCommand = txt
+					}
 					// consoleMessage("> " + txt)
 				}
 				inputHistory = append(inputHistory, txt)

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -978,6 +978,7 @@ func checkHotkeys() {
 				// If this is a plugin hotkey with a function handler, call it.
 				if hk.Plugin != "" {
 					if fn, ok := pluginGetHotkeyFn(hk.Plugin, hk.Combo); ok && fn != nil {
+						pluginLogEvent(hk.Plugin, "Hotkey", combo)
 						parts := strings.Split(combo, "-")
 						trig := ""
 						if len(parts) > 0 {

--- a/player.go
+++ b/player.go
@@ -144,14 +144,15 @@ func getPlayers() []Player {
 
 func notifyPlayerHandlers(p Player) {
 	playerHandlersMu.RLock()
-	handlers := make([]func(Player), 0, len(playerHandlers)+len(pluginPlayerHandlers))
-	handlers = append(handlers, playerHandlers...)
-	for _, h := range pluginPlayerHandlers {
-		handlers = append(handlers, h.fn)
-	}
+	base := append([]func(Player){}, playerHandlers...)
+	plug := append([]playerHandler{}, pluginPlayerHandlers...)
 	playerHandlersMu.RUnlock()
-	for _, fn := range handlers {
+	for _, fn := range base {
 		go fn(p)
+	}
+	for _, h := range plug {
+		pluginLogEvent(h.owner, "PlayerHandler", p.Name)
+		go h.fn(p)
 	}
 }
 

--- a/settings.go
+++ b/settings.go
@@ -172,6 +172,7 @@ var gsdef settings = settings{
 	pictAgainDebug:    false,
 	pictIDDebug:       false,
 	pluginOutputDebug: false,
+	pluginEventDebug:  false,
 	forceNightLevel:   -1,
 }
 
@@ -309,6 +310,7 @@ type settings struct {
 	pictAgainDebug    bool
 	pictIDDebug       bool
 	pluginOutputDebug bool
+	pluginEventDebug  bool
 	altNetMode        bool
 	altNetDelay       int
 	hideMoving        bool


### PR DESCRIPTION
## Summary
- add toggleable event debugging in Scripts window
- log plugin events with context
- wire logging for chat, console, input, command, player, and hotkey handlers

## Testing
- `sudo apt-get update && sudo apt-get install -y build-essential libgl1-mesa-dev libglu1-mesa-dev xorg-dev libxrandr-dev libasound2-dev libgtk-3-dev xdg-utils >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c644d10994832aa936197f00933648