### PR TITLE
Remove Lanczos upscaler remnants

### DIFF
--- a/game.go
+++ b/game.go
@@ -1371,30 +1371,16 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	drawH := float64(offH) * sy
 	tx := (float64(bufW) - drawW) / 2
 	ty := (float64(bufH) - drawH) / 2
-	if gs.lanczosUpscale && gs.GameScale > 1 {
-		geo := ebiten.GeoM{}
-		geo.Scale(sx, sy)
-		geo.Translate(tx, ty)
-		unis := map[string]any{
-			"SrcSize":    [2]float32{float32(offW), float32(offH)},
-			"SampleStep": [2]float32{1 / float32(offW), 1 / float32(offH)},
-		}
-		sop := ebiten.DrawRectShaderOptions{Uniforms: unis, Blend: ebiten.BlendCopy}
-		sop.Images[0] = worldView
-		sop.GeoM = geo
-		gameImage.DrawRectShader(offW, offH, upscaleShader, &sop)
-	} else {
-		op := acquireDrawOpts()
-		// Always use linear filtering for the final window composite.
-		op.Filter = ebiten.FilterLinear
-		op.DisableMipmaps = true
-		// worldView was cleared and fully redrawn; a copy avoids extra blending cost.
-		op.Blend = ebiten.BlendCopy
-		op.GeoM.Scale(sx, sy)
-		op.GeoM.Translate(tx, ty)
-		gameImage.DrawImage(worldView, op)
-		releaseDrawOpts(op)
-	}
+	op := acquireDrawOpts()
+	// Always use linear filtering for the final window composite.
+	op.Filter = ebiten.FilterLinear
+	op.DisableMipmaps = true
+	// worldView was cleared and fully redrawn; a copy avoids extra blending cost.
+	op.Blend = ebiten.BlendCopy
+	op.GeoM.Scale(sx, sy)
+	op.GeoM.Translate(tx, ty)
+	gameImage.DrawImage(worldView, op)
+	releaseDrawOpts(op)
 	if haveSnap {
 		prev := gs.GameScale
 		finalScale := float64(offIntScale) * scaleDown

--- a/settings.go
+++ b/settings.go
@@ -159,7 +159,6 @@ var gsdef settings = settings{
 
 	//Unexported
 	vsync:             true,
-	lanczosUpscale:    false,
 	precacheSounds:    false,
 	precacheImages:    false,
 	smoothMoving:      false,
@@ -321,7 +320,6 @@ type settings struct {
 
 	// Window behavior
 	ShowClanLordSplashImage bool
-	lanczosUpscale          bool
 	precacheSounds          bool
 	precacheImages          bool
 	smoothMoving            bool

--- a/ui.go
+++ b/ui.go
@@ -4941,18 +4941,6 @@ func makeDebugWindow() {
 	}
 	debugFlow.AddItem(pingBtn)
 
-	lanczosCB, lanczosEvents := eui.NewCheckbox()
-	lanczosCB.Text = "Lanczos Upscale Filter (experimental)"
-	lanczosCB.Size = eui.Point{X: width, Y: 24}
-	lanczosCB.Checked = gs.lanczosUpscale
-	lanczosEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventCheckboxChanged {
-			gs.lanczosUpscale = ev.Checked
-			settingsDirty = true
-		}
-	}
-	debugFlow.AddItem(lanczosCB)
-
 	// Add a small "Reload" button beside the shader checkbox for hot-reload.
 	reloadBtn, reloadEv := eui.NewButton()
 	reloadBtn.Text = "Reload Shaders"


### PR DESCRIPTION
## Summary
- strip out Lanczos upscaler shader usage
- remove unused lanczosUpscale setting and checkbox

## Testing
- `go test ./...` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c76796a96c832a915bd0ac09d7144b