### PR TITLE
Add configurable sprite upscaling

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -16,6 +16,8 @@ func clearCaches() {
 	mobileCache = make(map[mobileKey]*ebiten.Image)
 	mobileBlendCache = make(map[mobileBlendKey]*ebiten.Image)
 	pictBlendCache = make(map[pictBlendKey]*ebiten.Image)
+	scaledImageCache = make(map[scaledImageKey]*ebiten.Image)
+	scaledMobileCache = make(map[scaledMobileKey]*ebiten.Image)
 	imageMu.Unlock()
 
 	pixelCountMu.Lock()

--- a/settings.go
+++ b/settings.go
@@ -96,6 +96,7 @@ var gsdef settings = settings{
 	GameSound:            true,
 	Mute:                 false,
 	GameScale:            2.0,
+	SpriteUpscale:        2,
 	BarPlacement:         BarPlacementBottom,
 	MaxNightLevel:        100,
 	MessagesToConsole:    false,
@@ -240,6 +241,7 @@ type settings struct {
 	GameSound            bool
 	Mute                 bool
 	GameScale            float64
+	SpriteUpscale        int
 	BarPlacement         BarPlacement
 	MaxNightLevel        int
 	forceNightLevel      int
@@ -444,6 +446,10 @@ func loadSettings() bool {
 	// Clamp BubbleScale to 1.0–8.0
 	if gs.BubbleScale < 1.0 || gs.BubbleScale > 8.0 {
 		gs.BubbleScale = gsdef.BubbleScale
+	}
+
+	if gs.SpriteUpscale != 0 && gs.SpriteUpscale != 2 && gs.SpriteUpscale != 3 {
+		gs.SpriteUpscale = gsdef.SpriteUpscale
 	}
 
 	if gs.WindowWidth > 0 && gs.WindowHeight > 0 {
@@ -744,9 +750,11 @@ var (
 
 func applyQualityPreset(name string) {
 	var p qualityPreset
+	spriteUpscale := gsdef.SpriteUpscale
 	switch name {
 	case "Ultra Low":
 		p = ultraLowPreset
+		spriteUpscale = 0
 	case "Low":
 		p = lowPreset
 	case "Standard":
@@ -762,6 +770,7 @@ func applyQualityPreset(name string) {
 	gs.BlendMobiles = p.BlendMobiles
 	gs.BlendPicts = p.BlendPicts
 	gs.ShaderLighting = p.ShaderLighting
+	gs.SpriteUpscale = spriteUpscale
 
 	if denoiseCB != nil {
 		denoiseCB.Checked = gs.DenoiseImages
@@ -774,6 +783,9 @@ func applyQualityPreset(name string) {
 	}
 	if pictBlendCB != nil {
 		pictBlendCB.Checked = gs.BlendPicts
+	}
+	if spriteUpscaleDD != nil {
+		spriteUpscaleDD.Selected = spriteUpscaleIndex(gs.SpriteUpscale)
 	}
 
 	applySettings()

--- a/sprite_upscale.go
+++ b/sprite_upscale.go
@@ -1,0 +1,149 @@
+package main
+
+import "image"
+
+type rgbaPixel struct {
+	r uint8
+	g uint8
+	b uint8
+	a uint8
+}
+
+func sampleRGBA(src *image.RGBA, x, y int) rgbaPixel {
+	b := src.Bounds()
+	w := b.Dx()
+	h := b.Dy()
+	if w == 0 || h == 0 {
+		return rgbaPixel{}
+	}
+	if x < 0 {
+		x = 0
+	} else if x >= w {
+		x = w - 1
+	}
+	if y < 0 {
+		y = 0
+	} else if y >= h {
+		y = h - 1
+	}
+	ax := b.Min.X + x
+	ay := b.Min.Y + y
+	i := src.PixOffset(ax, ay)
+	pix := src.Pix
+	return rgbaPixel{r: pix[i+0], g: pix[i+1], b: pix[i+2], a: pix[i+3]}
+}
+
+func setRGBA(dst *image.RGBA, x, y int, c rgbaPixel) {
+	b := dst.Bounds()
+	ax := b.Min.X + x
+	ay := b.Min.Y + y
+	i := dst.PixOffset(ax, ay)
+	pix := dst.Pix
+	pix[i+0] = c.r
+	pix[i+1] = c.g
+	pix[i+2] = c.b
+	pix[i+3] = c.a
+}
+
+func scale2xRGBA(src *image.RGBA) *image.RGBA {
+	b := src.Bounds()
+	w := b.Dx()
+	h := b.Dy()
+	if w == 0 || h == 0 {
+		return image.NewRGBA(image.Rect(0, 0, 0, 0))
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, w*2, h*2))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			bPix := sampleRGBA(src, x, y-1)
+			d := sampleRGBA(src, x-1, y)
+			e := sampleRGBA(src, x, y)
+			f := sampleRGBA(src, x+1, y)
+			hPix := sampleRGBA(src, x, y+1)
+
+			e0, e1, e2, e3 := e, e, e, e
+			if bPix != hPix && d != f {
+				if d == bPix {
+					e0 = d
+				}
+				if bPix == f {
+					e1 = f
+				}
+				if d == hPix {
+					e2 = d
+				}
+				if hPix == f {
+					e3 = f
+				}
+			}
+			setRGBA(dst, x*2+0, y*2+0, e0)
+			setRGBA(dst, x*2+1, y*2+0, e1)
+			setRGBA(dst, x*2+0, y*2+1, e2)
+			setRGBA(dst, x*2+1, y*2+1, e3)
+		}
+	}
+	return dst
+}
+
+func scale3xRGBA(src *image.RGBA) *image.RGBA {
+	b := src.Bounds()
+	w := b.Dx()
+	h := b.Dy()
+	if w == 0 || h == 0 {
+		return image.NewRGBA(image.Rect(0, 0, 0, 0))
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, w*3, h*3))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			a := sampleRGBA(src, x-1, y-1)
+			bPix := sampleRGBA(src, x, y-1)
+			c := sampleRGBA(src, x+1, y-1)
+			d := sampleRGBA(src, x-1, y)
+			e := sampleRGBA(src, x, y)
+			f := sampleRGBA(src, x+1, y)
+			g := sampleRGBA(src, x-1, y+1)
+			hPix := sampleRGBA(src, x, y+1)
+			i := sampleRGBA(src, x+1, y+1)
+
+			e0, e1, e2, e3, e4, e5, e6, e7, e8 := e, e, e, e, e, e, e, e, e
+			if bPix != hPix && d != f {
+				if d == bPix {
+					e0 = d
+				}
+				if (d == bPix && e != c) || (bPix == f && e != a) {
+					e1 = bPix
+				}
+				if bPix == f {
+					e2 = f
+				}
+				if (d == bPix && e != g) || (d == hPix && e != a) {
+					e3 = d
+				}
+				if (bPix == f && e != i) || (hPix == f && e != c) {
+					e5 = f
+				}
+				if d == hPix {
+					e6 = d
+				}
+				if (d == hPix && e != i) || (hPix == f && e != g) {
+					e7 = hPix
+				}
+				if hPix == f {
+					e8 = f
+				}
+			}
+			ox := x * 3
+			oy := y * 3
+			setRGBA(dst, ox+0, oy+0, e0)
+			setRGBA(dst, ox+1, oy+0, e1)
+			setRGBA(dst, ox+2, oy+0, e2)
+			setRGBA(dst, ox+0, oy+1, e3)
+			setRGBA(dst, ox+1, oy+1, e4)
+			setRGBA(dst, ox+2, oy+1, e5)
+			setRGBA(dst, ox+0, oy+2, e6)
+			setRGBA(dst, ox+1, oy+2, e7)
+			setRGBA(dst, ox+2, oy+2, e8)
+		}
+	}
+	return dst
+}

--- a/sprite_upscale_test.go
+++ b/sprite_upscale_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+func TestScale2xRGBAProducesExpectedEdges(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	blue := color.RGBA{0, 0, 255, 255}
+	red := color.RGBA{255, 0, 0, 255}
+	green := color.RGBA{0, 255, 0, 255}
+	white := color.RGBA{255, 255, 255, 255}
+
+	src.SetRGBA(1, 0, blue)  // B
+	src.SetRGBA(0, 1, blue)  // D
+	src.SetRGBA(1, 1, white) // E
+	src.SetRGBA(2, 1, red)   // F
+	src.SetRGBA(1, 2, green) // H
+
+	dst := scale2xRGBA(src)
+	if dst.Bounds().Dx() != 6 || dst.Bounds().Dy() != 6 {
+		t.Fatalf("unexpected size: %v", dst.Bounds())
+	}
+
+	// Center pixel block starts at (2,2) in the scaled image.
+	topLeft := dst.RGBAAt(2, 2)
+	if topLeft != blue {
+		t.Fatalf("expected top-left pixel to match left/top neighbor, got %#v", topLeft)
+	}
+	topRight := dst.RGBAAt(3, 2)
+	if topRight != white {
+		t.Fatalf("expected top-right pixel to stay center color, got %#v", topRight)
+	}
+}
+
+func TestScale3xRGBAProducesExpectedEdges(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 3, 3))
+	blue := color.RGBA{0, 0, 255, 255}
+	red := color.RGBA{200, 0, 0, 255}
+	green := color.RGBA{0, 255, 0, 255}
+	white := color.RGBA{255, 255, 255, 255}
+	black := color.RGBA{0, 0, 0, 255}
+
+	src.SetRGBA(1, 0, red)   // B
+	src.SetRGBA(0, 1, blue)  // D
+	src.SetRGBA(1, 1, white) // E
+	src.SetRGBA(2, 1, red)   // F
+	src.SetRGBA(1, 2, green) // H
+	src.SetRGBA(2, 2, black) // I
+
+	dst := scale3xRGBA(src)
+	if dst.Bounds().Dx() != 9 || dst.Bounds().Dy() != 9 {
+		t.Fatalf("unexpected size: %v", dst.Bounds())
+	}
+
+	// Center block origin at (3,3). Verify E2 (top-right) and E5 (middle-right).
+	topRight := dst.RGBAAt(5, 3)
+	if topRight != red {
+		t.Fatalf("expected top-right pixel to adopt right neighbor, got %#v", topRight)
+	}
+	middleRight := dst.RGBAAt(5, 4)
+	if middleRight != red {
+		t.Fatalf("expected middle-right pixel to adopt right neighbor, got %#v", middleRight)
+	}
+}

--- a/ui.go
+++ b/ui.go
@@ -75,6 +75,28 @@ func applyBoldFace(it *eui.ItemData) {
 	}
 }
 
+func spriteUpscaleIndex(val int) int {
+	switch val {
+	case 2:
+		return 1
+	case 3:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func spriteUpscaleValue(idx int) int {
+	switch idx {
+	case 1:
+		return 2
+	case 2:
+		return 3
+	default:
+		return 0
+	}
+}
+
 var changelogList *eui.ItemData
 var changelogPrevBtn *eui.ItemData
 var changelogNextBtn *eui.ItemData
@@ -106,19 +128,22 @@ var shaderWarnWin *eui.WindowData
 var shaderWarnDontShowCB *eui.ItemData
 
 var (
-	sheetCacheLabel  *eui.ItemData
-	frameCacheLabel  *eui.ItemData
-	mobileCacheLabel *eui.ItemData
-	soundCacheLabel  *eui.ItemData
-	mobileBlendLabel *eui.ItemData
-	pictBlendLabel   *eui.ItemData
-	totalCacheLabel  *eui.ItemData
-	pingLabel        *eui.ItemData
+	sheetCacheLabel        *eui.ItemData
+	frameCacheLabel        *eui.ItemData
+	scaledFrameCacheLabel  *eui.ItemData
+	mobileCacheLabel       *eui.ItemData
+	scaledMobileCacheLabel *eui.ItemData
+	soundCacheLabel        *eui.ItemData
+	mobileBlendLabel       *eui.ItemData
+	pictBlendLabel         *eui.ItemData
+	totalCacheLabel        *eui.ItemData
+	pingLabel              *eui.ItemData
 
 	recordBtn         *eui.ItemData
 	recordStatus      *eui.ItemData
 	recordPath        string
 	qualityPresetDD   *eui.ItemData
+	spriteUpscaleDD   *eui.ItemData
 	shaderLightSlider *eui.ItemData
 	shaderGlowSlider  *eui.ItemData
 	denoiseCB         *eui.ItemData
@@ -4320,19 +4345,41 @@ func makeQualityWindow() {
 	}
 	left.AddItem(renderScale)
 
-	/*
-		showFPSCB, showFPSEvents := eui.NewCheckbox()
-		showFPSCB.Text = "Show FPS + UPS"
-		showFPSCB.Size = eui.Point{X: width, Y: 24}
-		showFPSCB.Checked = gs.ShowFPS
-		showFPSCB.SetTooltip("Display frames per second, and updates per second")
-		showFPSEvents.Handle = func(ev eui.UIEvent) {
-			if ev.Type == eui.EventCheckboxChanged {
-				gs.ShowFPS = ev.Checked
+	dd, spriteUpscaleEvents := eui.NewDropdown()
+	spriteUpscaleDD = dd
+	spriteUpscaleDD.Label = "Sprite Upscaling"
+	spriteUpscaleDD.Options = []string{"Off", "2x XBR-like", "3x XBR-like"}
+	spriteUpscaleDD.Size = eui.Point{X: width - 10, Y: 24}
+	spriteUpscaleDD.Selected = spriteUpscaleIndex(gs.SpriteUpscale)
+	spriteUpscaleDD.SetTooltip("Edge-aware upscaling for world sprites (higher values increase VRAM use)")
+	spriteUpscaleEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventDropdownSelected {
+			newVal := spriteUpscaleValue(ev.Index)
+			if newVal != gs.SpriteUpscale {
+				gs.SpriteUpscale = newVal
 				settingsDirty = true
+				clearCaches()
+				if qualityPresetDD != nil {
+					qualityPresetDD.Selected = detectQualityPreset()
+				}
 			}
 		}
-		flow.AddItem(showFPSCB)
+	}
+	left.AddItem(spriteUpscaleDD)
+
+	/*
+	                showFPSCB, showFPSEvents := eui.NewCheckbox()
+	                showFPSCB.Text = "Show FPS + UPS"
+			showFPSCB.Size = eui.Point{X: width, Y: 24}
+			showFPSCB.Checked = gs.ShowFPS
+			showFPSCB.SetTooltip("Display frames per second, and updates per second")
+			showFPSEvents.Handle = func(ev eui.UIEvent) {
+				if ev.Type == eui.EventCheckboxChanged {
+					gs.ShowFPS = ev.Checked
+					settingsDirty = true
+				}
+			}
+			flow.AddItem(showFPSCB)
 	*/
 
 	psCB, precacheSoundEvents := eui.NewCheckbox()
@@ -5107,11 +5154,23 @@ func makeDebugWindow() {
 	frameCacheLabel.FontSize = 10
 	debugFlow.AddItem(frameCacheLabel)
 
+	scaledFrameCacheLabel, _ = eui.NewText()
+	scaledFrameCacheLabel.Text = ""
+	scaledFrameCacheLabel.Size = eui.Point{X: width, Y: 24}
+	scaledFrameCacheLabel.FontSize = 10
+	debugFlow.AddItem(scaledFrameCacheLabel)
+
 	mobileCacheLabel, _ = eui.NewText()
 	mobileCacheLabel.Text = ""
 	mobileCacheLabel.Size = eui.Point{X: width, Y: 24}
 	mobileCacheLabel.FontSize = 10
 	debugFlow.AddItem(mobileCacheLabel)
+
+	scaledMobileCacheLabel, _ = eui.NewText()
+	scaledMobileCacheLabel.Text = ""
+	scaledMobileCacheLabel.Size = eui.Point{X: width, Y: 24}
+	scaledMobileCacheLabel.FontSize = 10
+	debugFlow.AddItem(scaledMobileCacheLabel)
 
 	soundCacheLabel, _ = eui.NewText()
 	soundCacheLabel.Text = ""
@@ -5159,27 +5218,35 @@ func updateDebugStats() {
 		return
 	}
 
-	sheetCount, sheetBytes, frameCount, frameBytes, mobileCount, mobileBytes, mobileBlendCount, mobileBlendBytes, pictBlendCount, pictBlendBytes := imageCacheStats()
+	stats := imageCacheStats()
 	soundCount, soundBytes := soundCacheStats()
 
 	if sheetCacheLabel != nil {
-		sheetCacheLabel.Text = fmt.Sprintf("Sprite Sheets: %d (%s)", sheetCount, humanize.Bytes(uint64(sheetBytes)))
+		sheetCacheLabel.Text = fmt.Sprintf("Sprite Sheets: %d (%s)", stats.sheetCount, humanize.Bytes(uint64(stats.sheetBytes)))
 		sheetCacheLabel.Dirty = true
 	}
 	if frameCacheLabel != nil {
-		frameCacheLabel.Text = fmt.Sprintf("Animation Frames: %d (%s)", frameCount, humanize.Bytes(uint64(frameBytes)))
+		frameCacheLabel.Text = fmt.Sprintf("Animation Frames: %d (%s)", stats.frameCount, humanize.Bytes(uint64(stats.frameBytes)))
 		frameCacheLabel.Dirty = true
 	}
+	if scaledFrameCacheLabel != nil {
+		scaledFrameCacheLabel.Text = fmt.Sprintf("Upscaled Frames: %d (%s)", stats.scaledFrameCount, humanize.Bytes(uint64(stats.scaledFrameBytes)))
+		scaledFrameCacheLabel.Dirty = true
+	}
 	if mobileCacheLabel != nil {
-		mobileCacheLabel.Text = fmt.Sprintf("Mobile Animation Frames: %d (%s)", mobileCount, humanize.Bytes(uint64(mobileBytes)))
+		mobileCacheLabel.Text = fmt.Sprintf("Mobile Animation Frames: %d (%s)", stats.mobileCount, humanize.Bytes(uint64(stats.mobileBytes)))
 		mobileCacheLabel.Dirty = true
 	}
+	if scaledMobileCacheLabel != nil {
+		scaledMobileCacheLabel.Text = fmt.Sprintf("Upscaled Mobile Frames: %d (%s)", stats.scaledMobileCount, humanize.Bytes(uint64(stats.scaledMobileBytes)))
+		scaledMobileCacheLabel.Dirty = true
+	}
 	if mobileBlendLabel != nil {
-		mobileBlendLabel.Text = fmt.Sprintf("Mobile Blend Frames: %d (%s)", mobileBlendCount, humanize.Bytes(uint64(mobileBlendBytes)))
+		mobileBlendLabel.Text = fmt.Sprintf("Mobile Blend Frames: %d (%s)", stats.mobileBlendCount, humanize.Bytes(uint64(stats.mobileBlendBytes)))
 		mobileBlendLabel.Dirty = true
 	}
 	if pictBlendLabel != nil {
-		pictBlendLabel.Text = fmt.Sprintf("World Blend Frames: %d (%s)", pictBlendCount, humanize.Bytes(uint64(pictBlendBytes)))
+		pictBlendLabel.Text = fmt.Sprintf("World Blend Frames: %d (%s)", stats.pictBlendCount, humanize.Bytes(uint64(stats.pictBlendBytes)))
 		pictBlendLabel.Dirty = true
 	}
 	if soundCacheLabel != nil {
@@ -5187,7 +5254,8 @@ func updateDebugStats() {
 		soundCacheLabel.Dirty = true
 	}
 	if totalCacheLabel != nil {
-		totalCacheLabel.Text = fmt.Sprintf("Total: %s", humanize.Bytes(uint64(sheetBytes+frameBytes+mobileBytes+soundBytes+mobileBlendBytes+pictBlendBytes)))
+		total := stats.sheetBytes + stats.frameBytes + stats.scaledFrameBytes + stats.mobileBytes + stats.scaledMobileBytes + stats.mobileBlendBytes + stats.pictBlendBytes + soundBytes
+		totalCacheLabel.Text = fmt.Sprintf("Total: %s", humanize.Bytes(uint64(total)))
 		totalCacheLabel.Dirty = true
 	}
 }


### PR DESCRIPTION
## Summary
- implement 2x and 3x pixel-aware sprite upscaling and cache the scaled frames for pictures and mobiles
- add a sprite upscaling setting with defaults, quality preset integration, UI controls, and cache statistics
- add unit tests that exercise the scale2x and scale3x edge rules

## Testing
- go test ./... *(fails: missing spellcheck_words.txt and X11 headers in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9adb5f294832a9a1fc275195f0d52