### PR TITLE
Add audio enhancement pipeline and resampling option

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -147,11 +147,12 @@ var gsdef settings = settings{
 	ShaderLightStrength: 1.0,
 	ShaderGlowStrength:  1.0,
 
-	PotatoGPU:       false,
-	BarColorByValue: false,
-	ThrottleSounds:  true,
-	SoundReverb:     true,
-	MusicReverb:     true,
+	PotatoGPU:             false,
+	BarColorByValue:       false,
+	ThrottleSounds:        true,
+	SoundEnhancement:      true,
+	MusicEnhancement:      true,
+	HighQualityResampling: true,
 
 	NightEffect:    true,
 	ShaderLighting: true,
@@ -301,12 +302,13 @@ type settings struct {
 	ShaderLightStrength float64
 	ShaderGlowStrength  float64
 
-	PotatoGPU       bool
-	EnabledPlugins  map[string]any
-	BarColorByValue bool
-	ThrottleSounds  bool
-	SoundReverb     bool
-	MusicReverb     bool
+	PotatoGPU             bool
+	EnabledPlugins        map[string]any
+	BarColorByValue       bool
+	ThrottleSounds        bool
+	SoundEnhancement      bool
+	MusicEnhancement      bool
+	HighQualityResampling bool
 
 	imgPlanesDebug    bool
 	smoothingDebug    bool
@@ -370,7 +372,9 @@ func loadSettings() bool {
 
 	type settingsFile struct {
 		settings
-		EnabledPlugins map[string]any `json:"EnabledPlugins"`
+		EnabledPlugins    map[string]any `json:"EnabledPlugins"`
+		LegacySoundReverb *bool          `json:"SoundReverb"`
+		LegacyMusicReverb *bool          `json:"MusicReverb"`
 	}
 
 	tmp := settingsFile{settings: gsdef}
@@ -381,6 +385,12 @@ func loadSettings() bool {
 	}
 
 	if tmp.settings.Version == SETTINGS_VERSION {
+		if tmp.LegacySoundReverb != nil {
+			tmp.settings.SoundEnhancement = *tmp.LegacySoundReverb
+		}
+		if tmp.LegacyMusicReverb != nil {
+			tmp.settings.MusicEnhancement = *tmp.LegacyMusicReverb
+		}
 		gs = tmp.settings
 		// Normalize and retain whatever was in the file; migrate into runtime scope map.
 		gs.EnabledPlugins = make(map[string]any)

--- a/synth.go
+++ b/synth.go
@@ -404,7 +404,7 @@ func Play(ctx *audio.Context, program int, notes []Note) error {
 		return err
 	}
 
-	if gs.MusicReverb {
+	if gs.MusicEnhancement {
 		applyMusicReverb(leftAll, rightAll, sampleRate)
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -3627,31 +3627,45 @@ func makeSettingsWindow() {
 	}
 	center.AddItem(throttleSoundCB)
 
-	reverbCB, reverbEvents := eui.NewCheckbox()
-	reverbCB.Text = "Reverb for sound effects"
-	reverbCB.Size = eui.Point{X: panelWidth, Y: 24}
-	reverbCB.Checked = gs.SoundReverb
-	reverbCB.SetTooltip("Add subtle room ambience to in-game sounds")
-	reverbEvents.Handle = func(ev eui.UIEvent) {
+	enhancementCB, enhancementEvents := eui.NewCheckbox()
+	enhancementCB.Text = "Audio enhancement for sound effects"
+	enhancementCB.Size = eui.Point{X: panelWidth, Y: 24}
+	enhancementCB.Checked = gs.SoundEnhancement
+	enhancementCB.SetTooltip("Stereo width, ambience, and tone polish for in-game sounds")
+	enhancementEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
-			gs.SoundReverb = ev.Checked
+			gs.SoundEnhancement = ev.Checked
 			settingsDirty = true
 		}
 	}
-	center.AddItem(reverbCB)
+	center.AddItem(enhancementCB)
 
-	musicReverbCB, musicReverbEvents := eui.NewCheckbox()
-	musicReverbCB.Text = "Reverb for music"
-	musicReverbCB.Size = eui.Point{X: panelWidth, Y: 24}
-	musicReverbCB.Checked = gs.MusicReverb
-	musicReverbCB.SetTooltip("Add space and ambience to background music")
-	musicReverbEvents.Handle = func(ev eui.UIEvent) {
+	resampleCB, resampleEvents := eui.NewCheckbox()
+	resampleCB.Text = "High quality resampling"
+	resampleCB.Size = eui.Point{X: panelWidth, Y: 24}
+	resampleCB.Checked = gs.HighQualityResampling
+	resampleCB.SetTooltip("Lanczos resampling and dithering for cleaner audio (uses more CPU)")
+	resampleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
-			gs.MusicReverb = ev.Checked
+			gs.HighQualityResampling = ev.Checked
+			clearCaches()
 			settingsDirty = true
 		}
 	}
-	center.AddItem(musicReverbCB)
+	center.AddItem(resampleCB)
+
+	musicEnhancementCB, musicEnhancementEvents := eui.NewCheckbox()
+	musicEnhancementCB.Text = "Audio enhancement for music"
+	musicEnhancementCB.Size = eui.Point{X: panelWidth, Y: 24}
+	musicEnhancementCB.Checked = gs.MusicEnhancement
+	musicEnhancementCB.SetTooltip("Add space and ambience to background music")
+	musicEnhancementEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventCheckboxChanged {
+			gs.MusicEnhancement = ev.Checked
+			settingsDirty = true
+		}
+	}
+	center.AddItem(musicEnhancementCB)
 
 	/*
 		mixBtn, mixEvents := eui.NewButton()


### PR DESCRIPTION
## Summary
- replace the old sound-effect reverb with a stereo "Audio enhancement" chain that adds widening, ambience, tone shaping, and dynamics polish
- introduce a user-facing checkbox to keep high quality resampling enabled by default while allowing a faster resampling and conversion path when disabled
- rename the music setting to "Audio enhancement" and migrate legacy settings keys when loading existing configs

## Testing
- `go test ./...` *(fails: missing spellcheck_words.txt asset and X11 headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ae8d3b4c832a8d0afa37d0b707c8