### PR TITLE
Add slider for sound enhancement intensity

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -51,6 +51,16 @@ func spriteUpscaleFactor() int {
 	return spriteUpscaleFactorFromScale(gs.GameScale)
 }
 
+func clampSoundEnhancementAmount(v float64) float64 {
+	if v < 0.1 {
+		return 0.1
+	}
+	if v > 10 {
+		return 10
+	}
+	return v
+}
+
 var gsdef settings = settings{
 	Version: SETTINGS_VERSION,
 
@@ -164,12 +174,13 @@ var gsdef settings = settings{
 	ShaderLightStrength: 1.0,
 	ShaderGlowStrength:  1.0,
 
-	PotatoGPU:             false,
-	BarColorByValue:       false,
-	ThrottleSounds:        true,
-	SoundEnhancement:      true,
-	MusicEnhancement:      true,
-	HighQualityResampling: true,
+	PotatoGPU:              false,
+	BarColorByValue:        false,
+	ThrottleSounds:         true,
+	SoundEnhancement:       true,
+	SoundEnhancementAmount: 1.0,
+	MusicEnhancement:       true,
+	HighQualityResampling:  true,
 
 	NightEffect:    true,
 	ShaderLighting: true,
@@ -320,13 +331,14 @@ type settings struct {
 	ShaderLightStrength float64
 	ShaderGlowStrength  float64
 
-	PotatoGPU             bool
-	EnabledPlugins        map[string]any
-	BarColorByValue       bool
-	ThrottleSounds        bool
-	SoundEnhancement      bool
-	MusicEnhancement      bool
-	HighQualityResampling bool
+	PotatoGPU              bool
+	EnabledPlugins         map[string]any
+	BarColorByValue        bool
+	ThrottleSounds         bool
+	SoundEnhancement       bool
+	SoundEnhancementAmount float64
+	MusicEnhancement       bool
+	HighQualityResampling  bool
 
 	imgPlanesDebug    bool
 	smoothingDebug    bool
@@ -468,6 +480,8 @@ func loadSettings() bool {
 	if gs.ShaderGlowStrength < 0 || gs.ShaderGlowStrength > 2 {
 		gs.ShaderGlowStrength = gsdef.ShaderGlowStrength
 	}
+
+	gs.SoundEnhancementAmount = clampSoundEnhancementAmount(gs.SoundEnhancementAmount)
 
 	// Clamp BubbleScale to 1.0–8.0
 	if gs.BubbleScale < 1.0 || gs.BubbleScale > 8.0 {

--- a/sound.go
+++ b/sound.go
@@ -568,9 +568,31 @@ func applyGameSoundReverb(samples []int32) {
 		applyBiquad(wetBuffer, shelf)
 	}
 
-	applySlapDelay(wetBuffer, rate, 0.085, 0.42, 0.58)
+	amount := clampSoundEnhancementAmount(gs.SoundEnhancementAmount)
+	mixScale := math.Sqrt(amount)
 
-	const wetMix = 0.14
+	delayFeedback := 0.42 * mixScale
+	if delayFeedback > 0.9 {
+		delayFeedback = 0.9
+	} else if delayFeedback < 0 {
+		delayFeedback = 0
+	}
+
+	delayMix := 0.58 * mixScale
+	if delayMix > 0.95 {
+		delayMix = 0.95
+	} else if delayMix < 0 {
+		delayMix = 0
+	}
+
+	applySlapDelay(wetBuffer, rate, 0.085, delayFeedback, delayMix)
+
+	wetMix := 0.14 * amount
+	if wetMix > 0.85 {
+		wetMix = 0.85
+	} else if wetMix < 0 {
+		wetMix = 0
+	}
 	const scatterRatio = 0.4
 	combMix := wetMix * (1 - scatterRatio)
 	if combMix < 0 {
@@ -580,9 +602,17 @@ func applyGameSoundReverb(samples []int32) {
 	if scatterMix < 0 {
 		scatterMix = 0
 	}
-	const dryMix = 1 - wetMix
+	dryMix := 1 - wetMix
+	if dryMix < 0 {
+		dryMix = 0
+	}
 	const wetLowpass = 0.3
-	const scatterFeedback = 0.1
+	scatterFeedback := 0.1 * amount
+	if scatterFeedback > 0.9 {
+		scatterFeedback = 0.9
+	} else if scatterFeedback < 0 {
+		scatterFeedback = 0
+	}
 	const maxInt32 = float64(1<<31 - 1)
 	const minInt32 = -float64(1 << 31)
 

--- a/ui.go
+++ b/ui.go
@@ -3634,13 +3634,30 @@ func makeSettingsWindow() {
 	enhancementCB.Size = eui.Point{X: panelWidth, Y: 24}
 	enhancementCB.Checked = gs.SoundEnhancement
 	enhancementCB.SetTooltip("Stereo width, ambience, and tone polish for in-game sounds")
+	enhancementStrengthSlider, enhancementStrengthEvents := eui.NewSlider()
+	enhancementStrengthSlider.Label = "Enhancement Strength"
+	enhancementStrengthSlider.MinValue = 0.1
+	enhancementStrengthSlider.MaxValue = 10
+	enhancementStrengthSlider.Value = float32(gs.SoundEnhancementAmount)
+	enhancementStrengthSlider.Size = eui.Point{X: panelWidth - 10, Y: 24}
+	enhancementStrengthSlider.Disabled = !gs.SoundEnhancement
+	enhancementStrengthSlider.SetTooltip("0.1 is subtle, 10 is very pronounced")
 	enhancementEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.SoundEnhancement = ev.Checked
+			enhancementStrengthSlider.Disabled = !ev.Checked
 			settingsDirty = true
 		}
 	}
 	center.AddItem(enhancementCB)
+
+	enhancementStrengthEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventSliderChanged {
+			gs.SoundEnhancementAmount = clampSoundEnhancementAmount(float64(ev.Value))
+			settingsDirty = true
+		}
+	}
+	center.AddItem(enhancementStrengthSlider)
 
 	resampleCB, resampleEvents := eui.NewCheckbox()
 	resampleCB.Text = "High quality resampling"
@@ -4342,18 +4359,18 @@ func makeQualityWindow() {
 	left.AddItem(renderScale)
 
 	/*
-	                                showFPSCB, showFPSEvents := eui.NewCheckbox()
-	                                showFPSCB.Text = "Show FPS + UPS"
-					showFPSCB.Size = eui.Point{X: width, Y: 24}
-					showFPSCB.Checked = gs.ShowFPS
-					showFPSCB.SetTooltip("Display frames per second, and updates per second")
-					showFPSEvents.Handle = func(ev eui.UIEvent) {
-						if ev.Type == eui.EventCheckboxChanged {
-							gs.ShowFPS = ev.Checked
-							settingsDirty = true
+		                                showFPSCB, showFPSEvents := eui.NewCheckbox()
+		                                showFPSCB.Text = "Show FPS + UPS"
+						showFPSCB.Size = eui.Point{X: width, Y: 24}
+						showFPSCB.Checked = gs.ShowFPS
+						showFPSCB.SetTooltip("Display frames per second, and updates per second")
+						showFPSEvents.Handle = func(ev eui.UIEvent) {
+							if ev.Type == eui.EventCheckboxChanged {
+								gs.ShowFPS = ev.Checked
+								settingsDirty = true
+							}
 						}
-					}
-					flow.AddItem(showFPSCB)
+						flow.AddItem(showFPSCB)
 	*/
 
 	psCB, precacheSoundEvents := eui.NewCheckbox()


### PR DESCRIPTION
## Summary
- add a settings slider that controls how strong the in-game sound enhancement is
- persist the enhancement amount in the settings file with defaults and clamping
- scale the reverb processing parameters based on the chosen enhancement amount

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e3d3795c832abfa143a175181d44