### PR TITLE
Rename sprite upscaling options to Smart Upscale

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -4366,7 +4366,7 @@ func makeQualityWindow() {
 	dd, spriteUpscaleEvents := eui.NewDropdown()
 	spriteUpscaleDD = dd
 	spriteUpscaleDD.Label = "Sprite Upscaling"
-	spriteUpscaleDD.Options = []string{"Off", "2x XBR-like", "3x XBR-like", "4x XBR-like"}
+	spriteUpscaleDD.Options = []string{"Off", "2x Smart Upscale", "3x Smart Upscale", "4x Smart Upscale"}
 	spriteUpscaleDD.Size = eui.Point{X: width - 10, Y: 24}
 	spriteUpscaleDD.Selected = spriteUpscaleIndex(gs.SpriteUpscale)
 	spriteUpscaleDD.SetTooltip("Edge-aware upscaling for world sprites (higher values increase VRAM use)")


### PR DESCRIPTION
## Summary
- rename the sprite upscaling dropdown options to use the "Smart Upscale" terminology

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c92cee8c832ab2a50e4f44a50a1e