### PR TITLE
Reuse static WASM index template in release script

### DIFF
--- a/build-scripts/build_binaries.sh
+++ b/build-scripts/build_binaries.sh
@@ -12,6 +12,7 @@ platforms=(
   "windows:amd64"
   "darwin:arm64"
   "darwin:amd64"
+  "js:wasm"
 )
 
 declare -A FRIENDLY_NAMES=(
@@ -19,7 +20,50 @@ declare -A FRIENDLY_NAMES=(
   ["windows:amd64"]="goThoom-Windows-x86_64"
   ["darwin:arm64"]="goThoom-macOS-AppleSilicon"
   ["darwin:amd64"]="goThoom-macOS-Intel"
+  ["js:wasm"]="goThoom-Web"
 )
+
+build_wasm() {
+  local friendly="${FRIENDLY_NAMES["js:wasm"]}"
+  local pkg_dir="${OUTPUT_DIR}/${friendly}"
+  local wasm_out="${pkg_dir}/gothoom.wasm"
+
+  rm -rf "$pkg_dir"
+  mkdir -p "$pkg_dir"
+
+  env \
+    GOOS=js GOARCH=wasm \
+    CGO_ENABLED=0 \
+    go build \
+      -trimpath \
+      -ldflags "-s -w" \
+      -o "$wasm_out" .
+
+  local goroot
+  goroot="$(go env GOROOT)"
+  local wasm_exec="${goroot}/misc/wasm/wasm_exec.js"
+  if [ ! -f "$wasm_exec" ]; then
+    echo "wasm_exec.js not found in ${wasm_exec}" >&2
+    exit 1
+  fi
+  cp "$wasm_exec" "$pkg_dir/"
+
+  local wasm_index="${SCRIPT_DIR}/../web/index.html"
+  if [ ! -f "$wasm_index" ]; then
+    echo "Missing web/index.html. Please create it before building the WASM bundle." >&2
+    exit 1
+  fi
+  cp "$wasm_index" "${pkg_dir}/index.html"
+
+  ensure_cmd brotli brotli
+  brotli -f -k "$wasm_out"
+
+  (
+    cd "$OUTPUT_DIR"
+    zip -q -r "${friendly}.zip" "$friendly"
+    rm -rf "$friendly"
+  )
+}
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -147,6 +191,11 @@ for platform in "${platforms[@]}"; do
   ZIP_NAME="${FRIENDLY}.zip"
   TAGS=""
   LDFLAGS="-s -w"
+
+  if [ "$GOOS:$GOARCH" = "js:wasm" ]; then
+    build_wasm
+    continue
+  fi
 
   if [ "$GOOS" = "windows" ]; then
     BIN_NAME+=".exe"

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/pprof"
-	"syscall"
 	"time"
 
 	"gothoom/climg"
@@ -154,7 +153,7 @@ func main() {
 	loadStats()
 	defer saveStats()
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+	ctx, cancel := signal.NotifyContext(context.Background(), shutdownSignals()...)
 	if *genPGO {
 		f, err := os.Create("default.pgo")
 		if err != nil {

--- a/movie_dialog.go
+++ b/movie_dialog.go
@@ -1,0 +1,22 @@
+//go:build !js
+
+package main
+
+import (
+	"errors"
+
+	"github.com/sqweek/dialog"
+)
+
+var errMovieDialogCancelled = errors.New("movie dialog cancelled")
+
+func pickMovieFile() (string, error) {
+	filename, err := dialog.File().Filter("clMov files", "clMov", "clmov", "zip", "ZIP").Load()
+	if err != nil {
+		if err == dialog.Cancelled {
+			return "", errMovieDialogCancelled
+		}
+		return "", err
+	}
+	return filename, nil
+}

--- a/movie_dialog_js.go
+++ b/movie_dialog_js.go
@@ -1,0 +1,11 @@
+//go:build js
+
+package main
+
+import "errors"
+
+var errMovieDialogCancelled = errors.New("movie dialog cancelled")
+
+func pickMovieFile() (string, error) {
+	return "", errors.New("movie playback is not available in the browser build")
+}

--- a/signals_default.go
+++ b/signals_default.go
@@ -1,0 +1,12 @@
+//go:build !js
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func shutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP}
+}

--- a/signals_js.go
+++ b/signals_js.go
@@ -1,0 +1,9 @@
+//go:build js
+
+package main
+
+import "os"
+
+func shutdownSignals() []os.Signal {
+	return nil
+}

--- a/ui.go
+++ b/ui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -23,7 +24,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/hajimehoshi/ebiten/v2"
 	open "github.com/skratchdot/open-golang/open"
-	"github.com/sqweek/dialog"
 
 	"gothoom/climg"
 	"gothoom/clsnd"
@@ -2526,13 +2526,14 @@ func makeLoginWindow() {
 	openBtn.Size = eui.Point{X: charWinWidth, Y: 24}
 	openEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
-			filename, err := dialog.File().Filter("clMov files", "clMov", "clmov", "zip", "ZIP").Load()
+			filename, err := pickMovieFile()
 			if err != nil {
-				if err != dialog.Cancelled {
-					logError("open clMov: %v", err)
-					// Keep popup on top of login
-					makeErrorWindow("Error: Open clMov: " + err.Error())
+				if errors.Is(err, errMovieDialogCancelled) {
+					return
 				}
+				logError("open clMov: %v", err)
+				// Keep popup on top of login
+				makeErrorWindow("Error: Open clMov: " + err.Error())
 				return
 			}
 			if filename == "" {

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>goThoom (WASM)</title>
+  </head>
+  <body>
+    <noscript>JavaScript is required to run goThoom in the browser.</noscript>
+    <script src="wasm_exec.js"></script>
+    <script>
+      (function () {
+        if (!WebAssembly.instantiateStreaming) {
+          WebAssembly.instantiateStreaming = async (resp, importObject) => {
+            const source = await resp.arrayBuffer();
+            return await WebAssembly.instantiate(source, importObject);
+          };
+        }
+
+        const go = new Go();
+        fetch("gothoom.wasm")
+          .then((resp) => {
+            if (!resp.ok) {
+              throw new Error(`Failed to fetch goThoom WASM binary: ${resp.status} ${resp.statusText}`);
+            }
+            return resp.arrayBuffer();
+          })
+          .then((bytes) => WebAssembly.instantiate(bytes, go.importObject))
+          .then((result) => {
+            go.run(result.instance);
+          })
+          .catch((err) => {
+            console.error(err);
+            const errorEl = document.createElement("pre");
+            errorEl.textContent = err.stack || err.message || String(err);
+            document.body.appendChild(errorEl);
+          });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a repository-managed `web/index.html` template for the browser bundle
- update the WASM build path to copy the static HTML instead of regenerating it inline

## Testing
- `GOOS=js GOARCH=wasm go build -o /tmp/gothoom.wasm .`
- `go test ./...` *(fails: missing ALSA/X11/GTK development headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd5be0c1c832ab220d4ca3a67d28a