### PR TITLE
Enable looping wasm clmov playback without power saver

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,6 +247,11 @@ func main() {
 			applyEnabledPlugins()
 
 			mp := newMoviePlayer(frames, clMovFPS, cancel)
+			if isWASM {
+				mp.repeat = true
+				gs.PowerSaveAlways = false
+				gs.PowerSaveBackground = false
+			}
 			mp.makePlaybackWindow()
 
 			if (gs.precacheSounds || gs.precacheImages) && !assetsPrecached {


### PR DESCRIPTION
## Summary
- enable repeat mode by default when running clMov playback in the wasm build
- disable power saving throttles in wasm movie playback to avoid frame limiting

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce25627884832a9f8cd203257946c4