### PR TITLE
Skip speech bubbles during wasm playback

### DIFF
--- a/game.go
+++ b/game.go
@@ -2267,6 +2267,9 @@ func drawSpeechBubbles(screen *ebiten.Image, snap drawSnapshot, alpha float64) {
 	if !gs.SpeechBubbles {
 		return
 	}
+	if wasmPrivacyActive() {
+		return
+	}
 	descMap := snap.descriptors
 	maxDist := maxMobileInterpPixels * (snap.dropped + 1)
 	for _, b := range snap.bubbles {


### PR DESCRIPTION
## Summary
- stop drawing speech bubbles when wasm privacy mode is active so wasm clmov playback no longer shows them

## Testing
- go test ./... *(fails: glfw requires DISPLAY in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce23dfe644832ab25892b139672dcb