### PR TITLE
Fix HighQualityResampling toggle

### DIFF
--- a/chat_tts_blocklist_test.go
+++ b/chat_tts_blocklist_test.go
@@ -14,7 +14,11 @@ func TestNoTTSBlocklist(t *testing.T) {
 	blockTTS = false
 	gs.ChatTTSBlocklist = []string{"blocked"}
 	syncTTSBlocklist()
-	defer func() { gs = origGS; syncTTSBlocklist() }()
+	defer func() {
+		gs = origGS
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
+		syncTTSBlocklist()
+	}()
 
 	stopAllTTS()
 

--- a/chat_tts_test.go
+++ b/chat_tts_test.go
@@ -67,7 +67,10 @@ func TestChatTTSPendingLimit(t *testing.T) {
 	gs.ChatTTS = true
 	gs.Mute = false
 	blockTTS = false
-	defer func() { gs = origGS }()
+	defer func() {
+		gs = origGS
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
+	}()
 
 	stopAllTTS()
 
@@ -100,7 +103,10 @@ func TestChatTTSDisableDropsQueued(t *testing.T) {
 	gs.ChatTTS = true
 	gs.Mute = false
 	blockTTS = false
-	defer func() { gs = origGS }()
+	defer func() {
+		gs = origGS
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
+	}()
 
 	stopAllTTS()
 
@@ -163,7 +169,10 @@ func TestChatTTSSameSpeakerCondenses(t *testing.T) {
 	gs.ChatTTS = true
 	gs.Mute = false
 	blockTTS = false
-	defer func() { gs = origGS }()
+	defer func() {
+		gs = origGS
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
+	}()
 
 	stopAllTTS()
 	lastTTSSpeaker = ""

--- a/quality_preset_test.go
+++ b/quality_preset_test.go
@@ -8,10 +8,12 @@ func TestQualityPresetPersisted(t *testing.T) {
 	t.Cleanup(func() { dataDirPath = origDir })
 
 	gs = gsdef
+	setHighQualityResamplingEnabled(gs.HighQualityResampling)
 	applyQualityPreset("Low")
 	saveSettings()
 
 	gs = gsdef
+	setHighQualityResamplingEnabled(gs.HighQualityResampling)
 	loadSettings()
 
 	if gs.ShaderLighting {

--- a/settings.go
+++ b/settings.go
@@ -384,6 +384,7 @@ func loadSettings() bool {
 	if err != nil {
 		gs = gsdef
 		applyQualityPreset("High")
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
 		settingsLoaded = false
 		return false
 	}
@@ -398,6 +399,7 @@ func loadSettings() bool {
 	tmp := settingsFile{settings: gsdef}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		gs = gsdef
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
 		settingsLoaded = false
 		return false
 	}
@@ -410,6 +412,7 @@ func loadSettings() bool {
 			tmp.settings.MusicEnhancement = *tmp.LegacyMusicReverb
 		}
 		gs = tmp.settings
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
 		// Normalize and retain whatever was in the file; migrate into runtime scope map.
 		gs.EnabledPlugins = make(map[string]any)
 		for k, v := range tmp.EnabledPlugins {
@@ -425,6 +428,7 @@ func loadSettings() bool {
 	} else {
 		gs = gsdef
 		applyQualityPreset("High")
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
 		settingsLoaded = false
 		return false
 	}

--- a/sound_settings_test.go
+++ b/sound_settings_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestSetHighQualityResamplingEnabled(t *testing.T) {
+	orig := highQualityResampling.Load()
+	defer setHighQualityResamplingEnabled(orig)
+
+	setHighQualityResamplingEnabled(false)
+	if highQualityResampling.Load() {
+		t.Fatalf("expected highQualityResampling to be false")
+	}
+
+	setHighQualityResamplingEnabled(true)
+	if !highQualityResampling.Load() {
+		t.Fatalf("expected highQualityResampling to be true")
+	}
+}

--- a/synth_test.go
+++ b/synth_test.go
@@ -157,7 +157,10 @@ func TestPlayMuted(t *testing.T) {
 	gs.Music = false
 	gs.MasterVolume = 1
 	gs.MusicVolume = 1
-	t.Cleanup(func() { gs = orig })
+	t.Cleanup(func() {
+		gs = orig
+		setHighQualityResamplingEnabled(gs.HighQualityResampling)
+	})
 	if err := Play(ctx, 0, nil); err == nil || err.Error() != "music muted" {
 		t.Fatalf("expected music muted error, got %v", err)
 	}

--- a/ui.go
+++ b/ui.go
@@ -3650,6 +3650,7 @@ func makeSettingsWindow() {
 	resampleEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			gs.HighQualityResampling = ev.Checked
+			setHighQualityResamplingEnabled(ev.Checked)
 			clearCaches()
 			settingsDirty = true
 		}
@@ -3949,6 +3950,7 @@ func makeSettingsWindow() {
 // resetAllSettings restores gs to defaults, reapplies, and refreshes windows.
 func resetAllSettings() {
 	gs = gsdef
+	setHighQualityResamplingEnabled(gs.HighQualityResampling)
 	clampWindowSettings()
 	applySettings()
 	updateGameWindowSize()
@@ -4342,18 +4344,18 @@ func makeQualityWindow() {
 	left.AddItem(renderScale)
 
 	/*
-	                                showFPSCB, showFPSEvents := eui.NewCheckbox()
-	                                showFPSCB.Text = "Show FPS + UPS"
-					showFPSCB.Size = eui.Point{X: width, Y: 24}
-					showFPSCB.Checked = gs.ShowFPS
-					showFPSCB.SetTooltip("Display frames per second, and updates per second")
-					showFPSEvents.Handle = func(ev eui.UIEvent) {
-						if ev.Type == eui.EventCheckboxChanged {
-							gs.ShowFPS = ev.Checked
-							settingsDirty = true
+		                                showFPSCB, showFPSEvents := eui.NewCheckbox()
+		                                showFPSCB.Text = "Show FPS + UPS"
+						showFPSCB.Size = eui.Point{X: width, Y: 24}
+						showFPSCB.Checked = gs.ShowFPS
+						showFPSCB.SetTooltip("Display frames per second, and updates per second")
+						showFPSEvents.Handle = func(ev eui.UIEvent) {
+							if ev.Type == eui.EventCheckboxChanged {
+								gs.ShowFPS = ev.Checked
+								settingsDirty = true
+							}
 						}
-					}
-					flow.AddItem(showFPSCB)
+						flow.AddItem(showFPSCB)
 	*/
 
 	psCB, precacheSoundEvents := eui.NewCheckbox()


### PR DESCRIPTION
## Summary
- back the HighQualityResampling toggle with an atomic flag and use it from the sound loader
- keep the runtime flag synchronized when loading settings and resetting from the UI
- update tests to restore the flag and add coverage for the setter helper

## Testing
- `go test ./...` *(fails: missing libasound/Xrandr development packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e2abe19c832a916df6e41f176ccb