### PR TITLE
Disable in-game notifications on wasm

### DIFF
--- a/notifications.go
+++ b/notifications.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-    "time"
+	"time"
 
-    "gothoom/eui"
+	"gothoom/eui"
 
-    "github.com/hajimehoshi/ebiten/v2"
-    text "github.com/hajimehoshi/ebiten/v2/text/v2"
+	"github.com/hajimehoshi/ebiten/v2"
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
 )
 
 type notification struct {
@@ -20,9 +20,12 @@ var notifications []*notification
 // enabled. Messages disappear after a timeout or when clicked.
 // Optional note keys can be provided to customize the notification sound.
 func showNotification(msg string, keys ...int) {
-    if !gs.Notifications || gameWin == nil {
-        return
-    }
+	if isWASM {
+		return
+	}
+	if !gs.Notifications || gameWin == nil {
+		return
+	}
 	if gs.NotificationBeep {
 		if len(keys) == 0 {
 			// middle C harp beep
@@ -31,13 +34,13 @@ func showNotification(msg string, keys ...int) {
 			playHarpNotes(keys...)
 		}
 	}
-    // If app is unfocused and user enabled background desktop notifications,
-    // mirror this in-game notification to the OS.
-    if gs.NotifyWhenBackground && !ebiten.IsFocused() {
-        notifyDesktop("goThoom", msg)
-    }
+	// If app is unfocused and user enabled background desktop notifications,
+	// mirror this in-game notification to the OS.
+	if gs.NotifyWhenBackground && !ebiten.IsFocused() {
+		notifyDesktop("goThoom", msg)
+	}
 
-    btn, events := eui.NewButton()
+	btn, events := eui.NewButton()
 	btn.Text = msg
 	btn.FontSize = float32(gs.ChatFontSize)
 	btn.Filled = true


### PR DESCRIPTION
## Summary
- return early from showNotification when running in the wasm build to skip in-game popups that would require additional UI windows

## Testing
- go test ./... *(fails: spellcheck.go:16:12: pattern spellcheck_words.txt: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce26478534832a9bfb66304c622a36