### PR TITLE
Bypass wasm file operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,9 @@ func main() {
 		}()
 	}
 
-	initDiscordRPC(ctx)
+	if !isWASM {
+		initDiscordRPC(ctx)
+	}
 
 	imgStart := time.Now()
 	if isWASM && len(wasmCLImagesData) > 0 {

--- a/platform.go
+++ b/platform.go
@@ -3,14 +3,9 @@ package main
 import "runtime"
 
 // isWASM is true when running in a WebAssembly (browser) environment.
-var isWASM bool
+var isWASM = (runtime.GOOS == "js" || runtime.GOARCH == "wasm")
 
 // In-memory archives when running under WASM.
 var wasmCLImagesData []byte
 var wasmCLSoundsData []byte
 var wasmMovieZipData []byte
-
-func init() {
-	// GOOS=js and GOARCH=wasm for GopherJS/WebAssembly targets.
-	isWASM = (runtime.GOOS == "js" || runtime.GOARCH == "wasm")
-}

--- a/stats.go
+++ b/stats.go
@@ -23,6 +23,9 @@ const statsFile = "stats.json"
 // to the executable so assets are placed alongside the binary regardless of the
 // current working directory.
 var dataDirPath = func() string {
+	if runtime.GOOS == "js" || runtime.GOARCH == "wasm" {
+		return "data"
+	}
 	if runtime.GOOS == "darwin" {
 		if home, err := os.UserHomeDir(); err == nil {
 			if filepath.Base(home) == "Data" && filepath.Base(filepath.Dir(home)) == "com.goThoom.client" {


### PR DESCRIPTION
## Summary
- ensure the wasm flag is initialized before other package inits and skip Discord RPC setup when running in the browser
- avoid filesystem lookups for data directories and keyfile versions when running under WASM by using in-memory archives or defaults

## Testing
- go test ./... *(fails: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce24f810cc832ab120c95cb7f506f0