### PR TITLE
Fix game sound playback speed

### DIFF
--- a/sound.go
+++ b/sound.go
@@ -896,7 +896,7 @@ func loadSound(id uint16) []byte {
 	statSoundLoaded(id)
 	//logDebug("loadSound(%d) loaded %d Hz %d-bit %d bytes", id, s.SampleRate, s.Bits, len(s.Data))
 
-	srcRate := int(s.SampleRate / 2)
+	srcRate := int(s.SampleRate)
 	dstRate := audioContext.SampleRate()
 
 	// Decode the sound data into 16-bit samples.


### PR DESCRIPTION
## Summary
- use the decoded sound's actual sample rate instead of halving it before resampling so effects no longer slow playback

## Testing
- go test ./... *(fails: GLFW requires a DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c839db3c832aacefb4af9605d4c7