### PR TITLE
Disable meltysynth reverb

### DIFF
--- a/synth.go
+++ b/synth.go
@@ -96,6 +96,8 @@ func setupSynth() {
 		return
 	}
 	settings := meltysynth.NewSynthesizerSettings(sampleRate)
+	// Disable the built-in reverb/chorus effect to match the desired dry output.
+	settings.EnableReverbAndChorus = false
 	// Align meltysynth internal block size with our render loop to reduce
 	// chances of effect buffers overrunning on odd boundaries.
 	settings.BlockSize = block


### PR DESCRIPTION
## Summary
- disable meltysynth's built-in reverb/chorus processing when configuring the synthesizer so playback uses a dry signal

## Testing
- go test ./... *(fails: glfw requires an X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_68c9924677e0832ab79419c40b6cbf99