### PR TITLE
Align sprite upscaling with game scale

### DIFF
--- a/images.go
+++ b/images.go
@@ -374,7 +374,7 @@ func upscaleSpriteImage(img *ebiten.Image, factor int) *ebiten.Image {
 }
 
 func getScaledPictureFrame(id uint16, frame int, img *ebiten.Image) *ebiten.Image {
-	factor := int(gs.SpriteUpscale)
+	factor := spriteUpscaleFactor()
 	if factor <= 1 || img == nil {
 		return img
 	}
@@ -393,7 +393,7 @@ func getScaledPictureFrame(id uint16, frame int, img *ebiten.Image) *ebiten.Imag
 }
 
 func getScaledMobileFrame(key mobileKey, img *ebiten.Image) *ebiten.Image {
-	factor := int(gs.SpriteUpscale)
+	factor := spriteUpscaleFactor()
 	if factor <= 1 || img == nil {
 		return img
 	}

--- a/settings.go
+++ b/settings.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -34,6 +35,21 @@ var settingsLoaded bool
 // current UI scale. Initialization defers restoration until the first layout
 // provides a final screen size.
 var windowsRestored bool
+
+func spriteUpscaleFactorFromScale(scale float64) int {
+	factor := int(math.Round(scale))
+	if factor < 1 {
+		factor = 1
+	}
+	if factor > 4 {
+		factor = 4
+	}
+	return factor
+}
+
+func spriteUpscaleFactor() int {
+	return spriteUpscaleFactorFromScale(gs.GameScale)
+}
 
 var gsdef settings = settings{
 	Version: SETTINGS_VERSION,
@@ -458,9 +474,7 @@ func loadSettings() bool {
 		gs.BubbleScale = gsdef.BubbleScale
 	}
 
-	if gs.SpriteUpscale != 0 && gs.SpriteUpscale != 2 && gs.SpriteUpscale != 3 && gs.SpriteUpscale != 4 {
-		gs.SpriteUpscale = gsdef.SpriteUpscale
-	}
+	gs.SpriteUpscale = spriteUpscaleFactor()
 
 	if gs.WindowWidth > 0 && gs.WindowHeight > 0 {
 		eui.SetScreenSize(gs.WindowWidth, gs.WindowHeight)
@@ -760,11 +774,9 @@ var (
 
 func applyQualityPreset(name string) {
 	var p qualityPreset
-	spriteUpscale := gsdef.SpriteUpscale
 	switch name {
 	case "Ultra Low":
 		p = ultraLowPreset
-		spriteUpscale = 0
 	case "Low":
 		p = lowPreset
 	case "Standard":
@@ -780,7 +792,7 @@ func applyQualityPreset(name string) {
 	gs.BlendMobiles = p.BlendMobiles
 	gs.BlendPicts = p.BlendPicts
 	gs.ShaderLighting = p.ShaderLighting
-	gs.SpriteUpscale = spriteUpscale
+	gs.SpriteUpscale = spriteUpscaleFactor()
 
 	if denoiseCB != nil {
 		denoiseCB.Checked = gs.DenoiseImages
@@ -794,10 +806,6 @@ func applyQualityPreset(name string) {
 	if pictBlendCB != nil {
 		pictBlendCB.Checked = gs.BlendPicts
 	}
-	if spriteUpscaleDD != nil {
-		spriteUpscaleDD.Selected = spriteUpscaleIndex(gs.SpriteUpscale)
-	}
-
 	applySettings()
 	clearCaches()
 	settingsDirty = true

--- a/ui.go
+++ b/ui.go
@@ -75,32 +75,6 @@ func applyBoldFace(it *eui.ItemData) {
 	}
 }
 
-func spriteUpscaleIndex(val int) int {
-	switch val {
-	case 2:
-		return 1
-	case 3:
-		return 2
-	case 4:
-		return 3
-	default:
-		return 0
-	}
-}
-
-func spriteUpscaleValue(idx int) int {
-	switch idx {
-	case 1:
-		return 2
-	case 2:
-		return 3
-	case 3:
-		return 4
-	default:
-		return 0
-	}
-}
-
 var changelogList *eui.ItemData
 var changelogPrevBtn *eui.ItemData
 var changelogNextBtn *eui.ItemData
@@ -147,7 +121,6 @@ var (
 	recordStatus      *eui.ItemData
 	recordPath        string
 	qualityPresetDD   *eui.ItemData
-	spriteUpscaleDD   *eui.ItemData
 	shaderLightSlider *eui.ItemData
 	shaderGlowSlider  *eui.ItemData
 	denoiseCB         *eui.ItemData
@@ -4345,6 +4318,7 @@ func makeQualityWindow() {
 	renderScale.SetTooltip("Game render resolution (1x - 4x). Higher will be shaper on higher-res displays.")
 	renderScaleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
+			prevUpscale := gs.SpriteUpscale
 			v := math.Round(float64(ev.Value))
 			if v < 1 {
 				v = 1
@@ -4353,6 +4327,10 @@ func makeQualityWindow() {
 				v = 10
 			}
 			gs.GameScale = v
+			gs.SpriteUpscale = spriteUpscaleFactor()
+			if gs.SpriteUpscale != prevUpscale {
+				clearCaches()
+			}
 			renderScale.Value = float32(v)
 			settingsDirty = true
 			initFont()
@@ -4363,41 +4341,19 @@ func makeQualityWindow() {
 	}
 	left.AddItem(renderScale)
 
-	dd, spriteUpscaleEvents := eui.NewDropdown()
-	spriteUpscaleDD = dd
-	spriteUpscaleDD.Label = "Sprite Upscaling"
-	spriteUpscaleDD.Options = []string{"Off", "2x Smart Upscale", "3x Smart Upscale", "4x Smart Upscale"}
-	spriteUpscaleDD.Size = eui.Point{X: width - 10, Y: 24}
-	spriteUpscaleDD.Selected = spriteUpscaleIndex(gs.SpriteUpscale)
-	spriteUpscaleDD.SetTooltip("Edge-aware upscaling for world sprites (higher values increase VRAM use)")
-	spriteUpscaleEvents.Handle = func(ev eui.UIEvent) {
-		if ev.Type == eui.EventDropdownSelected {
-			newVal := spriteUpscaleValue(ev.Index)
-			if newVal != gs.SpriteUpscale {
-				gs.SpriteUpscale = newVal
-				settingsDirty = true
-				clearCaches()
-				if qualityPresetDD != nil {
-					qualityPresetDD.Selected = detectQualityPreset()
-				}
-			}
-		}
-	}
-	left.AddItem(spriteUpscaleDD)
-
 	/*
-		                showFPSCB, showFPSEvents := eui.NewCheckbox()
-		                showFPSCB.Text = "Show FPS + UPS"
-				showFPSCB.Size = eui.Point{X: width, Y: 24}
-				showFPSCB.Checked = gs.ShowFPS
-				showFPSCB.SetTooltip("Display frames per second, and updates per second")
-				showFPSEvents.Handle = func(ev eui.UIEvent) {
-					if ev.Type == eui.EventCheckboxChanged {
-						gs.ShowFPS = ev.Checked
-						settingsDirty = true
+	                                showFPSCB, showFPSEvents := eui.NewCheckbox()
+	                                showFPSCB.Text = "Show FPS + UPS"
+					showFPSCB.Size = eui.Point{X: width, Y: 24}
+					showFPSCB.Checked = gs.ShowFPS
+					showFPSCB.SetTooltip("Display frames per second, and updates per second")
+					showFPSEvents.Handle = func(ev eui.UIEvent) {
+						if ev.Type == eui.EventCheckboxChanged {
+							gs.ShowFPS = ev.Checked
+							settingsDirty = true
+						}
 					}
-				}
-				flow.AddItem(showFPSCB)
+					flow.AddItem(showFPSCB)
 	*/
 
 	psCB, precacheSoundEvents := eui.NewCheckbox()


### PR DESCRIPTION
## Summary
- derive the sprite upscaling factor directly from the current game scale
- remove the separate sprite upscaling dropdown and clear caches when the render scale changes
- keep settings load and quality presets synced with the derived upscaling factor

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9df477800832a82c54dfb468b2a79